### PR TITLE
fix(frontend): rework arrow annotation shape

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -179,6 +179,8 @@ test.describe('Editor Critical Path', () => {
     expect(addedShape?.width).toBe(180)
     expect(addedShape?.height).toBe(48)
     expect(addedShape?.strokeColor).toBe('#FF0000')
+    await expect(page.getByTestId('preview-container').getByTestId('shape-arrow-polygon')).toHaveCount(1)
+    await expect(page.getByTestId('preview-container').locator('line')).toHaveCount(0)
     await expect(page.getByText(/Arrow|矢印/)).toBeVisible()
   })
 

--- a/frontend/src/components/editor/EditorPreviewShapeClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewShapeClip.tsx
@@ -1,7 +1,7 @@
 import type { MouseEvent as ReactMouseEvent } from 'react'
 import type { PreviewDragHandle } from '@/hooks/usePreviewDragWorkflow'
 import { type ActiveClipInfo, getHandleCursor } from '@/components/editor/editorPreviewStageShared'
-import { getArrowShapeMetrics } from '@/components/editor/shapeGeometry'
+import { getArrowShapePoints } from '@/components/editor/shapeGeometry'
 
 interface EditorPreviewShapeClipProps {
   activeClip: ActiveClipInfo
@@ -74,27 +74,13 @@ export default function EditorPreviewShapeClip({
             />
           )}
           {shape.type === 'arrow' && (() => {
-            const metrics = getArrowShapeMetrics(shape)
+            const points = getArrowShapePoints(shape)
             return (
-              <>
-                <line
-                  x1={metrics.shaftStartX}
-                  y1={metrics.centerY}
-                  x2={metrics.shaftEndX}
-                  y2={metrics.centerY}
-                  stroke={shape.strokeColor}
-                  strokeWidth={shape.strokeWidth}
-                  strokeLinecap="round"
-                />
-                <polygon
-                  points={[
-                    `${metrics.headBaseX},${metrics.centerY - metrics.headHalfHeight}`,
-                    `${metrics.headTipX},${metrics.centerY}`,
-                    `${metrics.headBaseX},${metrics.centerY + metrics.headHalfHeight}`,
-                  ].join(' ')}
-                  fill={shape.strokeColor}
-                />
-              </>
+              <polygon
+                data-testid="shape-arrow-polygon"
+                points={points}
+                fill={shape.strokeColor}
+              />
             )
           })()}
         </svg>

--- a/frontend/src/components/editor/ShapeSVGRenderer.tsx
+++ b/frontend/src/components/editor/ShapeSVGRenderer.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import type { Shape } from '@/store/projectStore'
-import { getArrowShapeMetrics } from '@/components/editor/shapeGeometry'
+import { getArrowShapePoints } from '@/components/editor/shapeGeometry'
 
 interface ShapeSVGRendererProps {
   shape: Shape
@@ -63,27 +63,13 @@ const ShapeSVGRenderer = memo(function ShapeSVGRenderer({
         />
       )}
       {shape.type === 'arrow' && (() => {
-        const metrics = getArrowShapeMetrics(shape)
+        const points = getArrowShapePoints(shape)
         return (
-          <>
-            <line
-              x1={metrics.shaftStartX}
-              y1={metrics.centerY}
-              x2={metrics.shaftEndX}
-              y2={metrics.centerY}
-              stroke={shape.strokeColor}
-              strokeWidth={shape.strokeWidth}
-              strokeLinecap="round"
-            />
-            <polygon
-              points={[
-                `${metrics.headBaseX},${metrics.centerY - metrics.headHalfHeight}`,
-                `${metrics.headTipX},${metrics.centerY}`,
-                `${metrics.headBaseX},${metrics.centerY + metrics.headHalfHeight}`,
-              ].join(' ')}
-              fill={shape.strokeColor}
-            />
-          </>
+          <polygon
+            data-testid="shape-arrow-polygon"
+            points={points}
+            fill={shape.strokeColor}
+          />
         )
       })()}
     </svg>

--- a/frontend/src/components/editor/shapeGeometry.ts
+++ b/frontend/src/components/editor/shapeGeometry.ts
@@ -1,36 +1,35 @@
 import type { Shape } from '@/store/projectStore'
 
-export interface ArrowShapeMetrics {
-  centerY: number
-  headBaseX: number
-  headHalfHeight: number
-  headTipX: number
-  shaftEndX: number
-  shaftStartX: number
-}
-
-export function getArrowShapeMetrics(shape: Shape): ArrowShapeMetrics {
-  const minInset = Math.max(shape.strokeWidth / 2, 2)
+export function getArrowShapePoints(shape: Shape): string {
+  const inset = 1
   const centerY = shape.height / 2
+  const tipX = shape.width - inset
   const headLength = Math.min(
-    shape.width * 0.42,
-    Math.max(shape.width * 0.22, shape.height * 0.78, shape.strokeWidth * 3)
+    shape.width * 0.34,
+    Math.max(shape.width * 0.2, shape.height * 1.05, shape.strokeWidth * 4)
   )
-  const headTipX = shape.width - minInset
-  const headBaseX = Math.max(minInset + 8, headTipX - headLength)
+  const headBaseX = Math.max(inset + 18, tipX - headLength)
+  const shoulderX = Math.max(inset + 10, headBaseX - Math.max(shape.width * 0.16, 12))
+  const tailHalfHeight = Math.min(
+    shape.height * 0.18,
+    Math.max(shape.strokeWidth * 0.18, shape.height * 0.05, 2)
+  )
+  const bodyHalfHeight = Math.min(
+    shape.height * 0.23,
+    Math.max(tailHalfHeight + 2, shape.height * 0.12, shape.strokeWidth * 0.22)
+  )
   const headHalfHeight = Math.min(
-    shape.height / 2 - minInset,
-    Math.max(shape.height * 0.26, shape.strokeWidth * 1.45)
+    shape.height / 2 - inset,
+    Math.max(bodyHalfHeight + 5, shape.height * 0.36, shape.strokeWidth * 0.7)
   )
-  const shaftStartX = minInset
-  const shaftEndX = Math.max(shaftStartX, headBaseX - Math.max(shape.strokeWidth * 0.35, 4))
 
-  return {
-    centerY,
-    headBaseX,
-    headHalfHeight,
-    headTipX,
-    shaftEndX,
-    shaftStartX,
-  }
+  return [
+    `${inset},${centerY - tailHalfHeight}`,
+    `${shoulderX},${centerY - bodyHalfHeight}`,
+    `${headBaseX},${centerY - bodyHalfHeight}`,
+    `${tipX},${centerY}`,
+    `${headBaseX},${centerY + headHalfHeight}`,
+    `${shoulderX},${centerY + bodyHalfHeight}`,
+    `${inset},${centerY + tailHalfHeight}`,
+  ].join(' ')
 }


### PR DESCRIPTION
## Summary
- replace the arrow geometry with a single filled polygon instead of a line plus triangle head
- reshape the silhouette so it starts thin at the tail and broadens continuously toward the tip
- extend the focused Playwright check so the preview contains the polygon-based arrow shape

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "adds a Skitch-style arrow shape through the existing shape flow"

Closes #42
