### PR TITLE
feat(frontend): add preview rotation handles

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -233,6 +233,119 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByTestId('shape-arrow-end-handle')).toBeVisible()
   })
 
+  test('shows a shared preview rotate handle for shape, image, and video clips and persists image rotation', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const videoAsset: Asset = {
+      id: 'asset-video-1',
+      project_id: mock.projectId,
+      name: 'Mock Video',
+      type: 'video',
+      subtype: 'mock',
+      storage_key: 'mock/video.mp4',
+      storage_url: '/lp/lp_video_en.mp4',
+      thumbnail_url: null,
+      duration_ms: 4000,
+      width: 1280,
+      height: 720,
+      file_size: 1024,
+      mime_type: 'video/mp4',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+    mock.assetsByProject[mock.projectId].push(videoAsset)
+    const seededVideoClip: Clip = {
+      id: 'clip-seeded-video-rotate',
+      asset_id: videoAsset.id,
+      start_ms: 500,
+      duration_ms: 3000,
+      in_point_ms: 0,
+      out_point_ms: null,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 120,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 0.4,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+    mock.projectDetails[mock.projectId].timeline_data.layers.push({
+      id: 'layer-video-seeded',
+      name: 'Layer 2',
+      type: 'content',
+      order: 1,
+      visible: true,
+      locked: false,
+      clips: [seededVideoClip],
+    })
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 4000
+    mock.projectDetails[mock.projectId].duration_ms = 4000
+    mock.sequences[mock.sequenceId].timeline_data.layers.push({
+      id: 'layer-video-seeded',
+      name: 'Layer 2',
+      type: 'content',
+      order: 1,
+      visible: true,
+      locked: false,
+      clips: [seededVideoClip],
+    })
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 4000
+    mock.sequences[mock.sequenceId].duration_ms = 4000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shape-rectangle').click()
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+    const shapeClipId = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips[0]?.id
+    expect(shapeClipId).toBeTruthy()
+    await page.getByTestId(`timeline-video-clip-${shapeClipId}`).click()
+    await expect(page.getByTestId('preview-rotate-handle')).toBeVisible()
+
+    await dragAssetToVideoLayer(page, {
+      assetId: mock.primaryAssetId,
+      layerId: 'layer-1',
+      offsetX: 240,
+    })
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(2)
+    const imageClipId = mock.calls.sequenceUpdates[1].timelineData.layers[0].clips.at(-1)?.id
+    expect(imageClipId).toBeTruthy()
+    await page.getByTestId(`timeline-video-clip-${imageClipId}`).click()
+    await expect(page.getByTestId('preview-rotate-handle')).toBeVisible()
+
+    const rotateHandle = page.getByTestId('preview-rotate-handle')
+    const rotateHandleBox = await rotateHandle.boundingBox()
+    expect(rotateHandleBox).not.toBeNull()
+    if (!rotateHandleBox) {
+      throw new Error('Preview rotate handle bounds were not available')
+    }
+    await page.mouse.move(rotateHandleBox.x + rotateHandleBox.width / 2, rotateHandleBox.y + rotateHandleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(rotateHandleBox.x + rotateHandleBox.width / 2 + 80, rotateHandleBox.y + rotateHandleBox.height / 2 + 30, { steps: 8 })
+    await page.mouse.up()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(3)
+    const rotatedImageClip = mock.calls.sequenceUpdates[2].timelineData.layers[0].clips.find((clip) => clip.id === imageClipId)
+    expect(Math.abs(rotatedImageClip?.transform.rotation ?? 0)).toBeGreaterThan(5)
+
+    await page.getByTestId(`timeline-video-clip-${seededVideoClip.id}`).click()
+    await expect(page.getByTestId('preview-rotate-handle')).toBeVisible()
+
+    await page.reload()
+    await page.getByTestId('editor-header').waitFor()
+    await page.getByTestId('timeline-area').waitFor()
+    await page.getByTestId(`timeline-video-clip-${imageClipId}`).click()
+    await expect(page.getByTestId('preview-rotate-handle')).toBeVisible()
+  })
+
   test('returns to the dashboard instead of the landing page from the editor', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
 

--- a/frontend/src/components/editor/EditorPreviewMediaClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewMediaClip.tsx
@@ -255,6 +255,13 @@ export default function EditorPreviewMediaClip({
           {isActive && activeClip && isSelected && !activeClip.locked && (
             <>
               <div className="absolute pointer-events-none border-2 border-primary-500" style={{ top: `${cropT}%`, left: `${cropL}%`, right: `${cropR}%`, bottom: `${cropB}%` }} />
+              <div className="absolute pointer-events-none" style={{ top: `calc(${cropT}% - 32px)`, left: `${centerX}%`, width: 2, height: 24, backgroundColor: '#60a5fa', transform: 'translateX(-50%)' }} />
+              <div
+                data-testid="preview-rotate-handle"
+                className="absolute w-5 h-5 rounded-full bg-amber-400 border-2 border-white shadow"
+                style={{ top: `calc(${cropT}% - 40px)`, left: `${centerX}%`, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'rotate') }}
+                onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'rotate', activeClip.layerId, activeClip.clip.id) }}
+              />
               <div className="absolute w-5 h-5 bg-primary-500 border-2 border-white rounded-sm" style={{ top: `${cropT}%`, left: `${cropL}%`, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tl') }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tl', activeClip.layerId, activeClip.clip.id) }} />
               <div className="absolute w-5 h-5 bg-primary-500 border-2 border-white rounded-sm" style={{ top: `${cropT}%`, right: `${cropR}%`, transform: 'translate(50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tr') }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tr', activeClip.layerId, activeClip.clip.id) }} />
               <div className="absolute w-5 h-5 bg-primary-500 border-2 border-white rounded-sm" style={{ bottom: `${cropB}%`, left: `${cropL}%`, transform: 'translate(-50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-bl') }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-bl', activeClip.layerId, activeClip.clip.id) }} />
@@ -373,6 +380,13 @@ export default function EditorPreviewMediaClip({
         {isActive && activeClip && isSelected && !activeClip.locked && (
           <>
             <div className="absolute pointer-events-none border-2 border-primary-500" style={{ top: `${cropT}%`, left: `${cropL}%`, right: `${cropR}%`, bottom: `${cropB}%` }} />
+            <div className="absolute pointer-events-none" style={{ top: `calc(${cropT}% - 32px)`, left: `${centerX}%`, width: 2, height: 24, backgroundColor: '#60a5fa', transform: 'translateX(-50%)' }} />
+            <div
+              data-testid="preview-rotate-handle"
+              className="absolute w-5 h-5 rounded-full bg-amber-400 border-2 border-white shadow"
+              style={{ top: `calc(${cropT}% - 40px)`, left: `${centerX}%`, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'rotate') }}
+              onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'rotate', activeClip.layerId, activeClip.clip.id) }}
+            />
             <div className="absolute w-5 h-5 bg-primary-500 border-2 border-white rounded-sm" style={{ top: `${cropT}%`, left: `${cropL}%`, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tl') }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tl', activeClip.layerId, activeClip.clip.id) }} />
             <div className="absolute w-5 h-5 bg-primary-500 border-2 border-white rounded-sm" style={{ top: `${cropT}%`, right: `${cropR}%`, transform: 'translate(50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-tr') }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-tr', activeClip.layerId, activeClip.clip.id) }} />
             <div className="absolute w-5 h-5 bg-primary-500 border-2 border-white rounded-sm" style={{ bottom: `${cropB}%`, left: `${cropL}%`, transform: 'translate(-50%, 50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'resize-bl') }} onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'resize-bl', activeClip.layerId, activeClip.clip.id) }} />

--- a/frontend/src/components/editor/EditorPreviewShapeClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewShapeClip.tsx
@@ -96,6 +96,15 @@ export default function EditorPreviewShapeClip({
         />
         {isSelected && !activeClip.locked && (
           <>
+            <div className="absolute pointer-events-none" style={{ left: '50%', top: -32, width: 2, height: 24, backgroundColor: '#60a5fa', transform: 'translateX(-50%)' }} />
+            <div
+              data-testid="preview-rotate-handle"
+              className="absolute"
+              style={{ left: '50%', top: -40, transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'rotate'), padding: 8 }}
+              onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'rotate', activeClip.layerId, activeClip.clip.id) }}
+            >
+              <div className="w-5 h-5 rounded-full bg-amber-400 border-2 border-white shadow pointer-events-none" />
+            </div>
             {isArrow ? (
               <>
                 <div

--- a/frontend/src/components/editor/editorPreviewStageShared.ts
+++ b/frontend/src/components/editor/editorPreviewStageShared.ts
@@ -62,6 +62,9 @@ export function getHandleCursor(rotation: number, handleType: string): string {
   if (handleType === 'arrow-start' || handleType === 'arrow-end') {
     return 'crosshair'
   }
+  if (handleType === 'rotate') {
+    return 'grab'
+  }
 
   const normalizedRotation = ((rotation % 360) + 360) % 360
   const diagonalCursors = ['nwse-resize', 'ns-resize', 'nesw-resize', 'ew-resize']

--- a/frontend/src/hooks/usePreviewDragWorkflow.ts
+++ b/frontend/src/hooks/usePreviewDragWorkflow.ts
@@ -16,6 +16,7 @@ export type PreviewDragHandle =
   | 'resize-b'
   | 'resize-l'
   | 'resize-r'
+  | 'rotate'
   | 'arrow-start'
   | 'arrow-end'
   | 'crop-t'
@@ -40,6 +41,8 @@ export interface PreviewDragState {
   initialImageWidth?: number
   initialImageHeight?: number
   isImageClip?: boolean
+  initialRotateHandleX?: number
+  initialRotateHandleY?: number
   initialArrowStartX?: number
   initialArrowStartY?: number
   initialArrowEndX?: number
@@ -271,12 +274,21 @@ export function usePreviewDragWorkflow({
 
     let anchorX = cx
     let anchorY = cy
+    let initialRotateHandleX: number | undefined
+    let initialRotateHandleY: number | undefined
     let initialArrowStartX: number | undefined
     let initialArrowStartY: number | undefined
     let initialArrowEndX: number | undefined
     let initialArrowEndY: number | undefined
 
-    if ((type === 'arrow-start' || type === 'arrow-end') && clip.shape?.type === 'arrow') {
+    if (type === 'rotate') {
+      const rotateHandleDistance = halfHeight + 32
+      const radians = ((currentTransform.rotation || 0) - 90) * (Math.PI / 180)
+      initialRotateHandleX = cx + Math.cos(radians) * rotateHandleDistance
+      initialRotateHandleY = cy + Math.sin(radians) * rotateHandleDistance
+      anchorX = cx
+      anchorY = cy
+    } else if ((type === 'arrow-start' || type === 'arrow-end') && clip.shape?.type === 'arrow') {
       const endpoints = getArrowEndpointPositions(
         cx,
         cy,
@@ -333,6 +345,8 @@ export function usePreviewDragWorkflow({
       initialImageWidth: isImageClip ? width : undefined,
       initialImageHeight: isImageClip ? height : undefined,
       isImageClip,
+      initialRotateHandleX,
+      initialRotateHandleY,
       initialArrowStartX,
       initialArrowStartY,
       initialArrowEndX,
@@ -365,6 +379,7 @@ export function usePreviewDragWorkflow({
 
     const getRotatedCursor = (handleType: PreviewDragHandle): string => {
       if (handleType === 'move') return 'grabbing'
+      if (handleType === 'rotate') return 'grabbing'
       if (handleType === 'resize') return diagonalCursors[cursorIndex]
 
       const handleBaseIndex: Partial<Record<PreviewDragHandle, number>> = {
@@ -404,7 +419,7 @@ export function usePreviewDragWorkflow({
     const cos = Math.cos(radians)
     const sin = Math.sin(radians)
 
-    const isResizeOp = previewDrag.type !== 'move'
+    const isResizeOp = !['move', 'rotate', 'arrow-start', 'arrow-end'].includes(previewDrag.type)
     const logicalDeltaX = isResizeOp ? rawLogicalDeltaX * cos - rawLogicalDeltaY * sin : rawLogicalDeltaX
     const logicalDeltaY = isResizeOp ? rawLogicalDeltaX * sin + rawLogicalDeltaY * cos : rawLogicalDeltaY
 
@@ -427,6 +442,14 @@ export function usePreviewDragWorkflow({
     if (type === 'move') {
       newX = previewDrag.initialX + logicalDeltaX
       newY = previewDrag.initialY + logicalDeltaY
+    } else if (type === 'rotate') {
+      const initialRotateHandleX = previewDrag.initialRotateHandleX ?? previewDrag.initialX
+      const initialRotateHandleY = previewDrag.initialRotateHandleY ?? previewDrag.initialY
+      const rotatedHandleX = initialRotateHandleX + rawLogicalDeltaX
+      const rotatedHandleY = initialRotateHandleY + rawLogicalDeltaY
+      const vectorX = rotatedHandleX - previewDrag.initialX
+      const vectorY = rotatedHandleY - previewDrag.initialY
+      newRotation = (Math.atan2(vectorY, vectorX) * 180) / Math.PI + 90
     } else if (type === 'arrow-start' || type === 'arrow-end') {
       const initialDraggedX = type === 'arrow-start'
         ? previewDrag.initialArrowStartX ?? previewDrag.initialX


### PR DESCRIPTION
## Summary
- add a shared preview rotate handle for shape, image, and video clips
- persist preview rotations through the existing transform.rotation field without widening the saved schema
- extend editor critical path coverage to exercise shape, image, and video rotate-handle flows

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts

Closes #52