### PR TITLE
test(backend): expand pytest CI coverage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -86,24 +86,16 @@ jobs:
       - name: Run mypy
         run: mypy src/ --ignore-missing-imports
 
-      # Temporary: run the backend suites that are stable under ENVIRONMENT=test and
-      # current CI dependencies. Roll back by restoring the broader pytest command here.
-      - name: Run pytest (stable CI-safe backend suite)
+      # Temporary: run the broad backend suite while excluding tests that still
+      # require local services, live API credentials, database fixtures, or local test data.
+      # Roll back by restoring the narrower allowlist command here.
+      - name: Run pytest (broad backend CI suite)
         run: >
           pytest
-          tests/contract/test_effects_contract.py
-          tests/contract/test_suggested_operations.py
-          tests/test_audio_extraction.py
-          tests/test_audio_mixer.py
-          tests/test_media_info.py
-          tests/test_preview.py
-          tests/test_render_pipeline.py
-          tests/test_template_service.py
-          tests/test_text_renderer.py
-          tests/test_transcription.py
-          tests/test_video_trimmer.py
-          tests/test_websocket.py
+          tests/
           -v
           --tb=short
+          -m
+          "not requires_db and not requires_test_data and not requires_e2e and not requires_live_api"
         env:
           ENVIRONMENT: test

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -122,6 +122,8 @@ testpaths = ["tests"]
 markers = [
     "requires_db: mark test as requiring database connection",
     "requires_test_data: mark test as requiring local test data files",
+    "requires_e2e: mark test as requiring local frontend/backend servers or browser runtime",
+    "requires_live_api: mark test as requiring a live API endpoint and credentials",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_ai_api.py
+++ b/backend/tests/test_ai_api.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
+from src.exceptions import ClipNotFoundError, LayerNotFoundError
 from src.schemas.ai import (
     AddAudioClipRequest,
     AddClipRequest,
@@ -431,10 +432,14 @@ class TestAddClip:
     @pytest.mark.asyncio
     async def test_adds_clip_successfully(self, ai_service, mock_project, mock_db):
         """Should add a new clip successfully."""
-        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+        asset = MagicMock()
+        asset.name = "Content asset"
+        asset.duration_ms = 120000
+        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: asset))
 
         request = AddClipRequest(
             layer_id="layer-content",
+            asset_id=uuid.uuid4(),
             start_ms=0,
             duration_ms=10000,
         )
@@ -446,17 +451,25 @@ class TestAddClip:
         assert result.timing.duration_ms == 10000
 
     @pytest.mark.asyncio
-    async def test_rejects_overlap(self, ai_service, mock_project, mock_db):
-        """Should reject clips that would overlap."""
+    async def test_allows_overlap_and_returns_overlap_warning(self, ai_service, mock_project, mock_db):
+        """Overlapping clips are allowed, but should be surfaced in the response warnings."""
+        asset = MagicMock()
+        asset.name = "Avatar asset"
+        asset.duration_ms = 120000
+        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: asset))
+
         request = AddClipRequest(
             layer_id="layer-avatar",
+            asset_id=uuid.uuid4(),
             start_ms=15000,  # Overlaps with clip-avatar-1 (0-30000)
             duration_ms=10000,
         )
 
-        with pytest.raises(ValueError) as exc_info:
-            await ai_service.add_clip(mock_project, request)
-        assert "overlap" in str(exc_info.value).lower()
+        result = await ai_service.add_clip(mock_project, request)
+
+        assert result is not None
+        assert result.timing.start_ms == 15000
+        assert any("overlap" in warning.lower() for warning in result._overlap_warnings)
 
     @pytest.mark.asyncio
     async def test_rejects_invalid_layer(self, ai_service, mock_project):
@@ -467,7 +480,7 @@ class TestAddClip:
             duration_ms=10000,
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(LayerNotFoundError) as exc_info:
             await ai_service.add_clip(mock_project, request)
         assert "Layer not found" in str(exc_info.value)
 
