### PR TITLE
fix(backend): unify audio duration metadata sources

### DIFF
--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -290,7 +290,9 @@ def _select_audio_asset_metadata(
 async def _sync_asset_duration_from_waveform(asset_id: UUID, duration_ms: int) -> None:
     """Keep asset.duration_ms aligned with the waveform payload duration."""
     async with async_session_maker() as session:
-        await session.execute(update(Asset).where(Asset.id == asset_id).values(duration_ms=duration_ms))
+        await session.execute(
+            update(Asset).where(Asset.id == asset_id).values(duration_ms=duration_ms)
+        )
         await session.commit()
 
 
@@ -549,13 +551,12 @@ async def _auto_extract_audio_background(
                 exc_info=True,
             )
 
-        effective_duration_ms, effective_sample_rate, effective_channels = _select_audio_asset_metadata(
-            probed_audio_info
+        effective_duration_ms, effective_sample_rate, effective_channels = (
+            _select_audio_asset_metadata(probed_audio_info)
         )
 
         # Create audio asset in DB
         async with async_session_maker() as db:
-
             audio_asset = Asset(
                 project_id=project_id,
                 name=audio_name,

--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -259,6 +259,41 @@ async def _probe_media_metadata_background(
         logger.exception("Background media probe failed for asset %s", asset_id)
 
 
+async def _probe_storage_media_info(
+    storage: StorageService,
+    storage_key: str,
+    asset_type: str,
+) -> dict:
+    """Download a stored media file and return probed metadata."""
+    suffix = ".mp4" if asset_type == "video" else (".mp3" if asset_type == "audio" else ".bin")
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+        await storage.download_file(storage_key, tmp.name)
+        return await asyncio.to_thread(get_media_info, tmp.name)
+
+
+def _select_audio_asset_metadata(
+    probed_info: dict | None,
+) -> tuple[int | None, int, int]:
+    """Pick canonical audio metadata from the extracted audio payload itself."""
+    duration_ms = None
+    sample_rate = 44100
+    channels = 2
+
+    if probed_info:
+        duration_ms = probed_info.get("duration_ms") or None
+        sample_rate = probed_info.get("sample_rate") or sample_rate
+        channels = probed_info.get("channels") or channels
+
+    return duration_ms, sample_rate, channels
+
+
+async def _sync_asset_duration_from_waveform(asset_id: UUID, duration_ms: int) -> None:
+    """Keep asset.duration_ms aligned with the waveform payload duration."""
+    async with async_session_maker() as session:
+        await session.execute(update(Asset).where(Asset.id == asset_id).values(duration_ms=duration_ms))
+        await session.commit()
+
+
 async def _probe_image_dimensions_background(asset_id: UUID, storage_key: str) -> None:
     """Background task: probe image file to fill in missing width/height.
 
@@ -450,7 +485,6 @@ async def _auto_extract_audio_background(
     video_asset_id: UUID,
     video_storage_key: str,
     video_name: str,
-    duration_ms: int | None,
 ) -> None:
     """Background task: auto-extract audio from uploaded video and create linked audio asset.
 
@@ -505,16 +539,22 @@ async def _auto_extract_audio_background(
             raise
 
         storage_url = storage.get_public_url(audio_key)
+        probed_audio_info: dict | None = None
+        try:
+            probed_audio_info = await _probe_storage_media_info(storage, audio_key, "audio")
+        except Exception:
+            logger.warning(
+                "Failed to probe extracted audio metadata for video asset %s",
+                video_asset_id,
+                exc_info=True,
+            )
+
+        effective_duration_ms, effective_sample_rate, effective_channels = _select_audio_asset_metadata(
+            probed_audio_info
+        )
 
         # Create audio asset in DB
         async with async_session_maker() as db:
-            # If duration_ms was not provided, try to get it from the (now possibly probed) source video
-            effective_duration_ms = duration_ms
-            if not effective_duration_ms:
-                video_result = await db.execute(select(Asset).where(Asset.id == video_asset_id))
-                source_video = video_result.scalar_one_or_none()
-                if source_video and source_video.duration_ms:
-                    effective_duration_ms = source_video.duration_ms
 
             audio_asset = Asset(
                 project_id=project_id,
@@ -526,8 +566,8 @@ async def _auto_extract_audio_background(
                 file_size=file_size,
                 mime_type="audio/mpeg",
                 duration_ms=effective_duration_ms,
-                sample_rate=44100,
-                channels=2,
+                sample_rate=effective_sample_rate,
+                channels=effective_channels,
                 is_internal=False,
                 source_asset_id=video_asset_id,
             )
@@ -537,13 +577,15 @@ async def _auto_extract_audio_background(
             audio_asset_id = audio_asset.id
 
         logger.info(
-            "Auto-extracted audio for video %s → audio asset %s (dur=%s)",
+            "Auto-extracted audio for video %s → audio asset %s (dur=%s, sample_rate=%s, channels=%s)",
             video_asset_id,
             audio_asset_id,
             effective_duration_ms,
+            effective_sample_rate,
+            effective_channels,
         )
 
-        # If we still don't have duration, probe the audio file itself
+        # If we still don't have duration, probe the audio file itself in a repair pass.
         if not effective_duration_ms:
             await _probe_media_metadata_background(audio_asset_id, audio_key, "audio")
 
@@ -803,6 +845,7 @@ async def _generate_waveform_background(
                 waveform_key,
                 "application/json",
             )
+            await _sync_asset_duration_from_waveform(asset_id, waveform.duration_ms)
 
             logger.info(
                 "Waveform generated for asset %s: %d peaks",
@@ -1095,7 +1138,6 @@ async def register_asset(
             asset.id,
             asset.storage_key,
             asset.name,
-            asset.duration_ms,
         )
 
     # Schedule waveform generation and audio analysis for audio assets

--- a/backend/tests/test_asset_duration_sync.py
+++ b/backend/tests/test_asset_duration_sync.py
@@ -1,0 +1,164 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.api import assets as assets_api
+
+
+def test_select_audio_asset_metadata_prefers_probed_audio_payload() -> None:
+    duration_ms, sample_rate, channels = assets_api._select_audio_asset_metadata(
+        {
+            "duration_ms": 6123,
+            "sample_rate": 48000,
+            "channels": 1,
+        }
+    )
+
+    assert duration_ms == 6123
+    assert sample_rate == 48000
+    assert channels == 1
+
+
+def test_select_audio_asset_metadata_falls_back_to_defaults_when_probe_missing() -> None:
+    duration_ms, sample_rate, channels = assets_api._select_audio_asset_metadata(None)
+
+    assert duration_ms is None
+    assert sample_rate == 44100
+    assert channels == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_waveform_background_syncs_asset_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    uploaded_payload: dict[str, object] = {}
+    synced_duration: dict[str, object] = {}
+
+    class FakeStorage:
+        async def download_file(self, storage_key: str, file_path: str) -> None:
+            return None
+
+        def upload_file_content(
+            self,
+            content: bytes,
+            storage_key: str,
+            content_type: str,
+        ) -> None:
+            uploaded_payload["content"] = content
+            uploaded_payload["storage_key"] = storage_key
+            uploaded_payload["content_type"] = content_type
+
+    class FakePreviewService:
+        def generate_waveform(self, file_path: str, samples_per_second: float = 10.0) -> SimpleNamespace:
+            return SimpleNamespace(peaks=[0.1, 0.2, 0.3], duration_ms=6123, sample_rate=44100)
+
+    async def fake_sync_asset_duration(asset_id: UUID, duration_ms: int) -> None:
+        synced_duration["asset_id"] = asset_id
+        synced_duration["duration_ms"] = duration_ms
+
+    monkeypatch.setattr(assets_api, "get_storage_service", lambda: FakeStorage())
+    monkeypatch.setattr(assets_api, "PreviewService", FakePreviewService)
+    monkeypatch.setattr(assets_api, "_sync_asset_duration_from_waveform", fake_sync_asset_duration)
+
+    project_id = uuid4()
+    asset_id = uuid4()
+    await assets_api._generate_waveform_background(project_id, asset_id, "audio/test.mp3")
+
+    assert uploaded_payload["storage_key"] == f"waveforms/{project_id}/{asset_id}.json"
+    assert uploaded_payload["content_type"] == "application/json"
+    assert synced_duration == {
+        "asset_id": asset_id,
+        "duration_ms": 6123,
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_extract_audio_uses_probed_audio_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_asset: dict[str, Any] = {}
+    follow_up_calls: dict[str, Any] = {"waveform": None, "analysis": None}
+
+    class FakeStorage:
+        def get_public_url(self, storage_key: str) -> str:
+            return f"https://storage.example/{storage_key}"
+
+    class FakeResult:
+        def scalar_one_or_none(self) -> None:
+            return None
+
+    class ExistingSession:
+        async def execute(self, stmt: Any) -> FakeResult:
+            return FakeResult()
+
+        async def commit(self) -> None:
+            return None
+
+    class CreateSession:
+        def add(self, asset: Any) -> None:
+            created_asset["asset"] = asset
+
+        async def commit(self) -> None:
+            return None
+
+        async def refresh(self, asset: Any) -> None:
+            asset.id = uuid4()
+
+    class SessionContext:
+        def __init__(self, session: Any) -> None:
+            self.session = session
+
+        async def __aenter__(self) -> Any:
+            return self.session
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+            return False
+
+    sessions = [ExistingSession(), CreateSession()]
+
+    async def fake_extract_audio_from_gcs(**kwargs: Any) -> tuple[str, int]:
+        return ("audio/generated.mp3", 1234)
+
+    async def fake_probe_storage_media_info(storage: Any, storage_key: str, asset_type: str) -> dict[str, int]:
+        assert storage_key == "audio/generated.mp3"
+        assert asset_type == "audio"
+        return {
+            "duration_ms": 6123,
+            "sample_rate": 48000,
+            "channels": 1,
+        }
+
+    async def fake_generate_waveform_background(project_id: UUID, asset_id: UUID, audio_key: str) -> None:
+        follow_up_calls["waveform"] = (project_id, asset_id, audio_key)
+
+    async def fake_analyze_audio_background(asset_id: UUID, audio_key: str, duration_ms: int | None) -> None:
+        follow_up_calls["analysis"] = (asset_id, audio_key, duration_ms)
+
+    monkeypatch.setattr(assets_api, "get_storage_service", lambda: FakeStorage())
+    monkeypatch.setattr(assets_api, "extract_audio_from_gcs", fake_extract_audio_from_gcs)
+    monkeypatch.setattr(assets_api, "_probe_storage_media_info", fake_probe_storage_media_info)
+    monkeypatch.setattr(assets_api, "_generate_waveform_background", fake_generate_waveform_background)
+    monkeypatch.setattr(assets_api, "_analyze_audio_background", fake_analyze_audio_background)
+    monkeypatch.setattr(
+        assets_api,
+        "async_session_maker",
+        lambda: SessionContext(sessions.pop(0)),
+    )
+
+    project_id = uuid4()
+    video_asset_id = uuid4()
+    await assets_api._auto_extract_audio_background(
+        project_id,
+        video_asset_id,
+        "video/source.mp4",
+        "recording.mp4",
+    )
+
+    asset = cast(Any, created_asset["asset"])
+    assert asset.duration_ms == 6123
+    assert asset.sample_rate == 48000
+    assert asset.channels == 1
+    assert asset.source_asset_id == video_asset_id
+    assert cast(tuple[UUID, str, int | None], follow_up_calls["analysis"])[2] == 6123

--- a/backend/tests/test_asset_duration_sync.py
+++ b/backend/tests/test_asset_duration_sync.py
@@ -51,7 +51,9 @@ async def test_generate_waveform_background_syncs_asset_duration(
             uploaded_payload["content_type"] = content_type
 
     class FakePreviewService:
-        def generate_waveform(self, file_path: str, samples_per_second: float = 10.0) -> SimpleNamespace:
+        def generate_waveform(
+            self, file_path: str, samples_per_second: float = 10.0
+        ) -> SimpleNamespace:
             return SimpleNamespace(peaks=[0.1, 0.2, 0.3], duration_ms=6123, sample_rate=44100)
 
     async def fake_sync_asset_duration(asset_id: UUID, duration_ms: int) -> None:
@@ -121,7 +123,9 @@ async def test_auto_extract_audio_uses_probed_audio_duration(
     async def fake_extract_audio_from_gcs(**kwargs: Any) -> tuple[str, int]:
         return ("audio/generated.mp3", 1234)
 
-    async def fake_probe_storage_media_info(storage: Any, storage_key: str, asset_type: str) -> dict[str, int]:
+    async def fake_probe_storage_media_info(
+        storage: Any, storage_key: str, asset_type: str
+    ) -> dict[str, int]:
         assert storage_key == "audio/generated.mp3"
         assert asset_type == "audio"
         return {
@@ -130,16 +134,22 @@ async def test_auto_extract_audio_uses_probed_audio_duration(
             "channels": 1,
         }
 
-    async def fake_generate_waveform_background(project_id: UUID, asset_id: UUID, audio_key: str) -> None:
+    async def fake_generate_waveform_background(
+        project_id: UUID, asset_id: UUID, audio_key: str
+    ) -> None:
         follow_up_calls["waveform"] = (project_id, asset_id, audio_key)
 
-    async def fake_analyze_audio_background(asset_id: UUID, audio_key: str, duration_ms: int | None) -> None:
+    async def fake_analyze_audio_background(
+        asset_id: UUID, audio_key: str, duration_ms: int | None
+    ) -> None:
         follow_up_calls["analysis"] = (asset_id, audio_key, duration_ms)
 
     monkeypatch.setattr(assets_api, "get_storage_service", lambda: FakeStorage())
     monkeypatch.setattr(assets_api, "extract_audio_from_gcs", fake_extract_audio_from_gcs)
     monkeypatch.setattr(assets_api, "_probe_storage_media_info", fake_probe_storage_media_info)
-    monkeypatch.setattr(assets_api, "_generate_waveform_background", fake_generate_waveform_background)
+    monkeypatch.setattr(
+        assets_api, "_generate_waveform_background", fake_generate_waveform_background
+    )
     monkeypatch.setattr(assets_api, "_analyze_audio_background", fake_analyze_audio_background)
     monkeypatch.setattr(
         assets_api,


### PR DESCRIPTION
## Summary
- probe extracted audio files directly and use that metadata when creating auto-extracted audio assets
- sync `asset.duration_ms` to the waveform payload duration after waveform generation/regeneration
- add backend regression coverage for both the auto-extract path and waveform repair path

## Verification
- `ENVIRONMENT=test uv run --python 3.12 ruff check src/api/assets.py tests/test_asset_duration_sync.py`
- `ENVIRONMENT=test uv run --python 3.12 --extra dev mypy src/api/assets.py tests/test_asset_duration_sync.py --ignore-missing-imports`
- `ENVIRONMENT=test uv run --python 3.12 pytest tests/test_asset_duration_sync.py -q`

## Rollback
- revert this PR to restore the previous duration assignment path
- existing drifted assets can still be repaired by regenerating waveforms after reapplying a fixed version

Closes #33