### PR TITLE
fix(frontend): resync normalized audio inspector

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -698,6 +698,7 @@ test.describe('Editor Critical Path', () => {
     const clipB = page.getByTestId('timeline-audio-clip-audio-normalize-b')
 
     await clipA.click()
+    await expect(page.getByTestId('audio-clip-volume-input')).toHaveValue('100')
     await clipB.click({ modifiers: ['Shift'] })
     await clipB.dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2, clientX: 320, clientY: 420 })
 
@@ -705,6 +706,7 @@ test.describe('Editor Critical Path', () => {
     await page.getByTestId('timeline-normalize-audio').click()
 
     await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+    await expect(page.getByTestId('audio-clip-volume-input')).toHaveValue('95')
 
     const updatedClips = mock.calls.sequenceUpdates[0].timelineData.audio_tracks[0].clips
     const updatedA = updatedClips.find((clip) => clip.id === 'audio-normalize-a')

--- a/frontend/src/components/editor/EditorAudioClipInspector.tsx
+++ b/frontend/src/components/editor/EditorAudioClipInspector.tsx
@@ -106,6 +106,7 @@ export default function EditorAudioClipInspector({
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.volumePercent')}</label>
         <input
+          data-testid="audio-clip-volume-input"
           type="number"
           min="0"
           max="100"

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -3424,7 +3424,30 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
       { ...timeline, audio_tracks: updatedTracks },
       i18n.t('editor:undo.audioClipNormalize')
     )
-  }, [assets, getContextMenuAudioSelection, projectId, timeline, updateTimeline])
+
+    // Keep the property panel in sync after normalization so users can see the
+    // updated volume/keyframe values without reselecting the clip.
+    if (selectedClip && onClipSelect) {
+      const updatedTrack = updatedTracks.find((track) => track.id === selectedClip.trackId)
+      const updatedClip = updatedTrack?.clips.find((clip) => clip.id === selectedClip.clipId)
+
+      if (updatedTrack && updatedClip) {
+        const asset = assets.find((candidate) => candidate.id === updatedClip.asset_id)
+        onClipSelect({
+          trackId: updatedTrack.id,
+          trackType: updatedTrack.type,
+          clipId: updatedClip.id,
+          assetId: updatedClip.asset_id,
+          assetName: asset?.name || updatedClip.asset_id.slice(0, 8),
+          startMs: updatedClip.start_ms,
+          durationMs: updatedClip.duration_ms,
+          volume: updatedClip.volume,
+          fadeInMs: updatedClip.fade_in_ms,
+          fadeOutMs: updatedClip.fade_out_ms,
+        })
+      }
+    }
+  }, [assets, getContextMenuAudioSelection, onClipSelect, projectId, selectedClip, timeline, updateTimeline])
 
   // Group selected clips (video + audio) into a new group
   const handleGroupClips = useCallback(async () => {


### PR DESCRIPTION
## Summary
- resync the selected audio clip after normalize updates the timeline
- expose the audio clip volume input to targeted UI verification
- extend the normalization Playwright test to assert the inspector updates from 100 to 95

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "normalizes only the selected audio clips and preserves undoable timeline updates"

Closes #30