@@ -490,13 +503,20 @@ class TestMoveClip:
         assert result.timing.start_ms == 100000
 
     @pytest.mark.asyncio
-    async def test_rejects_overlap_on_move(self, ai_service, mock_project, mock_db):
-        """Should reject moves that would cause overlap."""
+    async def test_returns_overlap_warning_on_move(self, ai_service, mock_project, mock_db):
+        """Moves that create overlap should succeed but surface overlap warnings."""
+        asset = MagicMock()
+        asset.name = "Avatar asset"
+        asset.duration_ms = 120000
+        mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: asset))
+
         request = MoveClipRequest(new_start_ms=50000)  # Would overlap with clip-avatar-2
 
-        with pytest.raises(ValueError) as exc_info:
-            await ai_service.move_clip(mock_project, "clip-avatar-1", request)
-        assert "overlap" in str(exc_info.value).lower()
+        result = await ai_service.move_clip(mock_project, "clip-avatar-1", request)
+
+        assert result is not None
+        assert result.timing.start_ms == 50000
+        assert any("overlap" in warning.lower() for warning in result._overlap_warnings)
 
 
 class TestDeleteClip:
@@ -506,7 +526,8 @@ class TestDeleteClip:
     async def test_deletes_clip_successfully(self, ai_service, mock_project, mock_db):
         """Should delete existing clip."""
         result = await ai_service.delete_clip(mock_project, "clip-avatar-1")
-        assert result is True
+        assert result["deleted_id"] == "clip-avatar-1"
+        assert result["deleted_linked_ids"] == []
 
         # Verify clip is removed
         avatar_layer = next(
@@ -516,10 +537,11 @@ class TestDeleteClip:
         assert "clip-avatar-1" not in clip_ids
 
     @pytest.mark.asyncio
-    async def test_returns_false_for_missing_clip(self, ai_service, mock_project, mock_db):
-        """Should return False for non-existent clip."""
-        result = await ai_service.delete_clip(mock_project, "nonexistent-clip")
-        assert result is False
+    async def test_raises_for_missing_clip(self, ai_service, mock_project, mock_db):
+        """Should raise for non-existent clip."""
+        with pytest.raises(ClipNotFoundError) as exc_info:
+            await ai_service.delete_clip(mock_project, "nonexistent-clip")
+        assert "Clip not found" in str(exc_info.value)
 
 
 # =============================================================================

--- a/backend/tests/test_ai_v1_api.py
+++ b/backend/tests/test_ai_v1_api.py
@@ -21,6 +21,8 @@ from fastapi.testclient import TestClient
 
 from src.main import app
 
+pytestmark = pytest.mark.requires_db
+
 
 # =============================================================================
 # Fixtures

--- a/backend/tests/test_ai_video.py
+++ b/backend/tests/test_ai_video.py
@@ -301,6 +301,10 @@ class TestPlanToTimeline:
             ],
         )
 
+    def _layer_by_type(self, timeline: dict, layer_type: str) -> dict:
+        """Find a layer by type without depending on list order."""
+        return next(layer for layer in timeline["layers"] if layer["type"] == layer_type)
+
     def test_timeline_structure(self):
         """Test that output has correct structure."""
         plan = self._make_simple_plan()
@@ -316,7 +320,7 @@ class TestPlanToTimeline:
         timeline = plan_to_timeline(plan)
 
         layer_types = [l["type"] for l in timeline["layers"]]
-        assert layer_types == ["background", "content", "avatar", "effects", "text"]
+        assert layer_types == ["text", "effects", "avatar", "content", "background"]
 
     def test_audio_track_types(self):
         """Test audio track type assignments."""
@@ -331,7 +335,7 @@ class TestPlanToTimeline:
         plan = self._make_simple_plan()
         timeline = plan_to_timeline(plan)
 
-        bg_layer = timeline["layers"][0]
+        bg_layer = self._layer_by_type(timeline, "background")
         assert len(bg_layer["clips"]) == 1
         assert bg_layer["clips"][0]["asset_id"] == "bg-uuid"
         assert bg_layer["clips"][0]["start_ms"] == 0
