### PR TITLE
feat(frontend): normalize selected audio clips

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -553,4 +553,168 @@ test.describe('Editor Critical Path', () => {
     expect(leftHeight).toBeGreaterThan(0)
     expect(rightHeight).toBeGreaterThan(leftHeight * 2)
   })
+
+  test('normalizes only the selected audio clips and preserves undoable timeline updates', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAssets: Asset[] = [
+      {
+        id: 'asset-audio-normalize-a',
+        project_id: mock.projectId,
+        name: 'Narration A',
+        type: 'audio',
+        subtype: 'narration',
+        storage_key: 'mock/narration-a.wav',
+        storage_url: '/lp/lp_video_en.mp4',
+        thumbnail_url: null,
+        duration_ms: 4000,
+        width: null,
+        height: null,
+        file_size: 2048,
+        mime_type: 'audio/wav',
+        chroma_key_color: null,
+        hash: null,
+        folder_id: null,
+        created_at: '2026-03-07T00:00:00.000Z',
+        metadata: null,
+      },
+      {
+        id: 'asset-audio-normalize-b',
+        project_id: mock.projectId,
+        name: 'Narration B',
+        type: 'audio',
+        subtype: 'narration',
+        storage_key: 'mock/narration-b.wav',
+        storage_url: '/lp/lp_video_en.mp4',
+        thumbnail_url: null,
+        duration_ms: 4000,
+        width: null,
+        height: null,
+        file_size: 2048,
+        mime_type: 'audio/wav',
+        chroma_key_color: null,
+        hash: null,
+        folder_id: null,
+        created_at: '2026-03-07T00:00:00.000Z',
+        metadata: null,
+      },
+      {
+        id: 'asset-audio-normalize-c',
+        project_id: mock.projectId,
+        name: 'Narration C',
+        type: 'audio',
+        subtype: 'narration',
+        storage_key: 'mock/narration-c.wav',
+        storage_url: '/lp/lp_video_en.mp4',
+        thumbnail_url: null,
+        duration_ms: 4000,
+        width: null,
+        height: null,
+        file_size: 2048,
+        mime_type: 'audio/wav',
+        chroma_key_color: null,
+        hash: null,
+        folder_id: null,
+        created_at: '2026-03-07T00:00:00.000Z',
+        metadata: null,
+      },
+    ]
+    const audioTrack: AudioTrack = {
+      id: 'track-audio-normalize',
+      name: 'Narration',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [
+        {
+          id: 'audio-normalize-a',
+          asset_id: audioAssets[0].id,
+          start_ms: 0,
+          duration_ms: 2000,
+          in_point_ms: 0,
+          out_point_ms: 2000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+        {
+          id: 'audio-normalize-b',
+          asset_id: audioAssets[1].id,
+          start_ms: 2200,
+          duration_ms: 2000,
+          in_point_ms: 0,
+          out_point_ms: 2000,
+          volume: 0.5,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+          volume_keyframes: [
+            { time_ms: 0, value: 0.4 },
+            { time_ms: 2000, value: 0.5 },
+          ],
+        },
+        {
+          id: 'audio-normalize-c',
+          asset_id: audioAssets[2].id,
+          start_ms: 4400,
+          duration_ms: 2000,
+          in_point_ms: 0,
+          out_point_ms: 2000,
+          volume: 0.7,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+          speed: 1,
+        },
+      ],
+    }
+
+    mock.assetsByProject[mock.projectId].push(...audioAssets)
+    mock.waveformsByAsset[audioAssets[0].id] = {
+      peaks: [0.95, 0.92, 0.9, 0.88],
+      duration_ms: 4000,
+      sample_rate: 10,
+    }
+    mock.waveformsByAsset[audioAssets[1].id] = {
+      peaks: [0.8, 0.72, 0.7, 0.68],
+      duration_ms: 4000,
+      sample_rate: 10,
+    }
+    mock.waveformsByAsset[audioAssets[2].id] = {
+      peaks: [0.55, 0.5, 0.48, 0.46],
+      duration_ms: 4000,
+      sample_rate: 10,
+    }
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [audioTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 6400
+    mock.projectDetails[mock.projectId].duration_ms = 6400
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = [audioTrack]
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 6400
+    mock.sequences[mock.sequenceId].duration_ms = 6400
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const clipA = page.getByTestId('timeline-audio-clip-audio-normalize-a')
+    const clipB = page.getByTestId('timeline-audio-clip-audio-normalize-b')
+
+    await clipA.click()
+    await clipB.click({ modifiers: ['Shift'] })
+    await clipB.dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2, clientX: 320, clientY: 420 })
+
+    await expect(page.getByTestId('timeline-normalize-audio')).toBeVisible()
+    await page.getByTestId('timeline-normalize-audio').click()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const updatedClips = mock.calls.sequenceUpdates[0].timelineData.audio_tracks[0].clips
+    const updatedA = updatedClips.find((clip) => clip.id === 'audio-normalize-a')
+    const updatedB = updatedClips.find((clip) => clip.id === 'audio-normalize-b')
+    const updatedC = updatedClips.find((clip) => clip.id === 'audio-normalize-c')
+
+    expect(updatedA?.volume).toBeCloseTo(0.947, 2)
+    expect(updatedB?.volume).toBeCloseTo(1, 5)
+    expect(updatedB?.volume_keyframes?.[0].value).toBeCloseTo(0.8, 5)
+    expect(updatedB?.volume_keyframes?.[1].value).toBeCloseTo(1, 5)
+    expect(updatedC?.volume).toBeCloseTo(0.7, 5)
+  })
 })

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -8,6 +8,7 @@ import { transcriptionApi, type Transcription } from '@/api/transcription'
 import { assetsApi } from '@/api/assets'
 import { aiVideoApi } from '@/api/aiVideo'
 import { addVolumeKeyframe } from '@/utils/volumeKeyframes'
+import { getClipMaxGain, getClipVisiblePeak, getNormalizationScaleFactor, scaleAudioClipGain } from '@/utils/audioNormalization'
 import TimelineContextMenu from './timeline/TimelineContextMenu'
 import TrackHeaderContextMenu from './timeline/TrackHeaderContextMenu'
 import ViewportBar from './timeline/ViewportBar'
@@ -3351,6 +3352,80 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     setContextMenu(null)
   }, [])
 
+  const getContextMenuAudioSelection = useCallback(() => {
+    if (contextMenu?.type !== 'audio') {
+      return new Set<string>()
+    }
+
+    if (selectedAudioClips.size > 0 && selectedAudioClips.has(contextMenu.clipId)) {
+      return new Set(selectedAudioClips)
+    }
+
+    if (selectedClip?.clipId === contextMenu.clipId) {
+      return new Set([selectedClip.clipId])
+    }
+
+    return new Set([contextMenu.clipId])
+  }, [contextMenu, selectedAudioClips, selectedClip])
+
+  const handleNormalizeAudioSelection = useCallback(async () => {
+    const selectedClipIds = getContextMenuAudioSelection()
+    if (selectedClipIds.size === 0) return
+
+    const selectedClips = timeline.audio_tracks.flatMap((track) =>
+      track.clips
+        .filter((clip) => selectedClipIds.has(clip.id))
+        .map((clip) => ({ clip }))
+    )
+
+    if (selectedClips.length === 0) return
+
+    const uniqueAssetIds = [...new Set(selectedClips.map(({ clip }) => clip.asset_id))]
+    const waveformEntries = await Promise.all(
+      uniqueAssetIds.map(async (assetId) => {
+        try {
+          const waveform = await assetsApi.getWaveform(projectId, assetId, 10)
+          return [assetId, waveform] as const
+        } catch (error) {
+          console.error('Failed to fetch waveform for normalization:', assetId, error)
+          return [assetId, null] as const
+        }
+      })
+    )
+    const waveforms = new Map(waveformEntries)
+
+    let hasChanges = false
+    const updatedTracks = timeline.audio_tracks.map((track) => ({
+      ...track,
+      clips: track.clips.map((clip) => {
+        if (!selectedClipIds.has(clip.id)) return clip
+
+        const waveform = waveforms.get(clip.asset_id)
+        if (!waveform) return clip
+
+        const assetDurationMs = assets.find((asset) => asset.id === clip.asset_id)?.duration_ms ?? null
+        const visiblePeak = getClipVisiblePeak(clip, waveform, assetDurationMs)
+        const currentGain = getClipMaxGain(clip)
+        const scaleFactor = getNormalizationScaleFactor(visiblePeak, currentGain)
+
+        if (Math.abs(scaleFactor - 1) < 0.0001) {
+          return clip
+        }
+
+        hasChanges = true
+        return scaleAudioClipGain(clip, scaleFactor)
+      }),
+    }))
+
+    if (!hasChanges) return
+
+    await updateTimeline(
+      projectId,
+      { ...timeline, audio_tracks: updatedTracks },
+      i18n.t('editor:undo.audioClipNormalize')
+    )
+  }, [assets, getContextMenuAudioSelection, projectId, timeline, updateTimeline])
+
   // Group selected clips (video + audio) into a new group
   const handleGroupClips = useCallback(async () => {
     if (selectedVideoClips.size === 0 && selectedAudioClips.size === 0) return
@@ -5726,6 +5801,8 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
         onAudioClipSelect={handleClipSelect}
         onCopyAudioClip={handleCopyAudioClip}
         onPasteAudioClip={handlePasteAudioClip}
+        onNormalizeAudioSelection={handleNormalizeAudioSelection}
+        canNormalizeAudioSelection={contextMenu?.type === 'audio'}
         hasClipboard={!!clipboardAudioClip}
         onFreezeFrame={onFreezeFrame ?? (() => {})}
         assets={assets}

--- a/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
+++ b/frontend/src/components/editor/timeline/AudioClipWaveform.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react'
 
 import { useWaveform } from '@/hooks/useWaveform'
 import { RequestPriority } from '@/utils/requestPriority'
+import { getVisibleWaveformPeaks } from '@/utils/audioNormalization'
 
 import WaveformDisplay from '../WaveformDisplay'
 
@@ -37,19 +38,7 @@ const AudioClipWaveform = memo(function AudioClipWaveform({
 
   // Slice peaks to show only the visible portion based on in-point and clip duration
   const visiblePeaks = useMemo(() => {
-    const sourceAssetDurationMs = waveformDurationMs && waveformDurationMs > 0 ? waveformDurationMs : assetDurationMs
-
-    if (!fullPeaks || fullPeaks.length === 0 || !sourceAssetDurationMs || sourceAssetDurationMs <= 0) {
-      return fullPeaks
-    }
-
-    const sourceEndMs = Math.min(inPointMs + Math.max(sourceDurationMs, 1), sourceAssetDurationMs)
-    const startRatio = Math.max(0, Math.min(inPointMs / sourceAssetDurationMs, 1))
-    const endRatio = Math.max(startRatio, Math.min(sourceEndMs / sourceAssetDurationMs, 1))
-    const startIdx = Math.min(Math.floor(startRatio * fullPeaks.length), Math.max(fullPeaks.length - 1, 0))
-    const endIdx = Math.max(startIdx + 1, Math.min(Math.ceil(endRatio * fullPeaks.length), fullPeaks.length))
-
-    return fullPeaks.slice(startIdx, endIdx)
+    return getVisibleWaveformPeaks(fullPeaks, waveformDurationMs, inPointMs, sourceDurationMs, assetDurationMs)
   }, [fullPeaks, inPointMs, sourceDurationMs, assetDurationMs, waveformDurationMs])
 
   // Show placeholder while loading waveform

--- a/frontend/src/components/editor/timeline/TimelineContextMenu.tsx
+++ b/frontend/src/components/editor/timeline/TimelineContextMenu.tsx
@@ -14,6 +14,8 @@ interface TimelineContextMenuProps {
   onAudioClipSelect: (trackId: string, clipId: string) => void
   onCopyAudioClip: () => void
   onPasteAudioClip: () => void
+  onNormalizeAudioSelection: () => void
+  canNormalizeAudioSelection: boolean
   hasClipboard: boolean
   onFreezeFrame: (clipId: string, layerId: string) => void
   assets: Array<{ id: string; type: string }>
@@ -31,6 +33,8 @@ function TimelineContextMenu({
   onAudioClipSelect,
   onCopyAudioClip,
   onPasteAudioClip,
+  onNormalizeAudioSelection,
+  canNormalizeAudioSelection,
   hasClipboard,
   onFreezeFrame,
   assets,
@@ -72,9 +76,10 @@ function TimelineContextMenu({
   const hasSelection = selectedVideoClips.size > 0 || selectedAudioClips.size > 0
   const hasOverlappingClips = contextMenu.overlappingClips && contextMenu.overlappingClips.length > 1
   const hasCopyPaste = isAudioClip || hasClipboard
+  const showNormalizeAudio = isAudioClip && canNormalizeAudioSelection
 
   // Don't show menu if there are no items
-  if (!hasSelection && !hasGroup && !hasOverlappingClips && !hasCopyPaste && hasFreezeFrame === null) {
+  if (!hasSelection && !hasGroup && !hasOverlappingClips && !hasCopyPaste && !showNormalizeAudio && hasFreezeFrame === null) {
     return null
   }
 
@@ -121,10 +126,26 @@ function TimelineContextMenu({
           </button>
         )}
 
+        {showNormalizeAudio && (
+          <button
+            data-testid="timeline-normalize-audio"
+            className="w-full px-4 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700/70 flex items-center gap-2 transition-colors"
+            onClick={() => {
+              onNormalizeAudioSelection()
+              onClose()
+            }}
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 12h4m4 0h8M7 8v8m8-6v4m5-8v12" />
+            </svg>
+            {t('timeline.contextMenu.normalizeAudio')}
+          </button>
+        )}
+
         {/* Freeze frame option for video clips */}
         {hasFreezeFrame !== null && (
           <>
-            {(isAudioClip || hasClipboard) && <div className="border-t border-gray-600 my-1" />}
+            {(isAudioClip || hasClipboard || showNormalizeAudio) && <div className="border-t border-gray-600 my-1" />}
             <button
               className="w-full px-4 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700/70 flex items-center gap-2 transition-colors"
               onClick={() => {
@@ -143,7 +164,7 @@ function TimelineContextMenu({
         )}
 
         {/* Separator between copy/paste and group options */}
-        {(isAudioClip || hasClipboard || hasFreezeFrame !== null) && (hasSelection || hasGroup) && (
+        {(isAudioClip || hasClipboard || showNormalizeAudio || hasFreezeFrame !== null) && (hasSelection || hasGroup) && (
           <div className="border-t border-gray-600 my-1" />
         )}
 

--- a/frontend/src/i18n/locales/en/editor.json
+++ b/frontend/src/i18n/locales/en/editor.json
@@ -51,6 +51,7 @@
     "contextMenu": {
       "copy": "Copy",
       "paste": "Paste",
+      "normalizeAudio": "Normalize selected audio",
       "freezeFrame": "Add freeze frame",
       "removeFreezeFrame": "Remove freeze frame",
       "group": "Group",
@@ -219,6 +220,7 @@
     "textAdd": "Add text",
     "layerRename": "Rename layer",
     "trackRename": "Rename track",
+    "audioClipNormalize": "Normalize audio clips",
     "trackAdd": "Add track",
     "trackDelete": "Delete track",
     "audioClipAdd": "Add audio clip",

--- a/frontend/src/i18n/locales/ja/editor.json
+++ b/frontend/src/i18n/locales/ja/editor.json
@@ -34,6 +34,7 @@
     "contextMenu": {
       "copy": "コピー",
       "paste": "貼り付け",
+      "normalizeAudio": "選択音声を正規化",
       "freezeFrame": "静止画で延長",
       "removeFreezeFrame": "静止画延長を解除",
       "group": "グループ化",
@@ -85,5 +86,8 @@
     "sessionSaveFailedKeepEditing": "現在のタイムラインはそのまま編集できますが、このスナップショットはまだ保存されていません。",
     "retrySave": "再試行",
     "dismissSaveWarning": "閉じる"
+  },
+  "undo": {
+    "audioClipNormalize": "音声クリップを正規化"
   }
 }

--- a/frontend/src/utils/audioNormalization.ts
+++ b/frontend/src/utils/audioNormalization.ts
@@ -1,0 +1,87 @@
+import type { WaveformData } from '@/api/assets'
+import type { AudioClip as TimelineAudioClip } from '@/store/projectStore'
+
+const DEFAULT_TARGET_PEAK = 0.9
+
+export function getVisibleWaveformPeaks(
+  peaks: number[] | null | undefined,
+  waveformDurationMs: number | null | undefined,
+  inPointMs: number,
+  sourceDurationMs: number,
+  assetDurationMs: number | null | undefined
+): number[] {
+  const sourceAssetDurationMs = waveformDurationMs && waveformDurationMs > 0
+    ? waveformDurationMs
+    : assetDurationMs
+
+  if (!peaks || peaks.length === 0 || !sourceAssetDurationMs || sourceAssetDurationMs <= 0) {
+    return peaks ?? []
+  }
+
+  const sourceEndMs = Math.min(inPointMs + Math.max(sourceDurationMs, 1), sourceAssetDurationMs)
+  const startRatio = Math.max(0, Math.min(inPointMs / sourceAssetDurationMs, 1))
+  const endRatio = Math.max(startRatio, Math.min(sourceEndMs / sourceAssetDurationMs, 1))
+  const startIdx = Math.min(Math.floor(startRatio * peaks.length), Math.max(peaks.length - 1, 0))
+  const endIdx = Math.max(startIdx + 1, Math.min(Math.ceil(endRatio * peaks.length), peaks.length))
+
+  return peaks.slice(startIdx, endIdx)
+}
+
+export function getMaxPeak(peaks: number[] | null | undefined): number {
+  if (!peaks || peaks.length === 0) return 0
+  return Math.max(...peaks.map((peak) => Math.abs(peak)), 0)
+}
+
+export function getClipMaxGain(clip: TimelineAudioClip): number {
+  const keyframeMax = clip.volume_keyframes && clip.volume_keyframes.length > 0
+    ? Math.max(...clip.volume_keyframes.map((keyframe) => keyframe.value), 0)
+    : 0
+
+  return Math.max(clip.volume, keyframeMax, 0)
+}
+
+export function getNormalizationScaleFactor(
+  visiblePeak: number,
+  currentGain: number,
+  targetPeak: number = DEFAULT_TARGET_PEAK
+): number {
+  if (visiblePeak <= 0 || currentGain <= 0) return 1
+
+  const desiredScale = targetPeak / (visiblePeak * currentGain)
+  const maxAllowedScale = 1 / currentGain
+
+  return Math.max(0, Math.min(desiredScale, maxAllowedScale))
+}
+
+export function scaleAudioClipGain(clip: TimelineAudioClip, scaleFactor: number): TimelineAudioClip {
+  if (!Number.isFinite(scaleFactor) || scaleFactor <= 0 || Math.abs(scaleFactor - 1) < 0.0001) {
+    return clip
+  }
+
+  return {
+    ...clip,
+    volume: Math.max(0, Math.min(1, clip.volume * scaleFactor)),
+    volume_keyframes: clip.volume_keyframes?.map((keyframe) => ({
+      ...keyframe,
+      value: Math.max(0, Math.min(1, keyframe.value * scaleFactor)),
+    })),
+  }
+}
+
+export function getClipVisiblePeak(
+  clip: TimelineAudioClip,
+  waveform: WaveformData,
+  assetDurationMs: number | null | undefined
+): number {
+  const clipSpeed = clip.speed || 1
+  const sourceDurationMs = clip.duration_ms * clipSpeed
+  const visiblePeaks = getVisibleWaveformPeaks(
+    waveform.peaks,
+    waveform.duration_ms,
+    clip.in_point_ms,
+    sourceDurationMs,
+    assetDurationMs
+  )
+
+  return getMaxPeak(visiblePeaks)
+}


### PR DESCRIPTION
## Summary
- add a normalize action to the audio clip context menu
- normalize selected audio clips from their visible waveform slice in a single undoable timeline update
- scale `clip.volume` and `volume_keyframes` together and cover the flow with editor critical path regression

Closes #30

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts