### PR TITLE
feat(frontend): add Skitch-style arrow shape

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -164,6 +164,24 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByText('No activity yet')).toBeVisible()
   })
 
+  test('adds a Skitch-style arrow shape through the existing shape flow', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shape-arrow').click()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const addedShape = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips[0]?.shape
+    expect(addedShape?.type).toBe('arrow')
+    expect(addedShape?.width).toBe(180)
+    expect(addedShape?.height).toBe(48)
+    expect(addedShape?.strokeColor).toBe('#FF0000')
+    await expect(page.getByText(/Arrow|矢印/)).toBeVisible()
+  })
+
   test('returns to the dashboard instead of the landing page from the editor', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
 

--- a/frontend/e2e/page-objects/EditorPage.ts
+++ b/frontend/e2e/page-objects/EditorPage.ts
@@ -73,6 +73,17 @@ export class EditorPage {
     return false
   }
 
+  async addArrowShape() {
+    if (!(await this.openAddDropdown())) return false
+    const arrowButton = this.page.getByTestId('timeline-add-shape-arrow')
+    if (await arrowButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await arrowButton.click()
+      await this.page.waitForTimeout(500)
+      return true
+    }
+    return false
+  }
+
   async addTextClip() {
     if (!(await this.openAddDropdown())) return false
     const textButton = this.addDropdown.locator('button:has-text("Text"), button:has-text("テキスト")')

--- a/frontend/src/components/editor/EditorPreviewShapeClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewShapeClip.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent as ReactMouseEvent } from 'react'
 import type { PreviewDragHandle } from '@/hooks/usePreviewDragWorkflow'
 import { type ActiveClipInfo, getHandleCursor } from '@/components/editor/editorPreviewStageShared'
+import { getArrowShapeMetrics } from '@/components/editor/shapeGeometry'
 
 interface EditorPreviewShapeClipProps {
   activeClip: ActiveClipInfo
@@ -72,6 +73,30 @@ export default function EditorPreviewShapeClip({
               strokeLinecap="round"
             />
           )}
+          {shape.type === 'arrow' && (() => {
+            const metrics = getArrowShapeMetrics(shape)
+            return (
+              <>
+                <line
+                  x1={metrics.shaftStartX}
+                  y1={metrics.centerY}
+                  x2={metrics.shaftEndX}
+                  y2={metrics.centerY}
+                  stroke={shape.strokeColor}
+                  strokeWidth={shape.strokeWidth}
+                  strokeLinecap="round"
+                />
+                <polygon
+                  points={[
+                    `${metrics.headBaseX},${metrics.centerY - metrics.headHalfHeight}`,
+                    `${metrics.headTipX},${metrics.centerY}`,
+                    `${metrics.headBaseX},${metrics.centerY + metrics.headHalfHeight}`,
+                  ].join(' ')}
+                  fill={shape.strokeColor}
+                />
+              </>
+            )
+          })()}
         </svg>
         <div
           className="absolute inset-0"

--- a/frontend/src/components/editor/EditorVideoClipShapeSection.tsx
+++ b/frontend/src/components/editor/EditorVideoClipShapeSection.tsx
@@ -29,7 +29,7 @@ export default function EditorVideoClipShapeSection({
     <div className="pt-4 border-t border-gray-700">
       <label className="block text-xs text-gray-500 mb-3">{t('editor.shapeProps')}</label>
       <div className="space-y-3">
-        {shape.type !== 'line' && (
+        {shape.type !== 'line' && shape.type !== 'arrow' && (
           <div>
             <div className="flex items-center justify-between mb-2">
               <label className="text-xs text-gray-400">{t('editor.fill')}</label>

--- a/frontend/src/components/editor/ShapeSVGRenderer.tsx
+++ b/frontend/src/components/editor/ShapeSVGRenderer.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import type { Shape } from '@/store/projectStore'
+import { getArrowShapeMetrics } from '@/components/editor/shapeGeometry'
 
 interface ShapeSVGRendererProps {
   shape: Shape
@@ -11,7 +12,7 @@ interface ShapeSVGRendererProps {
 
 /**
  * Renders a shape as SVG with proper viewBox scaling.
- * Supports rectangle, circle, and line shapes.
+ * Supports rectangle, circle, line, and arrow shapes.
  */
 const ShapeSVGRenderer = memo(function ShapeSVGRenderer({
   shape,
@@ -61,6 +62,30 @@ const ShapeSVGRenderer = memo(function ShapeSVGRenderer({
           strokeLinecap="round"
         />
       )}
+      {shape.type === 'arrow' && (() => {
+        const metrics = getArrowShapeMetrics(shape)
+        return (
+          <>
+            <line
+              x1={metrics.shaftStartX}
+              y1={metrics.centerY}
+              x2={metrics.shaftEndX}
+              y2={metrics.centerY}
+              stroke={shape.strokeColor}
+              strokeWidth={shape.strokeWidth}
+              strokeLinecap="round"
+            />
+            <polygon
+              points={[
+                `${metrics.headBaseX},${metrics.centerY - metrics.headHalfHeight}`,
+                `${metrics.headTipX},${metrics.centerY}`,
+                `${metrics.headBaseX},${metrics.centerY + metrics.headHalfHeight}`,
+              ].join(' ')}
+              fill={shape.strokeColor}
+            />
+          </>
+        )
+      })()}
     </svg>
   )
 })

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -1248,7 +1248,12 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
           } else if (clip.text_content) {
             assetName = `${t('timeline.text')}: ${clip.text_content.slice(0, 10)}${clip.text_content.length > 10 ? '...' : ''}`
           } else if (clip.shape) {
-            const shapeNames: Record<string, string> = { rectangle: t('timeline.rectangle'), circle: t('timeline.circle'), line: t('timeline.line') }
+            const shapeNames: Record<string, string> = {
+              rectangle: t('timeline.rectangle'),
+              circle: t('timeline.circle'),
+              line: t('timeline.line'),
+              arrow: t('timeline.arrow'),
+            }
             assetName = shapeNames[clip.shape.type] || clip.shape.type
           } else if (clip.asset_id) {
             assetName = clip.asset_id.slice(0, 8)
@@ -2012,8 +2017,8 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     const defaultShape: Shape = {
       type: shapeType,
       name: shapeName,  // Optional name provided by user
-      width: shapeType === 'circle' ? 100 : 150,
-      height: shapeType === 'circle' ? 100 : (shapeType === 'line' ? 4 : 100),
+      width: shapeType === 'circle' ? 100 : (shapeType === 'arrow' ? 180 : 150),
+      height: shapeType === 'circle' ? 100 : (shapeType === 'line' ? 4 : (shapeType === 'arrow' ? 48 : 100)),
       fillColor: 'transparent',
       strokeColor: '#FF0000',
       strokeWidth: 5,
@@ -3308,10 +3313,18 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
               const clip = layer.clips.find(c => c.id === id)
               if (!clip) return null
               const asset = clip.asset_id ? assets.find(a => a.id === clip.asset_id) : null
+              const shapeLabel = clip.shape
+                ? ({
+                  rectangle: t('timeline.rectangle'),
+                  circle: t('timeline.circle'),
+                  line: t('timeline.line'),
+                  arrow: t('timeline.arrow'),
+                } as const)[clip.shape.type]
+                : null
               const name = clip.text_content
                 ? `${t('timeline.text')}: ${clip.text_content.slice(0, 15)}${clip.text_content.length > 15 ? '...' : ''}`
                 : clip.shape
-                  ? `${t('timeline.shapeSection')}: ${clip.shape.type}`
+                  ? `${t('timeline.shapeSection')}: ${shapeLabel || clip.shape.type}`
                   : asset?.name || t('timeline.trackLabel')
               return { clipId: id, name }
             })
@@ -4533,10 +4546,16 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     }
     if (clip.shape) {
       // Use shape name if available, otherwise use shape type
-      return clip.shape.name || clip.shape.type
+      const shapeLabel = {
+        rectangle: t('timeline.rectangle'),
+        circle: t('timeline.circle'),
+        line: t('timeline.line'),
+        arrow: t('timeline.arrow'),
+      }[clip.shape.type]
+      return clip.shape.name || shapeLabel || clip.shape.type
     }
     return 'Clip'
-  }, [getAssetName])
+  }, [getAssetName, t])
 
   const getSelectedClipData = useCallback(() => {
     if (!selectedClip) return null
@@ -4763,23 +4782,30 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
                 </button>
                 <div className="h-px bg-gray-600 my-1 mx-2" />
                 <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">{t('timeline.shapeSection')}</div>
-                <button onClick={() => { handleAddShape('rectangle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                <button data-testid="timeline-add-shape-rectangle" onClick={() => { handleAddShape('rectangle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
                   <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth={2} />
                   </svg>
                   {t('timeline.rectangle')}
                 </button>
-                <button onClick={() => { handleAddShape('circle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                <button data-testid="timeline-add-shape-circle" onClick={() => { handleAddShape('circle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
                   <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <circle cx="12" cy="12" r="9" strokeWidth={2} />
                   </svg>
                   {t('timeline.circle')}
                 </button>
-                <button onClick={() => { handleAddShape('line'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                <button data-testid="timeline-add-shape-line" onClick={() => { handleAddShape('line'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
                   <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <line x1="4" y1="20" x2="20" y2="4" strokeWidth={2} />
                   </svg>
                   {t('timeline.line')}
+                </button>
+                <button data-testid="timeline-add-shape-arrow" onClick={() => { handleAddShape('arrow'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                  <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path d="M4 12h10" strokeWidth={2.4} strokeLinecap="round" />
+                    <path d="m12 6 8 6-8 6" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  {t('timeline.arrow')}
                 </button>
                 <div className="h-px bg-gray-600 my-1 mx-2" />
                 <button onClick={() => { handleAddText(); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">

--- a/frontend/src/components/editor/shapeGeometry.ts
+++ b/frontend/src/components/editor/shapeGeometry.ts
@@ -1,0 +1,36 @@
+import type { Shape } from '@/store/projectStore'
+
+export interface ArrowShapeMetrics {
+  centerY: number
+  headBaseX: number
+  headHalfHeight: number
+  headTipX: number
+  shaftEndX: number
+  shaftStartX: number
+}
+
+export function getArrowShapeMetrics(shape: Shape): ArrowShapeMetrics {
+  const minInset = Math.max(shape.strokeWidth / 2, 2)
+  const centerY = shape.height / 2
+  const headLength = Math.min(
+    shape.width * 0.42,
+    Math.max(shape.width * 0.22, shape.height * 0.78, shape.strokeWidth * 3)
+  )
+  const headTipX = shape.width - minInset
+  const headBaseX = Math.max(minInset + 8, headTipX - headLength)
+  const headHalfHeight = Math.min(
+    shape.height / 2 - minInset,
+    Math.max(shape.height * 0.26, shape.strokeWidth * 1.45)
+  )
+  const shaftStartX = minInset
+  const shaftEndX = Math.max(shaftStartX, headBaseX - Math.max(shape.strokeWidth * 0.35, 4))
+
+  return {
+    centerY,
+    headBaseX,
+    headHalfHeight,
+    headTipX,
+    shaftEndX,
+    shaftStartX,
+  }
+}

--- a/frontend/src/i18n/locales/en/editor.json
+++ b/frontend/src/i18n/locales/en/editor.json
@@ -75,6 +75,7 @@
     "rectangle": "Rectangle",
     "circle": "Circle",
     "line": "Line",
+    "arrow": "Arrow",
     "text": "Text",
     "muteAll": "Mute all tracks",
     "unmuteAll": "Unmute all tracks",

--- a/frontend/src/i18n/locales/ja/editor.json
+++ b/frontend/src/i18n/locales/ja/editor.json
@@ -65,7 +65,14 @@
     "generateTelop": "テロップ自動生成（AI）",
     "generatingTelop": "テロップ生成中...",
     "noLayerSelected": "レイヤーを選択してください",
-    "noAssetClips": "選択レイヤーに音声/動画クリップがありません"
+    "noAssetClips": "選択レイヤーに音声/動画クリップがありません",
+    "shapeSection": "図形",
+    "rectangle": "四角形",
+    "circle": "円",
+    "line": "線",
+    "arrow": "矢印",
+    "text": "テキスト",
+    "trackLabel": "トラック"
   },
   "editor": {
     "sequenceSaveStatusTitle": "シーケンス保存状態",

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -2352,7 +2352,14 @@ export default function Editor() {
           let assetName = 'Clip'
           if (asset) assetName = asset.name
           else if (clip.text_content) assetName = `${t('timeline.text')}: ${clip.text_content.slice(0, 10)}`
-          else if (clip.shape) assetName = clip.shape.type
+          else if (clip.shape) {
+            assetName = ({
+              rectangle: t('timeline.rectangle'),
+              circle: t('timeline.circle'),
+              line: t('timeline.line'),
+              arrow: t('timeline.arrow'),
+            } as const)[clip.shape.type] || clip.shape.type
+          }
           setSelectedVideoClip({
             layerId: layer.id,
             layerName: layer.name,

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -79,14 +79,14 @@ export interface Keyframe {
   opacity?: number
 }
 
-// Shape types for drawing primitives
-export type ShapeType = 'rectangle' | 'circle' | 'line'
+// Shape types for drawing primitives and annotations
+export type ShapeType = 'rectangle' | 'circle' | 'line' | 'arrow'
 
 export interface Shape {
   type: ShapeType
   name?: string        // Optional name for the shape (displayed on hover)
-  width: number        // Width for rectangle, diameter for circle, length for line
-  height: number       // Height for rectangle, same as width for circle, thickness for line
+  width: number        // Width for rectangle/arrow, diameter for circle, length for line
+  height: number       // Height for rectangle/arrow, same as width for circle, thickness for line
   fillColor: string    // Fill color (hex or rgba)
   strokeColor: string  // Stroke/border color
   strokeWidth: number  // Stroke/border width in pixels


### PR DESCRIPTION
## Summary
- add `arrow` as a first-class shape type for Skitch-style annotations
- render the arrow consistently in both shape preview paths and expose it in the add-shape menu
- add a focused Playwright regression that creates an arrow through the existing shape flow

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "adds a Skitch-style arrow shape through the existing shape flow"

Closes #42