@@ -342,7 +346,7 @@ class TestPlanToTimeline:
         plan = self._make_simple_plan()
         timeline = plan_to_timeline(plan)
 
-        content_layer = timeline["layers"][1]
+        content_layer = self._layer_by_type(timeline, "content")
         assert len(content_layer["clips"]) == 1
         assert content_layer["clips"][0]["asset_id"] == "slide-uuid"
         # Section 2 starts at 15000ms
@@ -353,7 +357,7 @@ class TestPlanToTimeline:
         plan = self._make_simple_plan()
         timeline = plan_to_timeline(plan)
 
-        avatar_layer = timeline["layers"][2]
+        avatar_layer = self._layer_by_type(timeline, "avatar")
         assert len(avatar_layer["clips"]) == 2
 
         # First avatar clip: section 1
@@ -371,7 +375,7 @@ class TestPlanToTimeline:
         plan = self._make_simple_plan()
         timeline = plan_to_timeline(plan)
 
-        text_layer = timeline["layers"][4]
+        text_layer = self._layer_by_type(timeline, "text")
         assert len(text_layer["clips"]) == 1
         clip = text_layer["clips"][0]
         assert clip["text_content"] == "セクション3\nスクリプト基礎"
@@ -422,7 +426,7 @@ class TestPlanToTimeline:
         plan = self._make_simple_plan()
         timeline = plan_to_timeline(plan)
 
-        avatar_layer = timeline["layers"][2]
+        avatar_layer = self._layer_by_type(timeline, "avatar")
         first_avatar = avatar_layer["clips"][0]
         assert first_avatar["effects"]["chroma_key"]["enabled"] is True
         assert first_avatar["effects"]["chroma_key"]["color"] == "#00FF00"
@@ -452,7 +456,7 @@ class TestPlanToTimeline:
             ],
         )
         timeline = plan_to_timeline(plan)
-        text_clip = timeline["layers"][4]["clips"][0]
+        text_clip = self._layer_by_type(timeline, "text")["clips"][0]
         assert text_clip["transition_in"]["type"] == "fade"
         assert text_clip["transition_in"]["duration_ms"] == 500
         assert text_clip["transition_out"]["type"] == "fade"

--- a/backend/tests/test_e2e_playwright.py
+++ b/backend/tests/test_e2e_playwright.py
@@ -11,6 +11,7 @@ import pytest
 
 # Skip if Playwright not installed or servers not running
 pytest.importorskip("playwright")
+pytestmark = pytest.mark.requires_e2e
 
 
 class TestFrontendE2E:

--- a/backend/tests/test_layer_compositor.py
+++ b/backend/tests/test_layer_compositor.py
@@ -73,7 +73,7 @@ class TestChromaKeyConfig:
         config = ChromaKeyConfig()
         assert config.enabled is False
         assert config.color == "0x00FF00"  # Green
-        assert config.similarity == 0.3
+        assert config.similarity == 0.4
         assert config.blend == 0.1
 
     def test_chroma_key_green_screen(self):

--- a/backend/tests/test_v1_api_all_endpoints.py
+++ b/backend/tests/test_v1_api_all_endpoints.py
@@ -25,6 +25,10 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+import pytest
+
+pytestmark = pytest.mark.requires_live_api
+
 # ============================================================
 # Configuration
 # ============================================================


### PR DESCRIPTION
## Summary
- replace the backend pytest allowlist in CI with a broad marker-filtered test run
- mark browser- and live-API-dependent suites so backend CI can exclude them explicitly
- update stale backend test expectations that had drifted from current main behavior

## Verification
- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv run mypy src/ --ignore-missing-imports`
- `ENVIRONMENT=test uv run pytest tests/ -v --tb=short -m "not requires_db and not requires_test_data and not requires_e2e and not requires_live_api"`

Closes #14
