### PR TITLE
fix(frontend): route editor exit back to dashboard

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -164,6 +164,19 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByText('No activity yet')).toBeVisible()
   })
 
+  test('returns to the dashboard instead of the landing page from the editor', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await page.getByTestId('editor-open-exit-confirm').click()
+    await expect(page.getByTestId('editor-confirm-exit')).toBeVisible()
+    await page.getByTestId('editor-confirm-exit').click()
+
+    await expect(page).toHaveURL(/\/app$/)
+    await expect(page.getByText('Seeded Project')).toBeVisible()
+  })
+
   test('does not surface AbortError when stop interrupts a pending audio play()', async ({ page }) => {
     const consoleErrors: string[] = []
     const pageErrors: string[] = []

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -2839,7 +2839,8 @@ export default function Editor() {
         <div className="text-center">
           <p className="text-red-500 mb-4">{error || t('editor.projectNotFound')}</p>
           <button
-            onClick={() => navigate('/')}
+            data-testid="editor-back-to-dashboard"
+            onClick={() => navigate('/app')}
             className="text-primary-500 hover:text-primary-400"
           >
             {t('editor.backToDashboard')}
@@ -2876,6 +2877,7 @@ export default function Editor() {
         {/* Left: Navigation */}
         <div className="flex items-center gap-1">
           <button
+            data-testid="editor-open-exit-confirm"
             onClick={() => setShowExitConfirm(true)}
             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors"
             title={t('editor.backToProjects')}
@@ -3247,9 +3249,10 @@ export default function Editor() {
                 {t('editor.backCancel')}
               </button>
               <button
+                data-testid="editor-confirm-exit"
                 onClick={() => {
                   setShowExitConfirm(false)
-                  navigate('/')
+                  navigate('/app')
                 }}
                 className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded transition-colors"
               >


### PR DESCRIPTION
## Summary
- route editor dashboard return actions to `/app` instead of `/`
- keep the error fallback return action aligned with the authenticated dashboard path
- add a Playwright regression for editor -> dashboard navigation

## Verification
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npx playwright test e2e/editor-critical-path.spec.ts -g "returns to the dashboard instead of the landing page from the editor"`

Closes #29