### PR TITLE
fix(frontend): prioritize current sequence load

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import type { Asset } from '../src/api/assets'
-import type { AudioTrack } from '../src/store/projectStore'
+import type { AudioTrack, Clip } from '../src/store/projectStore'
 import { bootstrapMockEditorPage } from './helpers/editorMockServer'
 import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
 
@@ -43,6 +43,77 @@ test.describe('Editor Critical Path', () => {
     await expect(clipLocator).toHaveCount(1)
     await clipLocator.first().click()
     await expect(page.getByTestId('video-scale-input')).toHaveValue('150')
+  })
+
+  test('prioritizes current sequence before full asset catalog hydration', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page, {
+      sequenceDetailDelayMs: 250,
+    })
+    const deferredAsset: Asset = {
+      id: 'asset-image-deferred',
+      project_id: mock.projectId,
+      name: 'Deferred Asset',
+      type: 'image',
+      subtype: 'mock',
+      storage_key: 'mock/deferred.svg',
+      storage_url: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"></svg>',
+      thumbnail_url: null,
+      duration_ms: null,
+      width: 32,
+      height: 32,
+      file_size: 512,
+      mime_type: 'image/svg+xml',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+    const seededClip: Clip = {
+      id: 'clip-seeded-priority',
+      asset_id: mock.primaryAssetId,
+      start_ms: 0,
+      duration_ms: 3000,
+      in_point_ms: 0,
+      out_point_ms: null,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    mock.assetsByProject[mock.projectId].push(deferredAsset)
+    mock.projectDetails[mock.projectId].timeline_data.layers[0].clips = [seededClip]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 3000
+    mock.projectDetails[mock.projectId].duration_ms = 3000
+    mock.sequences[mock.sequenceId].timeline_data.layers[0].clips = [seededClip]
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 3000
+    mock.sequences[mock.sequenceId].duration_ms = 3000
+
+    await page.goto(`/project/${mock.projectId}/sequence/${mock.sequenceId}`)
+    await page.getByTestId('editor-header').waitFor()
+    await page.getByTestId('timeline-area').waitFor()
+
+    await expect.poll(() => mock.calls.sequenceRespondedAt.length).toBeGreaterThan(0)
+    await expect.poll(() => mock.calls.assetListRequestedAt.length).toBeGreaterThan(0)
+    expect(mock.calls.assetListRequestedAt[0]).toBeGreaterThanOrEqual(mock.calls.sequenceRespondedAt[0])
+
+    await expect(page.getByTestId(`timeline-video-clip-${seededClip.id}`)).toBeVisible()
+    await expect(page.getByTestId(`asset-item-${mock.primaryAssetId}`)).toHaveCount(0)
+    await expect(page.getByTestId(`asset-item-${deferredAsset.id}`)).toHaveCount(0)
+
+    await page.waitForTimeout(900)
+    await expect(page.getByTestId(`asset-item-${mock.primaryAssetId}`)).toBeVisible()
+    await expect(page.getByTestId(`asset-item-${deferredAsset.id}`)).toBeVisible()
   })
 
   test('opens lazy editor panels on demand without breaking the editor shell', async ({ page }) => {

--- a/frontend/e2e/helpers/editorMockServer.ts
+++ b/frontend/e2e/helpers/editorMockServer.ts
@@ -36,7 +36,10 @@ type MockLayoutSettings = {
 export interface MockEditorApiState {
   assetsByProject: Record<string, Asset[]>
   calls: {
+    assetListRequestedAt: number[]
     projectCreates: string[]
+    sequenceRequestedAt: number[]
+    sequenceRespondedAt: number[]
     sequenceUpdates: Array<{
       projectId: string
       sequenceId: string
@@ -167,7 +170,10 @@ export function createMockEditorApiState(): MockEditorApiState {
       [projectId]: [asset],
     },
     calls: {
+      assetListRequestedAt: [],
       projectCreates: [],
+      sequenceRequestedAt: [],
+      sequenceRespondedAt: [],
       sequenceUpdates: [],
     },
     defaultSequenceByProject: {
@@ -280,7 +286,9 @@ function matches(pathname: string, pattern: RegExp) {
 export async function bootstrapMockEditorPage(
   page: Page,
   options?: {
+    assetListDelayMs?: number
     layout?: Partial<MockLayoutSettings>
+    sequenceDetailDelayMs?: number
   }
 ): Promise<MockEditorApiState> {
   const defaultLayout: MockLayoutSettings = {
@@ -368,6 +376,11 @@ export async function bootstrapMockEditorPage(
       const [, , sequenceId] = sequenceDetailMatch
       const sequence = state.sequences[sequenceId]
       if (!sequence) return text(route, 'Not Found', 404)
+      state.calls.sequenceRequestedAt.push(Date.now())
+      if (options?.sequenceDetailDelayMs) {
+        await new Promise((resolve) => setTimeout(resolve, options.sequenceDetailDelayMs))
+      }
+      state.calls.sequenceRespondedAt.push(Date.now())
       return json(route, clone(sequence))
     }
 
@@ -423,6 +436,10 @@ export async function bootstrapMockEditorPage(
     const assetsMatch = matches(pathname, /^\/api\/projects\/([^/]+)\/assets$/)
     if (assetsMatch && method === 'GET') {
       const [, projectId] = assetsMatch
+      state.calls.assetListRequestedAt.push(Date.now())
+      if (options?.assetListDelayMs) {
+        await new Promise((resolve) => setTimeout(resolve, options.assetListDelayMs))
+      }
       return json(route, clone(state.assetsByProject[projectId] ?? []))
     }
 

--- a/frontend/src/components/assets/AssetLibrary.tsx
+++ b/frontend/src/components/assets/AssetLibrary.tsx
@@ -142,6 +142,7 @@ function saveViewPrefs(prefs: ViewPrefs): void {
 }
 
 interface AssetLibraryProps {
+  initialLoadEnabled?: boolean
   projectId: string
   onPreviewAsset?: (asset: Asset) => void
   onAssetsChange?: () => void
@@ -149,7 +150,16 @@ interface AssetLibraryProps {
   refreshTrigger?: number  // Increment this to force a refresh of the asset list
 }
 
-export default function AssetLibrary({ projectId, onPreviewAsset, onAssetsChange, onOpenSession, refreshTrigger }: AssetLibraryProps) {
+const ASSET_LIBRARY_BACKGROUND_LOAD_DELAY_MS = 500
+
+export default function AssetLibrary({
+  initialLoadEnabled = true,
+  projectId,
+  onPreviewAsset,
+  onAssetsChange,
+  onOpenSession,
+  refreshTrigger,
+}: AssetLibraryProps) {
   const { t, i18n } = useTranslation('assets')
   const [assets, setAssets] = useState<Asset[]>([])
   const [folders, setFolders] = useState<AssetFolder[]>([])
@@ -254,16 +264,24 @@ export default function AssetLibrary({ projectId, onPreviewAsset, onAssetsChange
   }, [projectId])
 
   useEffect(() => {
-    fetchAssets()
-    fetchFolders()
-  }, [fetchAssets, fetchFolders])
+    if (!initialLoadEnabled) return
+
+    setLoading(true)
+    const timerId = window.setTimeout(() => {
+      void fetchAssets()
+      void fetchFolders()
+    }, ASSET_LIBRARY_BACKGROUND_LOAD_DELAY_MS)
+
+    return () => window.clearTimeout(timerId)
+  }, [fetchAssets, fetchFolders, initialLoadEnabled])
 
   // Listen for global asset-changed events (reliable cross-component refresh)
   useEffect(() => {
+    if (!initialLoadEnabled) return
     const handler = () => fetchAssets()
     window.addEventListener('douga-assets-changed', handler)
     return () => window.removeEventListener('douga-assets-changed', handler)
-  }, [fetchAssets])
+  }, [fetchAssets, initialLoadEnabled])
 
   useLayoutEffect(() => {
     if (!tooltip.visible || !tooltipAnchor || !tooltipRef.current) return

--- a/frontend/src/components/assets/LeftPanel.tsx
+++ b/frontend/src/components/assets/LeftPanel.tsx
@@ -7,6 +7,7 @@ import type { Asset } from '@/api/assets'
 type PanelTab = 'assets' | 'sequences'
 
 interface LeftPanelProps {
+  assetLibraryReady?: boolean
   projectId: string
   currentSequenceId?: string
   onPreviewAsset?: (asset: Asset) => void
@@ -17,6 +18,7 @@ interface LeftPanelProps {
 }
 
 export default function LeftPanel({
+  assetLibraryReady = true,
   projectId,
   currentSequenceId,
   onPreviewAsset,
@@ -79,6 +81,7 @@ export default function LeftPanel({
       <div className="flex-1 overflow-hidden">
         {activeTab === 'assets' ? (
           <AssetLibrary
+            initialLoadEnabled={assetLibraryReady}
             projectId={projectId}
             onPreviewAsset={onPreviewAsset}
             onAssetsChange={onAssetsChange}

--- a/frontend/src/hooks/useAssetPreviewWorkflow.ts
+++ b/frontend/src/hooks/useAssetPreviewWorkflow.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { assetsApi, type Asset } from '@/api/assets'
 import type { TimelineData } from '@/store/projectStore'
 
+const BACKGROUND_ASSET_HYDRATION_DELAY_MS = 750
 const MAX_CONCURRENT_ASSET_REFRESHES = 4
 
 async function runWithConcurrencyLimit<T>(
@@ -57,6 +58,7 @@ export function useAssetPreviewWorkflow({
   const [preloadedImages, setPreloadedImages] = useState<Set<string>>(new Set())
   const assetUrlGenRef = useRef(new Map<string, number>())
   const assetUrlCacheRef = useRef(new Map<string, string>())
+  const backgroundHydrationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const preloadedImagesRef = useRef(new Set<string>())
 
   const clearPreview = useCallback(() => {
@@ -66,35 +68,6 @@ export function useAssetPreviewWorkflow({
   const replaceAssets = useCallback((nextAssets: Asset[]) => {
     setAssets(nextAssets)
   }, [])
-
-  const fetchAssets = useCallback(async () => {
-    if (!projectId) return
-    try {
-      const data = await assetsApi.list(projectId)
-      setAssets(data)
-    } catch (error) {
-      console.error('Failed to fetch assets:', error)
-    }
-  }, [projectId])
-
-  const previewAsset = useCallback(async (asset: Asset) => {
-    if (!projectId) return
-
-    if (preview.asset?.id === asset.id) {
-      clearPreview()
-      return
-    }
-
-    setPreview({ asset, url: null, loading: true })
-
-    try {
-      const { url } = await assetsApi.getSignedUrl(projectId, asset.id)
-      setPreview({ asset, url, loading: false })
-    } catch (error) {
-      console.error('Failed to get preview URL:', error)
-      clearPreview()
-    }
-  }, [clearPreview, preview.asset?.id, projectId])
 
   const timelineAssetIds = useMemo(() => {
     const next = new Set<string>()
@@ -118,6 +91,57 @@ export function useAssetPreviewWorkflow({
     return next
   }, [timelineData])
 
+  const fetchAssets = useCallback(async () => {
+    if (!projectId) return
+    try {
+      const data = await assetsApi.list(projectId)
+      if (backgroundHydrationTimerRef.current) {
+        clearTimeout(backgroundHydrationTimerRef.current)
+        backgroundHydrationTimerRef.current = null
+      }
+
+      if (timelineAssetIds.size === 0) {
+        setAssets(data)
+        return
+      }
+
+      const prioritizedAssets = data.filter((asset) => timelineAssetIds.has(asset.id))
+      if (prioritizedAssets.length === 0 || prioritizedAssets.length === data.length) {
+        setAssets(data)
+        return
+      }
+
+      setAssets(prioritizedAssets)
+      backgroundHydrationTimerRef.current = setTimeout(() => {
+        startTransition(() => {
+          setAssets(data)
+        })
+        backgroundHydrationTimerRef.current = null
+      }, BACKGROUND_ASSET_HYDRATION_DELAY_MS)
+    } catch (error) {
+      console.error('Failed to fetch assets:', error)
+    }
+  }, [projectId, timelineAssetIds])
+
+  const previewAsset = useCallback(async (asset: Asset) => {
+    if (!projectId) return
+
+    if (preview.asset?.id === asset.id) {
+      clearPreview()
+      return
+    }
+
+    setPreview({ asset, url: null, loading: true })
+
+    try {
+      const { url } = await assetsApi.getSignedUrl(projectId, asset.id)
+      setPreview({ asset, url, loading: false })
+    } catch (error) {
+      console.error('Failed to get preview URL:', error)
+      clearPreview()
+    }
+  }, [clearPreview, preview.asset?.id, projectId])
+
   useEffect(() => {
     assetUrlCacheRef.current = assetUrlCache
   }, [assetUrlCache])
@@ -125,6 +149,13 @@ export function useAssetPreviewWorkflow({
   useEffect(() => {
     preloadedImagesRef.current = preloadedImages
   }, [preloadedImages])
+
+  useEffect(() => () => {
+    if (backgroundHydrationTimerRef.current) {
+      clearTimeout(backgroundHydrationTimerRef.current)
+      backgroundHydrationTimerRef.current = null
+    }
+  }, [])
 
   const refreshAssetUrls = useCallback(async (forceRefresh = false) => {
     if (!projectId || assets.length === 0 || timelineAssetIds.size === 0) return

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -689,13 +689,27 @@ export default function Editor() {
     projectId,
     timelineData,
   })
+  const assetsLoadedSequenceRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (projectId) {
       fetchProject(projectId)
-      void fetchAssets()
     }
-  }, [projectId, fetchAssets, fetchProject])
+  }, [projectId, fetchProject])
+
+  useEffect(() => {
+    assetsLoadedSequenceRef.current = null
+  }, [projectId, sequenceId])
+
+  useEffect(() => {
+    if (!projectId || !sequenceId || currentSequence?.id !== sequenceId) return
+
+    const sequenceKey = `${projectId}:${sequenceId}`
+    if (assetsLoadedSequenceRef.current === sequenceKey) return
+
+    assetsLoadedSequenceRef.current = sequenceKey
+    void fetchAssets()
+  }, [currentSequence?.id, fetchAssets, projectId, sequenceId])
 
   const extractSaveErrorMessage = useCallback((error: unknown, fallback: string) => {
     if (typeof error === 'object' && error !== null && 'response' in error) {
@@ -3597,6 +3611,7 @@ export default function Editor() {
           >
             <Suspense fallback={<div className="h-full bg-gray-800" />}>
               <LazyLeftPanel
+                assetLibraryReady={currentSequence?.id === sequenceId}
                 projectId={currentProject.id}
                 currentSequenceId={sequenceId}
                 onPreviewAsset={handlePreviewAsset}


### PR DESCRIPTION
Closes #24

## Summary
- fetch the project first and defer asset hydration until the requested sequence is current
- prioritize timeline-referenced assets on initial editor hydration and delay the full asset catalog into the background
- gate the left-panel asset library initial load so shared project opens are sequence-first
- add a Playwright regression that asserts sequence detail resolves before the first asset-list fetch

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts
