### PR TITLE
ops(backend): sync cloud run git hash env

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -41,7 +41,7 @@ cd /Users/hgs/devel/douga_root/main/backend
 1. `git rev-parse HEAD` で deploy 対象 SHA を解決
 2. `docker build --platform linux/amd64 --build-arg GIT_HASH=<sha>` で backend image を build
 3. `asia-northeast1-docker.pkg.dev/douga-2f6f8/cloud-run-source-deploy/douga-api:<sha>` に push
-4. `gcloud run services update --image=<sha-tagged-image>` で Cloud Run 更新
+4. `gcloud run services update --image=<sha-tagged-image> --update-env-vars GIT_HASH=<sha>` で Cloud Run 更新
 
 **⚠️ 絶対に `gcloud run deploy` を使わない。env varがロールバックされる。必ず `gcloud run services update --image=` を使う。**
 
@@ -84,6 +84,10 @@ curl -s https://douga-api-344056413972.asia-northeast1.run.app/health
 期待値:
 - `status` は `healthy`
 - `git_hash` は deploy 対象 commit SHA と一致
+
+補足:
+- Cloud Run の service-level env `GIT_HASH` は image 内 `ENV GIT_HASH` を上書きする
+- そのため image tag/build arg だけでなく、service env も同じ SHA に更新する
 
 ### 2. Frontend デプロイ
 

--- a/backend/scripts/deploy_prod.sh
+++ b/backend/scripts/deploy_prod.sh
@@ -52,7 +52,8 @@ run docker push "${IMAGE_URI}"
 run gcloud run services update "${SERVICE_NAME}" \
   --region="${REGION}" \
   --project="${PROJECT_ID}" \
-  --image="${IMAGE_URI}"
+  --image="${IMAGE_URI}" \
+  --update-env-vars "GIT_HASH=${GIT_HASH}"
 
 if [[ "${DRY_RUN:-0}" == "1" ]]; then
   exit 0

--- a/backend/src/services/storage_service.py
+++ b/backend/src/services/storage_service.py
@@ -149,14 +149,14 @@ class GCSStorageService:
         self._bucket: Any | None = None
 
         # Get default credentials
-        self._credentials, self._project = default()  # type: ignore[no-untyped-call]
+        self._credentials, self._project = cast(Any, default)()
         self._service_account_email: str | None = None
-        self._auth_request: Any = auth_requests.Request()  # type: ignore[no-untyped-call]
+        self._auth_request: Any = cast(Any, auth_requests.Request)()
 
         # For Compute Engine/Cloud Run, we need to get the service account email
         if isinstance(self._credentials, compute_engine.Credentials):
             # Refresh to get the service account email
-            self._credentials.refresh(self._auth_request)  # type: ignore[no-untyped-call]
+            cast(Any, self._credentials).refresh(self._auth_request)
             self._service_account_email = self._credentials.service_account_email
         elif hasattr(self._credentials, "service_account_email"):
             # Service account credentials
@@ -189,7 +189,7 @@ class GCSStorageService:
 
         # Refresh credentials if needed
         if not self._credentials.valid:
-            self._credentials.refresh(self._auth_request)
+            cast(Any, self._credentials).refresh(self._auth_request)
 
         # Use the GCS library's built-in signed URL generation
         # On Cloud Run, this automatically uses IAM signBlob API


### PR DESCRIPTION
## Summary
- update backend deploy script to refresh the Cloud Run `GIT_HASH` env var alongside the image update
- document that service-level `GIT_HASH` overrides the image-level `ENV GIT_HASH`

## Validation
- `bash -n backend/scripts/deploy_prod.sh`
- `DRY_RUN=1 ./scripts/deploy_prod.sh`
- production verification after manual service update:
  - `/health.git_hash == 9a6683dda37863f9879db14b04cbcf798e9ec29f`

Refs #20
