### PR TITLE
fix(frontend): use waveform duration for audio slices

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -455,4 +455,89 @@ test.describe('Editor Critical Path', () => {
     expect(softHeight).toBeGreaterThan(0)
     expect(loudHeight).toBeGreaterThan(softHeight * 2)
   })
+
+  test('uses waveform payload duration when stored asset duration drifts', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAsset: Asset = {
+      id: 'asset-audio-duration-drift',
+      project_id: mock.projectId,
+      name: 'Narration Drift',
+      type: 'audio',
+      subtype: 'sound',
+      storage_key: 'mock/narration-drift.wav',
+      storage_url: '/lp/lp_video_en.mp4',
+      thumbnail_url: null,
+      duration_ms: 10000,
+      width: null,
+      height: null,
+      file_size: 2048,
+      mime_type: 'audio/wav',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+    const audioTrack: AudioTrack = {
+      id: 'track-audio-duration-drift',
+      name: 'Narration',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [
+        {
+          id: 'audio-drift-left',
+          asset_id: audioAsset.id,
+          start_ms: 0,
+          duration_ms: 3000,
+          in_point_ms: 0,
+          out_point_ms: 3000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+        {
+          id: 'audio-drift-right',
+          asset_id: audioAsset.id,
+          start_ms: 3000,
+          duration_ms: 3000,
+          in_point_ms: 3000,
+          out_point_ms: 6000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+      ],
+    }
+
+    mock.assetsByProject[mock.projectId].push(audioAsset)
+    mock.waveformsByAsset[audioAsset.id] = {
+      peaks: [0.08, 0.1, 0.12, 0.14, 0.84, 0.92],
+      duration_ms: 6000,
+      sample_rate: 10,
+    }
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [audioTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 6000
+    mock.projectDetails[mock.projectId].duration_ms = 6000
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = [audioTrack]
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 6000
+    mock.sequences[mock.sequenceId].duration_ms = 6000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const leftCanvas = page.locator('[data-testid="timeline-audio-clip-audio-drift-left"] canvas')
+    const rightCanvas = page.locator('[data-testid="timeline-audio-clip-audio-drift-right"] canvas')
+
+    await expect(leftCanvas).toBeVisible()
+    await expect(rightCanvas).toBeVisible()
+
+    const leftHeight = await measureCanvasInkHeight(leftCanvas)
+    const rightHeight = await measureCanvasInkHeight(rightCanvas)
+
+    expect(leftHeight).toBeGreaterThan(0)
+    expect(rightHeight).toBeGreaterThan(leftHeight * 2)
+  })
 })

--- a/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
+++ b/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
@@ -28,7 +28,7 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
 }: AudioClipWaveformProps) {
   // Request waveform data (cached, uses samples_per_second for consistent quality)
   // MEDIUM priority: Timeline waveforms load after thumbnails but before asset library content
-  const { peaks: fullPeaks, isLoading } = useWaveform(projectId, assetId, RequestPriority.MEDIUM)
+  const { peaks: fullPeaks, durationMs: waveformDurationMs, isLoading } = useWaveform(projectId, assetId, RequestPriority.MEDIUM)
 
   const normalizationPeak = useMemo(() => {
     if (!fullPeaks || fullPeaks.length === 0) return undefined
@@ -37,18 +37,20 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
 
   // Slice peaks to show only the visible portion based on in-point and clip duration
   const visiblePeaks = useMemo(() => {
-    if (!fullPeaks || fullPeaks.length === 0 || !assetDurationMs || assetDurationMs <= 0) {
+    const sourceAssetDurationMs = waveformDurationMs && waveformDurationMs > 0 ? waveformDurationMs : assetDurationMs
+
+    if (!fullPeaks || fullPeaks.length === 0 || !sourceAssetDurationMs || sourceAssetDurationMs <= 0) {
       return fullPeaks
     }
 
-    const sourceEndMs = Math.min(inPointMs + Math.max(sourceDurationMs, 1), assetDurationMs)
-    const startRatio = Math.max(0, Math.min(inPointMs / assetDurationMs, 1))
-    const endRatio = Math.max(startRatio, Math.min(sourceEndMs / assetDurationMs, 1))
+    const sourceEndMs = Math.min(inPointMs + Math.max(sourceDurationMs, 1), sourceAssetDurationMs)
+    const startRatio = Math.max(0, Math.min(inPointMs / sourceAssetDurationMs, 1))
+    const endRatio = Math.max(startRatio, Math.min(sourceEndMs / sourceAssetDurationMs, 1))
     const startIdx = Math.min(Math.floor(startRatio * fullPeaks.length), Math.max(fullPeaks.length - 1, 0))
     const endIdx = Math.max(startIdx + 1, Math.min(Math.ceil(endRatio * fullPeaks.length), fullPeaks.length))
 
     return fullPeaks.slice(startIdx, endIdx)
-  }, [fullPeaks, inPointMs, sourceDurationMs, assetDurationMs])
+  }, [fullPeaks, inPointMs, sourceDurationMs, assetDurationMs, waveformDurationMs])
 
   // Show placeholder while loading waveform
   if (!visiblePeaks || visiblePeaks.length === 0) {

--- a/frontend/src/hooks/useWaveform.ts
+++ b/frontend/src/hooks/useWaveform.ts
@@ -12,6 +12,7 @@ const pendingFetches = new Map<string, Promise<WaveformData>>()
 const WAVEFORM_SAMPLES_PER_SECOND = 10
 
 interface UseWaveformResult {
+  durationMs: number | null
   peaks: number[] | null
   isLoading: boolean
   error: string | null
@@ -30,6 +31,7 @@ export function useWaveform(
   assetId: string | null,
   priority: RequestPriority = RequestPriority.LOW // Default to LOW for asset library usage
 ): UseWaveformResult {
+  const [durationMs, setDurationMs] = useState<number | null>(null)
   const [peaks, setPeaks] = useState<number[] | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -40,6 +42,7 @@ export function useWaveform(
     cancelledRef.current = false
 
     if (!projectId || !assetId) {
+      setDurationMs(null)
       setPeaks(null)
       return
     }
@@ -49,7 +52,9 @@ export function useWaveform(
 
     // Check cache first
     if (waveformCache.has(cacheKey)) {
-      setPeaks(waveformCache.get(cacheKey)!.peaks)
+      const cached = waveformCache.get(cacheKey)!
+      setDurationMs(cached.duration_ms)
+      setPeaks(cached.peaks)
       return
     }
 
@@ -65,6 +70,7 @@ export function useWaveform(
         try {
           const data = await pendingFetches.get(cacheKey)!
           if (!cancelledRef.current) {
+            setDurationMs(data.duration_ms)
             setPeaks(data.peaks)
           }
         } catch {
@@ -97,12 +103,14 @@ export function useWaveform(
 
         if (!cancelledRef.current) {
           waveformCache.set(cacheKey, data)
+          setDurationMs(data.duration_ms)
           setPeaks(data.peaks)
         }
       } catch (err) {
         if (!cancelledRef.current && (err as Error).message !== 'Cancelled') {
           console.error('Failed to fetch waveform:', err)
           setError('波形データの取得に失敗しました')
+          setDurationMs(null)
           setPeaks(null)
         }
       } finally {
@@ -119,7 +127,7 @@ export function useWaveform(
     }
   }, [projectId, assetId, priority])
 
-  return { peaks, isLoading, error }
+  return { durationMs, peaks, isLoading, error }
 }
 
 /**


### PR DESCRIPTION
Closes #25

## Summary
- slice timeline audio waveforms using the waveform payload duration when available instead of trusting the stored asset duration
- expose waveform duration from the shared waveform hook so timeline rendering can align to the fetched waveform metadata
- add a regression for narration-style clips where `asset.duration_ms` and waveform duration disagree

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "cut audio waveform|amplitude scale|duration drifts|AbortError|adds an asset clip|opens lazy editor panels|prioritizes current sequence"
