### PR TITLE
fix(frontend): restore dashboard i18n labels

### DIFF
--- a/frontend/e2e/dashboard-i18n.spec.ts
+++ b/frontend/e2e/dashboard-i18n.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test'
+
+const mockProjects = [
+  {
+    id: 'project-dashboard-i18n',
+    name: 'Seeded Project',
+    description: null,
+    status: 'active',
+    duration_ms: 120000,
+    thumbnail_url: null,
+    created_at: '2026-03-07T00:00:00.000Z',
+    updated_at: '2026-03-07T00:00:00.000Z',
+    is_shared: false,
+    role: 'owner',
+    owner_name: 'Dev User',
+  },
+]
+
+test.describe('Dashboard i18n', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/projects', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockProjects),
+      })
+    })
+
+    await page.route('**/api/members/invitations', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    })
+  })
+
+  test('shows translated dashboard labels in Japanese without raw i18n keys', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('douga-language', 'ja')
+    })
+
+    await page.goto('/app')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByRole('heading', { name: 'ダッシュボード' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'プロジェクト' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '新規プロジェクト' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+
+    await expect(page.getByText('projects.sectionTitle')).toHaveCount(0)
+    await expect(page.getByText('projects.newProject')).toHaveCount(0)
+    await expect(page.getByText('header.signOut')).toHaveCount(0)
+  })
+
+  test('shows translated dashboard labels in English without raw i18n keys', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('douga-language', 'en')
+    })
+
+    await page.goto('/app')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'New Project' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible()
+
+    await expect(page.getByText('projects.sectionTitle')).toHaveCount(0)
+    await expect(page.getByText('projects.newProject')).toHaveCount(0)
+    await expect(page.getByText('header.signOut')).toHaveCount(0)
+  })
+})

--- a/frontend/src/i18n/locales/en/dashboard.json
+++ b/frontend/src/i18n/locales/en/dashboard.json
@@ -1,4 +1,30 @@
 {
+  "title": "Dashboard",
+  "header": {
+    "apiKeyManagement": "API Key Management",
+    "signOut": "Sign Out"
+  },
+  "projects": {
+    "sectionTitle": "Projects",
+    "newProject": "New Project",
+    "newProjectCreate": "Create your first project",
+    "emptyTitle": "No projects yet",
+    "emptyMessage": "Create a new project to start editing videos.",
+    "deleteConfirm": "Are you sure you want to delete this project?",
+    "shared": "Shared"
+  },
+  "newProjectModal": {
+    "title": "Create New Project",
+    "namePlaceholder": "Enter project name",
+    "cancel": "Cancel",
+    "create": "Create"
+  },
+  "invitations": {
+    "sectionTitle": "Invitations",
+    "invitedBy": "Invited by {{name}}",
+    "accept": "Accept",
+    "decline": "Decline"
+  },
   "nav": {
     "features": "Features",
     "waitlist": "Waitlist",

--- a/frontend/src/i18n/locales/ja/dashboard.json
+++ b/frontend/src/i18n/locales/ja/dashboard.json
@@ -1,4 +1,30 @@
 {
+  "title": "ダッシュボード",
+  "header": {
+    "apiKeyManagement": "APIキー管理",
+    "signOut": "ログアウト"
+  },
+  "projects": {
+    "sectionTitle": "プロジェクト",
+    "newProject": "新規プロジェクト",
+    "newProjectCreate": "最初のプロジェクトを作成",
+    "emptyTitle": "プロジェクトがまだありません",
+    "emptyMessage": "新しいプロジェクトを作成して動画編集を始めましょう。",
+    "deleteConfirm": "このプロジェクトを削除しますか？",
+    "shared": "共有"
+  },
+  "newProjectModal": {
+    "title": "新規プロジェクトを作成",
+    "namePlaceholder": "プロジェクト名を入力",
+    "cancel": "キャンセル",
+    "create": "作成"
+  },
+  "invitations": {
+    "sectionTitle": "招待",
+    "invitedBy": "{{name}} さんからの招待",
+    "accept": "参加",
+    "decline": "辞退"
+  },
   "nav": {
     "features": "機能",
     "waitlist": "順番待ち",


### PR DESCRIPTION
## Summary
- restore all dashboard locale entries referenced by Dashboard.tsx in both ja/en
- keep the existing `dashboard` namespace wiring and fix the user-facing key leakage at the resource layer
- add Playwright coverage for `/app` in ja/en so raw i18n keys do not reappear on the dashboard

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/dashboard-i18n.spec.ts

Closes #38
