### PR TITLE
fix(frontend): keep cut audio waveform scale stable

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -1,8 +1,34 @@
 import { expect, test } from '@playwright/test'
+import type { Locator } from '@playwright/test'
 import type { Asset } from '../src/api/assets'
 import type { AudioTrack, Clip } from '../src/store/projectStore'
 import { bootstrapMockEditorPage } from './helpers/editorMockServer'
 import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
+
+async function measureCanvasInkHeight(locator: Locator) {
+  return locator.evaluate((element: HTMLCanvasElement) => {
+    const context = element.getContext('2d')
+    if (!context) return 0
+
+    const { width, height } = element
+    const pixels = context.getImageData(0, 0, width, height).data
+    let top = height
+    let bottom = -1
+
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const alpha = pixels[(y * width + x) * 4 + 3]
+        if (alpha > 0) {
+          top = Math.min(top, y)
+          bottom = Math.max(bottom, y)
+          break
+        }
+      }
+    }
+
+    return bottom >= top ? bottom - top + 1 : 0
+  })
+}
 
 test.describe('Editor Critical Path', () => {
   test('adds an asset clip, edits it, and keeps the change after reload', async ({ page }) => {
@@ -343,5 +369,90 @@ test.describe('Editor Critical Path', () => {
     expect(leftAfterReload).toEqual(leftBeforeReload)
     expect(rightAfterReload).toEqual(rightBeforeReload)
     expect(leftAfterReload).not.toEqual(rightAfterReload)
+  })
+
+  test('keeps split audio waveform amplitude scale stable across cut clips', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAsset: Asset = {
+      id: 'asset-audio-cut-normalization',
+      project_id: mock.projectId,
+      name: 'Split Sound Dynamic',
+      type: 'audio',
+      subtype: 'sound',
+      storage_key: 'mock/sound-dynamic.wav',
+      storage_url: '/lp/lp_video_en.mp4',
+      thumbnail_url: null,
+      duration_ms: 8000,
+      width: null,
+      height: null,
+      file_size: 2048,
+      mime_type: 'audio/wav',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+    const audioTrack: AudioTrack = {
+      id: 'track-audio-cut-normalization',
+      name: 'Sound FX',
+      type: 'se',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [
+        {
+          id: 'audio-cut-soft',
+          asset_id: audioAsset.id,
+          start_ms: 0,
+          duration_ms: 4000,
+          in_point_ms: 0,
+          out_point_ms: 4000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+        {
+          id: 'audio-cut-loud',
+          asset_id: audioAsset.id,
+          start_ms: 4000,
+          duration_ms: 4000,
+          in_point_ms: 4000,
+          out_point_ms: 8000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+      ],
+    }
+
+    mock.assetsByProject[mock.projectId].push(audioAsset)
+    mock.waveformsByAsset[audioAsset.id] = {
+      peaks: [0.08, 0.12, 0.1, 0.14, 0.82, 0.9, 1, 0.88],
+      duration_ms: 8000,
+      sample_rate: 10,
+    }
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [audioTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 8000
+    mock.projectDetails[mock.projectId].duration_ms = 8000
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = [audioTrack]
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 8000
+    mock.sequences[mock.sequenceId].duration_ms = 8000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const softCanvas = page.locator('[data-testid="timeline-audio-clip-audio-cut-soft"] canvas')
+    const loudCanvas = page.locator('[data-testid="timeline-audio-clip-audio-cut-loud"] canvas')
+
+    await expect(softCanvas).toBeVisible()
+    await expect(loudCanvas).toBeVisible()
+
+    const softHeight = await measureCanvasInkHeight(softCanvas)
+    const loudHeight = await measureCanvasInkHeight(loudCanvas)
+
+    expect(softHeight).toBeGreaterThan(0)
+    expect(loudHeight).toBeGreaterThan(softHeight * 2)
   })
 })

--- a/frontend/src/components/editor/WaveformDisplay.tsx
+++ b/frontend/src/components/editor/WaveformDisplay.tsx
@@ -5,6 +5,7 @@ interface WaveformDisplayProps {
   width: number
   height: number
   color: string
+  normalizationPeak?: number
 }
 
 /**
@@ -16,6 +17,7 @@ const WaveformDisplay = memo(function WaveformDisplay({
   width,
   height,
   color,
+  normalizationPeak,
 }: WaveformDisplayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -36,7 +38,7 @@ const WaveformDisplay = memo(function WaveformDisplay({
     ctx.clearRect(0, 0, width, height)
 
     // Normalize peaks: find max and scale to fill available height
-    const maxPeak = Math.max(...peaks.map(p => Math.abs(p)), 0.01)
+    const maxPeak = Math.max(normalizationPeak ?? 0, ...peaks.map(p => Math.abs(p)), 0.01)
     const normalizeScale = 1 / maxPeak
 
     // Draw waveform
@@ -75,7 +77,7 @@ const WaveformDisplay = memo(function WaveformDisplay({
         ctx.fillRect(x, y, Math.max(0.5, rawBarWidth - 0.5), barHeight)
       }
     }
-  }, [peaks, width, height, color])
+  }, [peaks, width, height, color, normalizationPeak])
 
   return (
     <canvas

--- a/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
+++ b/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
@@ -30,6 +30,11 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
   // MEDIUM priority: Timeline waveforms load after thumbnails but before asset library content
   const { peaks: fullPeaks, isLoading } = useWaveform(projectId, assetId, RequestPriority.MEDIUM)
 
+  const normalizationPeak = useMemo(() => {
+    if (!fullPeaks || fullPeaks.length === 0) return undefined
+    return Math.max(...fullPeaks.map((peak) => Math.abs(peak)), 0.01)
+  }, [fullPeaks])
+
   // Slice peaks to show only the visible portion based on in-point and clip duration
   const visiblePeaks = useMemo(() => {
     if (!fullPeaks || fullPeaks.length === 0 || !assetDurationMs || assetDurationMs <= 0) {
@@ -77,6 +82,7 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
         width={width}
         height={height}
         color={color}
+        normalizationPeak={normalizationPeak}
       />
     </div>
   )


### PR DESCRIPTION
Closes #25

## Summary
- keep split audio clip waveform normalization anchored to the full asset waveform instead of re-normalizing each visible slice
- preserve waveform amplitude scale across cut clips so cutting a quieter section does not visually inflate it
- add a regression that covers split audio clips with different amplitude ranges

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "cut audio waveform|amplitude scale|AbortError|adds an asset clip|opens lazy editor panels|prioritizes current sequence"
