### PR TITLE
fix(backend): remove export audio loudness drift

### DIFF
--- a/backend/src/render/audio_mixer.py
+++ b/backend/src/render/audio_mixer.py
@@ -6,6 +6,7 @@ This module handles:
 - BGM ducking (automatically lower BGM when narration plays)
 - Volume control per track
 - Fade in/out effects
+- Final peak limiting for export safety
 """
 
 import subprocess
@@ -119,8 +120,11 @@ class AudioMixer:
             )
             final_output = "mixed"
 
-        # Add output normalization
-        filter_parts.append(f"[{final_output}]loudnorm=I=-16:TP=-1.5:LRA=11[out]")
+        # Keep export loudness aligned with the editor mix. The previous
+        # export-only loudnorm stage applied time-varying gain that made later
+        # sections creep louder than the timeline preview. A static limiter keeps
+        # peaks under control without rebalancing the mix over time.
+        filter_parts.append(f"[{final_output}]alimiter=limit=0.95:level=false[out]")
 
         # Build full command
         filter_complex = ";\n".join(filter_parts)

--- a/backend/tests/test_audio_mixer.py
+++ b/backend/tests/test_audio_mixer.py
@@ -6,7 +6,7 @@ Test cases:
 2. Mix multiple tracks
 3. BGM ducking with narration
 4. Fade in/out effects
-5. Volume normalization (-16 LUFS)
+5. Master output limiting
 6. Handle empty tracks
 """
 
@@ -23,23 +23,35 @@ class TestAudioMixer:
     @pytest.fixture
     def extract_audio_from_video(self, temp_output_dir: Path):
         """Helper to extract audio from video for mixing tests."""
+
         def _extract(video_path: Path, name: str) -> Path:
             output_path = temp_output_dir / f"{name}.mp3"
             cmd = [
-                "ffmpeg", "-y", "-i", str(video_path),
-                "-vn", "-acodec", "libmp3lame", "-ab", "192k",
-                "-ar", "44100", "-ac", "2",
-                str(output_path)
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(video_path),
+                "-vn",
+                "-acodec",
+                "libmp3lame",
+                "-ab",
+                "192k",
+                "-ar",
+                "44100",
+                "-ac",
+                "2",
+                str(output_path),
             ]
             subprocess.run(cmd, capture_output=True, check=True)
             return output_path
+
         return _extract
 
     def test_mix_single_narration_track(
         self, operation_video_with_audio: Path, temp_output_dir: Path, extract_audio_from_video
     ):
         """Test mixing a single narration track."""
-        from src.render.audio_mixer import AudioMixer, AudioClipData, AudioTrackData
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
 
         # Extract audio from test video
         audio_path = extract_audio_from_video(operation_video_with_audio, "narration")
@@ -55,7 +67,7 @@ class TestAudioMixer:
                     duration_ms=10000,  # 10 seconds
                     volume=1.0,
                 )
-            ]
+            ],
         )
 
         # Mix
@@ -71,7 +83,7 @@ class TestAudioMixer:
         self, multiple_audio_videos: list[Path], temp_output_dir: Path, extract_audio_from_video
     ):
         """Test BGM ducking when narration is present."""
-        from src.render.audio_mixer import AudioMixer, AudioClipData, AudioTrackData
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
 
         # Extract audio from two videos
         narration_path = extract_audio_from_video(multiple_audio_videos[0], "narration")
@@ -88,7 +100,7 @@ class TestAudioMixer:
                     duration_ms=10000,
                     volume=1.0,
                 )
-            ]
+            ],
         )
 
         bgm_track = AudioTrackData(
@@ -105,17 +117,13 @@ class TestAudioMixer:
                     duration_ms=10000,
                     volume=1.0,
                 )
-            ]
+            ],
         )
 
         # Mix
         mixer = AudioMixer(output_dir=str(temp_output_dir))
         output_path = temp_output_dir / "mixed_ducking.aac"
-        result = mixer.mix_tracks(
-            [narration_track, bgm_track],
-            str(output_path),
-            duration_ms=10000
-        )
+        result = mixer.mix_tracks([narration_track, bgm_track], str(output_path), duration_ms=10000)
 
         # Verify output
         assert Path(result).exists(), "Output file should be created"
@@ -124,7 +132,7 @@ class TestAudioMixer:
         self, operation_video_with_audio: Path, temp_output_dir: Path, extract_audio_from_video
     ):
         """Test fade in and fade out effects."""
-        from src.render.audio_mixer import AudioMixer, AudioClipData, AudioTrackData
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
 
         audio_path = extract_audio_from_video(operation_video_with_audio, "audio")
 
@@ -138,10 +146,10 @@ class TestAudioMixer:
                     start_ms=0,
                     duration_ms=10000,
                     volume=1.0,
-                    fade_in_ms=1000,   # 1 second fade in
+                    fade_in_ms=1000,  # 1 second fade in
                     fade_out_ms=1000,  # 1 second fade out
                 )
-            ]
+            ],
         )
 
         mixer = AudioMixer(output_dir=str(temp_output_dir))
@@ -154,7 +162,7 @@ class TestAudioMixer:
         self, multiple_audio_videos: list[Path], temp_output_dir: Path, extract_audio_from_video
     ):
         """Test positioning clips at different start times."""
-        from src.render.audio_mixer import AudioMixer, AudioClipData, AudioTrackData
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
 
         audio1_path = extract_audio_from_video(multiple_audio_videos[0], "clip1")
         audio2_path = extract_audio_from_video(multiple_audio_videos[1], "clip2")
@@ -175,20 +183,23 @@ class TestAudioMixer:
                     start_ms=5000,  # Start at 5 seconds
                     duration_ms=5000,
                     volume=1.0,
-                )
-            ]
+                ),
+            ],
         )
 
         mixer = AudioMixer(output_dir=str(temp_output_dir))
         output_path = temp_output_dir / "mixed_positioned.aac"
-        result = mixer.mix_tracks([track], str(output_path), duration_ms=10000)
+        mixer.mix_tracks([track], str(output_path), duration_ms=10000)
 
         # Verify output duration
         probe_cmd = [
-            "ffprobe", "-v", "quiet",
-            "-print_format", "json",
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
             "-show_format",
-            str(output_path)
+            str(output_path),
         ]
         probe_result = subprocess.run(probe_cmd, capture_output=True, text=True)
         probe_data = json.loads(probe_result.stdout)
@@ -201,7 +212,7 @@ class TestAudioMixer:
         self, multiple_audio_videos: list[Path], temp_output_dir: Path, extract_audio_from_video
     ):
         """Test mixing narration, BGM, and SE tracks together."""
-        from src.render.audio_mixer import AudioMixer, AudioClipData, AudioTrackData
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
 
         narration_path = extract_audio_from_video(multiple_audio_videos[0], "narration")
         bgm_path = extract_audio_from_video(multiple_audio_videos[1], "bgm")
@@ -218,7 +229,7 @@ class TestAudioMixer:
                         duration_ms=10000,
                         volume=1.0,
                     )
-                ]
+                ],
             ),
             AudioTrackData(
                 track_type="bgm",
@@ -232,7 +243,7 @@ class TestAudioMixer:
                         duration_ms=10000,
                         volume=1.0,
                     )
-                ]
+                ],
             ),
             AudioTrackData(
                 track_type="se",
@@ -244,8 +255,8 @@ class TestAudioMixer:
                         duration_ms=3000,
                         volume=1.0,
                     )
-                ]
-            )
+                ],
+            ),
         ]
 
         mixer = AudioMixer(output_dir=str(temp_output_dir))
@@ -271,11 +282,39 @@ class TestAudioMixer:
         # Should generate a silent file
         assert Path(result).exists(), "Should generate silence file"
 
-    def test_output_loudness_normalization(
+    def test_build_mix_command_uses_static_master_limiter(self):
+        """Export mix should avoid dynamic loudness normalization."""
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
+
+        mixer = AudioMixer()
+        cmd = mixer.build_mix_command(
+            [
+                AudioTrackData(
+                    track_type="narration",
+                    clips=[
+                        AudioClipData(
+                            file_path="/tmp/test-audio.wav",
+                            start_ms=0,
+                            duration_ms=5000,
+                            volume=1.0,
+                        )
+                    ],
+                )
+            ],
+            output_path="/tmp/out.aac",
+            duration_ms=5000,
+        )
+
+        assert cmd is not None
+        filter_complex = cmd[cmd.index("-filter_complex") + 1]
+        assert "loudnorm" not in filter_complex
+        assert "alimiter=limit=0.95:level=false[out]" in filter_complex
+
+    def test_output_audio_file_is_valid(
         self, operation_video_with_audio: Path, temp_output_dir: Path, extract_audio_from_video
     ):
-        """Test that output is normalized to approximately -16 LUFS."""
-        from src.render.audio_mixer import AudioMixer, AudioClipData, AudioTrackData
+        """Mixed output should still produce a valid audio file."""
+        from src.render.audio_mixer import AudioClipData, AudioMixer, AudioTrackData
 
         audio_path = extract_audio_from_video(operation_video_with_audio, "audio")
 
@@ -289,20 +328,21 @@ class TestAudioMixer:
                     duration_ms=10000,
                     volume=1.0,
                 )
-            ]
+            ],
         )
 
         mixer = AudioMixer(output_dir=str(temp_output_dir))
         output_path = temp_output_dir / "normalized.aac"
         mixer.mix_tracks([track], str(output_path), duration_ms=10000)
 
-        # Measure loudness using ffmpeg loudnorm filter (two-pass)
-        # This is a simplified check - just verify the file is valid
         probe_cmd = [
-            "ffprobe", "-v", "quiet",
-            "-print_format", "json",
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
             "-show_streams",
-            str(output_path)
+            str(output_path),
         ]
         probe_result = subprocess.run(probe_cmd, capture_output=True, text=True)
         probe_data = json.loads(probe_result.stdout)


### PR DESCRIPTION
## Summary
- remove the export-only `loudnorm` stage that was rebalancing the mix over time after clip and track volumes were already applied
- keep a static master peak limiter so export output stays safe without drifting louder toward the end
- add a regression test that asserts the generated mix command no longer includes `loudnorm`

## Verification
- `uv run --python 3.11 pytest backend/tests/test_audio_mixer.py -q`
- `uv run --python 3.11 ruff check backend/src/render/audio_mixer.py backend/tests/test_audio_mixer.py`
- `uv run --python 3.11 ruff format --check backend/src/render/audio_mixer.py backend/tests/test_audio_mixer.py`
- `ENVIRONMENT=test uv run --python 3.11 --extra dev mypy backend/src/render/audio_mixer.py --ignore-missing-imports`

Closes #46