### PR TITLE
ci(backend): restore full mypy command

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -83,18 +83,8 @@ jobs:
       - name: Run ruff format check
         run: ruff format --check src/
 
-      # Temporary: keep mypy required checks green on main while legacy strict errors
-      # are handled in follow-up work. Roll back by restoring `mypy src/` here.
-      - name: Run mypy (strict-clean subset)
-        run: >
-          mypy
-          src/__init__.py
-          src/constants
-          src/middleware/__init__.py
-          src/middleware/etag.py
-          src/tasks/__init__.py
-          src/utils/__init__.py
-          --ignore-missing-imports
+      - name: Run mypy
+        run: mypy src/ --ignore-missing-imports
 
       # Temporary: run the backend suites that are stable under ENVIRONMENT=test and
       # current CI dependencies. Roll back by restoring the broader pytest command here.

--- a/backend/docs/MYPY_DEBT_PLAN.md
+++ b/backend/docs/MYPY_DEBT_PLAN.md
@@ -38,3 +38,11 @@ Operating rules:
 - Do not block unrelated merges by coupling debt repayment with new CI policy.
 - When a slice touches runtime logic, keep the diff focused and verify behavior
   separately from the typing cleanup itself.
+
+Current CI policy on main:
+
+- Required CI now runs `mypy src/ --ignore-missing-imports` again.
+- Remaining legacy mypy clusters are explicitly suppressed in `pyproject.toml`
+  using per-module overrides.
+- Debt repayment should remove modules from that override list as slices land.
+- New code should not add new override entries.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -59,6 +59,63 @@ python_version = "3.11"
 strict = true
 ignore_missing_imports = true
 
+# Restore the full `mypy src/` command in CI while carrying forward explicit
+# suppressions for the remaining legacy modules. New work should remove entries
+# from this list rather than adding new ones.
+[[tool.mypy.overrides]]
+module = [
+    "src.api.ai",
+    "src.api.ai_analysis",
+    "src.api.ai_v1",
+    "src.api.ai_video",
+    "src.api.assets",
+    "src.api.deps",
+    "src.api.folders",
+    "src.api.members",
+    "src.api.operations",
+    "src.api.preview",
+    "src.api.render",
+    "src.api.transcription",
+    "src.api.websocket",
+    "src.config",
+    "src.mcp",
+    "src.mcp.server",
+    "src.middleware.rate_limit",
+    "src.middleware.request_context",
+    "src.models.database",
+    "src.render.layer_compositor",
+    "src.render.pipeline",
+    "src.render.text_renderer",
+    "src.schemas.ai",
+    "src.schemas.asset",
+    "src.schemas.clip_adapter",
+    "src.schemas.effects_generated",
+    "src.schemas.options",
+    "src.schemas.project",
+    "src.services.ai_service",
+    "src.services.ai_video_service",
+    "src.services.chroma_key_sampler",
+    "src.services.click_detector",
+    "src.services.directors_eye_service",
+    "src.services.event_detector",
+    "src.services.event_manager",
+    "src.services.frame_sampler",
+    "src.services.idempotency_store",
+    "src.services.plan_actual_diff_service",
+    "src.services.plan_to_timeline",
+    "src.services.preview_service",
+    "src.services.quality_checker",
+    "src.services.template_service",
+    "src.services.timeline_analysis",
+    "src.services.transcription_service",
+    "src.services.validation_service",
+    "src.services.video_trimmer",
+    "src.utils.edit_token",
+    "src.utils.interpolation",
+    "src.utils.media_info",
+]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- restore the required CI command to `mypy src/ --ignore-missing-imports` on current `main`
- carry forward the remaining backend mypy debt as explicit per-module overrides in `pyproject.toml` instead of a path subset in the workflow
- document that future debt slices should remove override entries rather than adding new ones

## Verification
- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv run mypy src/ --ignore-missing-imports`
- `ENVIRONMENT=test uv run pytest tests/contract/test_effects_contract.py tests/contract/test_suggested_operations.py tests/test_audio_extraction.py tests/test_audio_mixer.py tests/test_media_info.py tests/test_preview.py tests/test_render_pipeline.py tests/test_template_service.py tests/test_text_renderer.py tests/test_transcription.py tests/test_video_trimmer.py tests/test_websocket.py -v --tb=short`

Closes #13
