### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/emergency-hotfix.yml
+++ b/.github/ISSUE_TEMPLATE/emergency-hotfix.yml
@@ -1,0 +1,40 @@
+name: Emergency hotfix
+description: Use only for an explicitly approved urgent production fix.
+title: "[Hotfix] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template only for an approved emergency exception. Normal work should use the standard work item template.
+  - type: textarea
+    id: incident
+    attributes:
+      label: Incident Summary
+      description: What is broken right now, and who is affected?
+      placeholder: Describe the production problem and urgency.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Intended Change Scope
+      description: Keep this as narrow as possible.
+      placeholder: Explain the smallest change that should resolve the incident.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification Plan
+      description: What checks will prove the hotfix works?
+      placeholder: Include local checks, targeted manual checks, and any automated coverage.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback Plan
+      description: How can this be reverted safely if it fails?
+      placeholder: Describe rollback steps and residual risks.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,43 @@
+name: Work item
+description: Start a feature, bugfix, refactor, or investigation from a structured issue.
+title: "[Work] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for normal work. New implementation should start from an issue before a branch is created.
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: What problem, context, or prior decision makes this work necessary?
+      placeholder: Explain the current state, user impact, and any relevant history.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-outcome
+    attributes:
+      label: Expected Outcome
+      description: What should be true after this work is complete?
+      placeholder: Describe the intended result in concrete terms.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the checks that must pass before this can be considered done.
+      placeholder: |
+        - ...
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: deploy-rollback
+    attributes:
+      label: Deploy / Rollback Concerns
+      description: What should be checked before deploy, and how would you back this out if needed?
+      placeholder: Describe verification, staging/preview needs, and rollback risks.
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- add a standard work-item issue form
- add an emergency hotfix issue form
- disable blank issues so new work starts from a structured issue

Closes #1
