### PR TITLE
feat(frontend): edit arrows from start and end handles

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -190,6 +190,49 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByText(/Arrow|矢印/)).toBeVisible()
   })
 
+  test('edits an arrow by dragging its start/end handles and keeps the result after reload', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shape-arrow').click()
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const clipId = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips[0]?.id
+    expect(clipId).toBeTruthy()
+
+    await page.getByTestId(`timeline-video-clip-${clipId}`).click()
+    await expect(page.getByTestId('shape-arrow-end-handle')).toBeVisible()
+
+    const endHandle = page.getByTestId('shape-arrow-end-handle')
+    const handleBox = await endHandle.boundingBox()
+    expect(handleBox).not.toBeNull()
+    if (!handleBox) {
+      throw new Error('Arrow end handle bounds were not available')
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 140, handleBox.y + handleBox.height / 2 - 60, { steps: 8 })
+    await page.mouse.up()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(2)
+
+    const updatedClip = mock.calls.sequenceUpdates[1].timelineData.layers[0].clips[0]
+    expect(updatedClip?.shape?.type).toBe('arrow')
+    expect(updatedClip?.shape?.width ?? 0).toBeGreaterThan(180)
+    expect(Math.abs(updatedClip?.transform.rotation ?? 0)).toBeGreaterThan(5)
+    expect(updatedClip?.transform.x ?? 0).not.toBe(0)
+    expect(updatedClip?.transform.y ?? 0).not.toBe(0)
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('timeline-video-clip-' + clipId).click()
+    await expect(page.getByTestId('shape-arrow-start-handle')).toBeVisible()
+    await expect(page.getByTestId('shape-arrow-end-handle')).toBeVisible()
+  })
+
   test('returns to the dashboard instead of the landing page from the editor', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
 

--- a/frontend/src/components/editor/EditorPreviewShapeClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewShapeClip.tsx
@@ -25,6 +25,7 @@ export default function EditorPreviewShapeClip({
 }: EditorPreviewShapeClipProps) {
   const shape = activeClip.shape
   if (!shape) return null
+  const isArrow = shape.type === 'arrow'
 
   return (
     <div
@@ -95,14 +96,37 @@ export default function EditorPreviewShapeClip({
         />
         {isSelected && !activeClip.locked && (
           <>
-            <div className="absolute" style={{ top: 0, left: 0, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tl'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tl', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ top: 0, right: 0, transform: 'translate(50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tr'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tr', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ bottom: 0, left: 0, transform: 'translate(-50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-bl'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-bl', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ bottom: 0, right: 0, transform: 'translate(50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-br'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-br', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ top: 0, left: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-t'), padding: '8px 12px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-t', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-3 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ bottom: 0, left: '50%', transform: 'translate(-50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-b'), padding: '8px 12px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-b', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-3 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ left: 0, top: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-l'), padding: '12px 8px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-l', activeClip.layerId, activeClip.clip.id) }}><div className="w-3 h-5 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
-            <div className="absolute" style={{ right: 0, top: '50%', transform: 'translate(50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-r'), padding: '12px 8px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-r', activeClip.layerId, activeClip.clip.id) }}><div className="w-3 h-5 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+            {isArrow ? (
+              <>
+                <div
+                  data-testid="shape-arrow-start-handle"
+                  className="absolute"
+                  style={{ left: 0, top: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'arrow-start'), padding: 10 }}
+                  onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'arrow-start', activeClip.layerId, activeClip.clip.id) }}
+                >
+                  <div className="w-5 h-5 rounded-full bg-primary-500 border-2 border-white pointer-events-none" />
+                </div>
+                <div
+                  data-testid="shape-arrow-end-handle"
+                  className="absolute"
+                  style={{ left: shape.width, top: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'arrow-end'), padding: 10 }}
+                  onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'arrow-end', activeClip.layerId, activeClip.clip.id) }}
+                >
+                  <div className="w-5 h-5 rounded-full bg-pink-500 border-2 border-white pointer-events-none" />
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="absolute" style={{ top: 0, left: 0, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tl'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tl', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ top: 0, right: 0, transform: 'translate(50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tr'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tr', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ bottom: 0, left: 0, transform: 'translate(-50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-bl'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-bl', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ bottom: 0, right: 0, transform: 'translate(50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-br'), padding: 8 }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-br', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-5 bg-primary-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ top: 0, left: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-t'), padding: '8px 12px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-t', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-3 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ bottom: 0, left: '50%', transform: 'translate(-50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-b'), padding: '8px 12px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-b', activeClip.layerId, activeClip.clip.id) }}><div className="w-5 h-3 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ left: 0, top: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-l'), padding: '12px 8px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-l', activeClip.layerId, activeClip.clip.id) }}><div className="w-3 h-5 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+                <div className="absolute" style={{ right: 0, top: '50%', transform: 'translate(50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-r'), padding: '12px 8px' }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-r', activeClip.layerId, activeClip.clip.id) }}><div className="w-3 h-5 bg-green-500 border-2 border-white rounded-sm pointer-events-none" /></div>
+              </>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/components/editor/editorPreviewStageShared.ts
+++ b/frontend/src/components/editor/editorPreviewStageShared.ts
@@ -59,6 +59,10 @@ function calculateFadeOpacity(
 }
 
 export function getHandleCursor(rotation: number, handleType: string): string {
+  if (handleType === 'arrow-start' || handleType === 'arrow-end') {
+    return 'crosshair'
+  }
+
   const normalizedRotation = ((rotation % 360) + 360) % 360
   const diagonalCursors = ['nwse-resize', 'ns-resize', 'nesw-resize', 'ew-resize']
   const edgeCursors = ['ns-resize', 'nesw-resize', 'ew-resize', 'nwse-resize']
@@ -152,6 +156,7 @@ export function buildActivePreviewClips({
             x: dragTransform.x,
             y: dragTransform.y,
             scale: dragTransform.scale,
+            rotation: dragTransform.rotation ?? interpolated.rotation,
             opacity: fadeOpacity,
             width: dragTransform.imageWidth,
             height: dragTransform.imageHeight,

--- a/frontend/src/components/editor/shapeGeometry.ts
+++ b/frontend/src/components/editor/shapeGeometry.ts
@@ -1,9 +1,43 @@
 export const ARROW_VIEWBOX_WIDTH = 300
 export const ARROW_VIEWBOX_HEIGHT = 80
+export const ARROW_PATH_WIDTH = 230
+export const ARROW_PATH_HEIGHT = 40
+export const ARROW_PATH_MIN_Y = 20
 
 // The user-provided SVG is the source of truth for the arrow silhouette.
 export const ARROW_SOURCE_PATH = 'M0 40 L160 34 L154 20 L230 40 L154 60 L160 46 Z'
 
 export function getArrowShapeTransform(width: number, height: number): string {
-  return `scale(${width / ARROW_VIEWBOX_WIDTH} ${height / ARROW_VIEWBOX_HEIGHT})`
+  return `translate(0 ${-(ARROW_PATH_MIN_Y * height) / ARROW_PATH_HEIGHT}) scale(${width / ARROW_PATH_WIDTH} ${height / ARROW_PATH_HEIGHT})`
+}
+
+function rotateOffset(x: number, y: number, rotationDegrees: number) {
+  const radians = (rotationDegrees * Math.PI) / 180
+  const cos = Math.cos(radians)
+  const sin = Math.sin(radians)
+  return {
+    x: x * cos - y * sin,
+    y: x * sin + y * cos,
+  }
+}
+
+export function getArrowEndpointPositions(
+  centerX: number,
+  centerY: number,
+  width: number,
+  rotationDegrees: number,
+) {
+  const halfLength = width / 2
+  const startOffset = rotateOffset(-halfLength, 0, rotationDegrees)
+  const endOffset = rotateOffset(halfLength, 0, rotationDegrees)
+  return {
+    start: {
+      x: centerX + startOffset.x,
+      y: centerY + startOffset.y,
+    },
+    end: {
+      x: centerX + endOffset.x,
+      y: centerY + endOffset.y,
+    },
+  }
 }

--- a/frontend/src/hooks/usePreviewDragWorkflow.ts
+++ b/frontend/src/hooks/usePreviewDragWorkflow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type Dispatch, type MouseEvent as ReactMouseEvent, type RefObject, type SetStateAction } from 'react'
 import type { Asset } from '@/api/assets'
 import type { SelectedClipInfo, SelectedVideoClipInfo } from '@/components/editor/Timeline'
+import { getArrowEndpointPositions } from '@/components/editor/shapeGeometry'
 import type { Clip, ProjectDetail, TimelineData } from '@/store/projectStore'
 import { addKeyframe, getInterpolatedTransform } from '@/utils/keyframes'
 
@@ -15,6 +16,8 @@ export type PreviewDragHandle =
   | 'resize-b'
   | 'resize-l'
   | 'resize-r'
+  | 'arrow-start'
+  | 'arrow-end'
   | 'crop-t'
   | 'crop-r'
   | 'crop-b'
@@ -37,6 +40,10 @@ export interface PreviewDragState {
   initialImageWidth?: number
   initialImageHeight?: number
   isImageClip?: boolean
+  initialArrowStartX?: number
+  initialArrowStartY?: number
+  initialArrowEndX?: number
+  initialArrowEndY?: number
   anchorX?: number
   anchorY?: number
   handleOffsetX?: number
@@ -50,6 +57,7 @@ export interface PreviewDragTransform {
   x: number
   y: number
   scale: number
+  rotation?: number
   shapeWidth?: number
   shapeHeight?: number
   imageWidth?: number
@@ -263,8 +271,30 @@ export function usePreviewDragWorkflow({
 
     let anchorX = cx
     let anchorY = cy
+    let initialArrowStartX: number | undefined
+    let initialArrowStartY: number | undefined
+    let initialArrowEndX: number | undefined
+    let initialArrowEndY: number | undefined
 
-    if (type === 'resize-tl') {
+    if ((type === 'arrow-start' || type === 'arrow-end') && clip.shape?.type === 'arrow') {
+      const endpoints = getArrowEndpointPositions(
+        cx,
+        cy,
+        clip.shape.width * scale,
+        currentTransform.rotation || 0,
+      )
+      initialArrowStartX = endpoints.start.x
+      initialArrowStartY = endpoints.start.y
+      initialArrowEndX = endpoints.end.x
+      initialArrowEndY = endpoints.end.y
+      if (type === 'arrow-start') {
+        anchorX = endpoints.end.x
+        anchorY = endpoints.end.y
+      } else {
+        anchorX = endpoints.start.x
+        anchorY = endpoints.start.y
+      }
+    } else if (type === 'resize-tl') {
       anchorX = cx + halfWidth
       anchorY = cy + halfHeight
     } else if (type === 'resize-tr') {
@@ -303,6 +333,10 @@ export function usePreviewDragWorkflow({
       initialImageWidth: isImageClip ? width : undefined,
       initialImageHeight: isImageClip ? height : undefined,
       isImageClip,
+      initialArrowStartX,
+      initialArrowStartY,
+      initialArrowEndX,
+      initialArrowEndY,
       anchorX,
       anchorY,
       initialCrop: clip.crop || { top: 0, right: 0, bottom: 0, left: 0 },
@@ -314,6 +348,7 @@ export function usePreviewDragWorkflow({
       x: currentTransform.x,
       y: currentTransform.y,
       scale: currentTransform.scale,
+      rotation: currentTransform.rotation || 0,
       shapeWidth: clip.shape?.width,
       shapeHeight: clip.shape?.height,
       imageWidth: isImageClip ? width : undefined,
@@ -387,10 +422,27 @@ export function usePreviewDragWorkflow({
     const initialScale = previewDrag.initialScale
     const anchorX = previewDrag.anchorX ?? previewDrag.initialX
     const anchorY = previewDrag.anchorY ?? previewDrag.initialY
+    let newRotation = previewDrag.initialRotation || 0
 
     if (type === 'move') {
       newX = previewDrag.initialX + logicalDeltaX
       newY = previewDrag.initialY + logicalDeltaY
+    } else if (type === 'arrow-start' || type === 'arrow-end') {
+      const initialDraggedX = type === 'arrow-start'
+        ? previewDrag.initialArrowStartX ?? previewDrag.initialX
+        : previewDrag.initialArrowEndX ?? previewDrag.initialX
+      const initialDraggedY = type === 'arrow-start'
+        ? previewDrag.initialArrowStartY ?? previewDrag.initialY
+        : previewDrag.initialArrowEndY ?? previewDrag.initialY
+      const draggedX = initialDraggedX + rawLogicalDeltaX
+      const draggedY = initialDraggedY + rawLogicalDeltaY
+      const vectorX = type === 'arrow-start' ? anchorX - draggedX : draggedX - anchorX
+      const vectorY = type === 'arrow-start' ? anchorY - draggedY : draggedY - anchorY
+      const nextWidth = Math.max(10, Math.hypot(vectorX, vectorY))
+      newShapeWidth = nextWidth
+      newX = Math.round((anchorX + draggedX) / 2)
+      newY = Math.round((anchorY + draggedY) / 2)
+      newRotation = (Math.atan2(vectorY, vectorX) * 180) / Math.PI
     } else if (type === 'resize') {
       const scaleFactor = 1 + (rawDeltaX + rawDeltaY) / 200
       newScale = Math.max(0.1, Math.min(5, previewDrag.initialScale * scaleFactor))
@@ -722,6 +774,7 @@ export function usePreviewDragWorkflow({
       x: Math.round(newX),
       y: Math.round(newY),
       scale: newScale,
+      rotation: newRotation,
       shapeWidth: newShapeWidth,
       shapeHeight: newShapeHeight,
       imageWidth: newImageWidth,
@@ -786,7 +839,7 @@ export function usePreviewDragWorkflow({
                     x: dragTransform.x,
                     y: dragTransform.y,
                     scale: dragTransform.scale,
-                    rotation: keyframe.transform.rotation,
+                    rotation: dragTransform.rotation ?? keyframe.transform.rotation,
                   },
                 }
               })
@@ -805,6 +858,7 @@ export function usePreviewDragWorkflow({
               x: dragTransform.x,
               y: dragTransform.y,
               scale: dragTransform.scale,
+              rotation: dragTransform.rotation ?? clip.transform.rotation,
               width: dragTransform.imageWidth !== undefined ? dragTransform.imageWidth : (existingWidth ?? null),
               height: dragTransform.imageHeight !== undefined ? dragTransform.imageHeight : (existingHeight ?? null),
             }


### PR DESCRIPTION
## Summary
- add dedicated start/end drag handles for arrow shapes in the preview
- keep the existing persisted transform model and derive arrow endpoint edits into width/center/rotation updates
- cover arrow endpoint editing with Playwright so reload persistence stays exercised

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "arrow"

Closes #51