### PR TITLE
fix(frontend): restore cut audio waveform thumbnails

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -175,4 +175,102 @@ test.describe('Editor Critical Path', () => {
     expect(pageErrors).toEqual([])
     expect(consoleErrors.filter((entry) => entry.includes('AbortError'))).toEqual([])
   })
+
+  test('keeps cut audio waveform thumbnails aligned after reload when asset duration is unknown', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAsset: Asset = {
+      id: 'asset-audio-cut-1',
+      project_id: mock.projectId,
+      name: 'Split Sound',
+      type: 'audio',
+      subtype: 'sound',
+      storage_key: 'mock/sound.wav',
+      storage_url: '/lp/lp_video_en.mp4',
+      thumbnail_url: null,
+      duration_ms: null,
+      width: null,
+      height: null,
+      file_size: 2048,
+      mime_type: 'audio/wav',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+    const audioTrack: AudioTrack = {
+      id: 'track-audio-cut-1',
+      name: 'Sound FX',
+      type: 'se',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [
+        {
+          id: 'audio-cut-left',
+          asset_id: audioAsset.id,
+          start_ms: 0,
+          duration_ms: 3000,
+          in_point_ms: 0,
+          out_point_ms: 3000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+        {
+          id: 'audio-cut-right',
+          asset_id: audioAsset.id,
+          start_ms: 3000,
+          duration_ms: 3000,
+          in_point_ms: 3000,
+          out_point_ms: 6000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+      ],
+    }
+
+    mock.assetsByProject[mock.projectId].push(audioAsset)
+    mock.waveformsByAsset[audioAsset.id] = {
+      peaks: [0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6],
+      duration_ms: 6000,
+      sample_rate: 10,
+    }
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [audioTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 6000
+    mock.projectDetails[mock.projectId].duration_ms = 6000
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = [audioTrack]
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 6000
+    mock.sequences[mock.sequenceId].duration_ms = 6000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const leftCanvas = page.locator('[data-testid="timeline-audio-clip-audio-cut-left"] canvas')
+    const rightCanvas = page.locator('[data-testid="timeline-audio-clip-audio-cut-right"] canvas')
+
+    await expect(leftCanvas).toBeVisible()
+    await expect(rightCanvas).toBeVisible()
+
+    const leftBeforeReload = await leftCanvas.evaluate((element: HTMLCanvasElement) => element.toDataURL())
+    const rightBeforeReload = await rightCanvas.evaluate((element: HTMLCanvasElement) => element.toDataURL())
+
+    expect(leftBeforeReload).not.toEqual(rightBeforeReload)
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('editor-header').waitFor()
+
+    await expect(leftCanvas).toBeVisible()
+    await expect(rightCanvas).toBeVisible()
+
+    const leftAfterReload = await leftCanvas.evaluate((element: HTMLCanvasElement) => element.toDataURL())
+    const rightAfterReload = await rightCanvas.evaluate((element: HTMLCanvasElement) => element.toDataURL())
+
+    expect(leftAfterReload).toEqual(leftBeforeReload)
+    expect(rightAfterReload).toEqual(rightBeforeReload)
+    expect(leftAfterReload).not.toEqual(rightAfterReload)
+  })
 })

--- a/frontend/e2e/helpers/editorMockServer.ts
+++ b/frontend/e2e/helpers/editorMockServer.ts
@@ -1,5 +1,5 @@
 import type { Page, Route } from '@playwright/test'
-import type { Asset, AssetFolder } from '../../src/api/assets'
+import type { Asset, AssetFolder, WaveformData } from '../../src/api/assets'
 import type { OperationHistoryItem } from '../../src/api/operations'
 import type { SequenceDetail, SequenceListItem, SnapshotItem } from '../../src/api/sequences'
 import type { Project, ProjectDetail, TimelineData } from '../../src/store/projectStore'
@@ -55,6 +55,7 @@ export interface MockEditorApiState {
   sequenceId: string
   sequences: Record<string, SequenceDetail>
   snapshotsBySequence: Record<string, SnapshotItem[]>
+  waveformsByAsset: Record<string, WaveformData>
 }
 
 function clone<T>(value: T): T {
@@ -194,6 +195,7 @@ export function createMockEditorApiState(): MockEditorApiState {
     snapshotsBySequence: {
       [sequenceId]: [],
     },
+    waveformsByAsset: {},
   }
 }
 
@@ -436,6 +438,14 @@ export async function bootstrapMockEditorPage(
       const asset = (state.assetsByProject[projectId] ?? []).find((candidate) => candidate.id === assetId)
       if (!asset) return text(route, 'Not Found', 404)
       return json(route, { url: asset.storage_url, expires_in_seconds: 3600 })
+    }
+
+    const waveformMatch = matches(pathname, /^\/api\/projects\/([^/]+)\/assets\/([^/]+)\/waveform$/)
+    if (waveformMatch && method === 'GET') {
+      const [, , assetId] = waveformMatch
+      const waveform = state.waveformsByAsset[assetId]
+      if (!waveform) return text(route, 'Not Found', 404)
+      return json(route, clone(waveform))
     }
 
     const operationsMatch = matches(pathname, /^\/api\/projects\/([^/]+)\/operations$/)

--- a/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
+++ b/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
@@ -12,7 +12,7 @@ interface AudioClipWaveformProps {
   height: number
   color: string
   inPointMs: number      // Where in the source the clip starts
-  clipDurationMs: number // Duration of the clip on timeline
+  sourceDurationMs: number // Duration of the visible source segment
   assetDurationMs: number // Total duration of the source asset
 }
 
@@ -23,7 +23,7 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
   height,
   color,
   inPointMs,
-  clipDurationMs,
+  sourceDurationMs,
   assetDurationMs,
 }: AudioClipWaveformProps) {
   // Request waveform data (cached, uses samples_per_second for consistent quality)
@@ -35,12 +35,15 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
     if (!fullPeaks || fullPeaks.length === 0 || !assetDurationMs || assetDurationMs <= 0) {
       return fullPeaks
     }
-    const startRatio = inPointMs / assetDurationMs
-    const endRatio = Math.min((inPointMs + clipDurationMs) / assetDurationMs, 1)
-    const startIdx = Math.floor(startRatio * fullPeaks.length)
-    const endIdx = Math.ceil(endRatio * fullPeaks.length)
+
+    const sourceEndMs = Math.min(inPointMs + Math.max(sourceDurationMs, 1), assetDurationMs)
+    const startRatio = Math.max(0, Math.min(inPointMs / assetDurationMs, 1))
+    const endRatio = Math.max(startRatio, Math.min(sourceEndMs / assetDurationMs, 1))
+    const startIdx = Math.min(Math.floor(startRatio * fullPeaks.length), Math.max(fullPeaks.length - 1, 0))
+    const endIdx = Math.max(startIdx + 1, Math.min(Math.ceil(endRatio * fullPeaks.length), fullPeaks.length))
+
     return fullPeaks.slice(startIdx, endIdx)
-  }, [fullPeaks, inPointMs, clipDurationMs, assetDurationMs])
+  }, [fullPeaks, inPointMs, sourceDurationMs, assetDurationMs])
 
   // Show placeholder while loading waveform
   if (!visiblePeaks || visiblePeaks.length === 0) {

--- a/frontend/src/components/editor/timeline/AudioTracks.tsx
+++ b/frontend/src/components/editor/timeline/AudioTracks.tsx
@@ -155,6 +155,11 @@ function AudioTracks({
               }
             }
             const clipWidth = Math.max((visualDurationMs / 1000) * pixelsPerSecond, 2)
+            const clipSpeed = clip.speed || 1
+            const visibleSourceEndMs = visualInPointMs + visualDurationMs * clipSpeed
+            const sourceDurationMs = Math.max(1, visibleSourceEndMs - visualInPointMs)
+            const fallbackAssetDurationMs = Math.max(clip.out_point_ms ?? 0, visibleSourceEndMs)
+            const assetDurationMs = assets.find(a => a.id === clip.asset_id)?.duration_ms ?? fallbackAssetDurationMs
 
             // Determine box-shadow based on selection state
             const selectionShadow = (isSelected || isMultiSelected)
@@ -166,6 +171,7 @@ function AudioTracks({
             return (
               <div
                 key={clip.id}
+                data-testid={`timeline-audio-clip-${clip.id}`}
                 className={`absolute top-1 bottom-1 rounded select-none group overflow-hidden ${
                   (isSelected || isMultiSelected) ? 'z-10' : ''
                 } ${isDragging ? 'opacity-80' : ''} ${hasAudioOverlap ? 'z-10' : ''}`}
@@ -200,8 +206,8 @@ function AudioTracks({
                   height={56}
                   color={clipColor}
                   inPointMs={visualInPointMs}
-                  clipDurationMs={visualDurationMs}
-                  assetDurationMs={assets.find(a => a.id === clip.asset_id)?.duration_ms || clip.duration_ms}
+                  sourceDurationMs={sourceDurationMs}
+                  assetDurationMs={assetDurationMs}
                 />
                 {clipWidth > 24 && (() => {
                   // Dynamic handle width: max 12px, but no more than 20% of clip width


### PR DESCRIPTION
## Summary
- compute audio waveform slices from the visible source span instead of raw timeline duration
- fall back to the clip's source end when asset duration metadata is missing
- add a regression test for split audio clips after reload when `asset.duration_ms` is null

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts

## Rollback
- revert this PR to restore the previous waveform slice calculation

Closes #25