### PR TITLE
style(backend): format storage service typing slice

### DIFF
--- a/backend/src/services/storage_service.py
+++ b/backend/src/services/storage_service.py
@@ -56,7 +56,9 @@ class LocalStorageService:
         full_path.write_bytes(data)
         return self.get_public_url(storage_key)
 
-    def upload_file_from_fileobj(self, storage_key: str, file_obj: BinaryIO, content_type: str) -> str:
+    def upload_file_from_fileobj(
+        self, storage_key: str, file_obj: BinaryIO, content_type: str
+    ) -> str:
         """Upload file from file object."""
         full_path = self._get_full_path(storage_key)
         full_path.write_bytes(file_obj.read())


### PR DESCRIPTION
## Summary
- format `src/services/storage_service.py` after the mypy debt slice from PR #12
- restore backend workflow parity on current `main` by fixing the only remaining `ruff format --check` failure

## Verification
- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv run mypy src/__init__.py src/constants src/middleware/__init__.py src/middleware/etag.py src/tasks/__init__.py src/utils/__init__.py --ignore-missing-imports`
- `ENVIRONMENT=test uv run pytest tests/contract/test_effects_contract.py tests/contract/test_suggested_operations.py tests/test_audio_extraction.py tests/test_audio_mixer.py tests/test_media_info.py tests/test_preview.py tests/test_render_pipeline.py tests/test_template_service.py tests/test_text_renderer.py tests/test_transcription.py tests/test_video_trimmer.py tests/test_websocket.py -v --tb=short`

Refs #11
