### PR TITLE
fix(frontend): keep arrow head size fixed

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 import type { Asset } from '../src/api/assets'
+import { getArrowHeadLength, getArrowShapePath } from '../src/components/editor/shapeGeometry'
 import type { AudioTrack, Clip } from '../src/store/projectStore'
 import { bootstrapMockEditorPage } from './helpers/editorMockServer'
 import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
@@ -184,7 +185,7 @@ test.describe('Editor Critical Path', () => {
     expect(addedShape?.filled).toBe(true)
     const arrowPath = page.getByTestId('preview-container').getByTestId('shape-arrow-path')
     await expect(arrowPath).toHaveCount(1)
-    await expect(arrowPath).toHaveAttribute('d', 'M0 40 L160 34 L154 20 L230 40 L154 60 L160 46 Z')
+    await expect(arrowPath).toHaveAttribute('d', getArrowShapePath(180, 48))
     await expect(page.getByTestId('preview-container').locator('polygon')).toHaveCount(0)
     await expect(page.getByTestId('preview-container').locator('line')).toHaveCount(0)
     await expect(page.getByText(/Arrow|矢印/)).toBeVisible()
@@ -225,9 +226,18 @@ test.describe('Editor Critical Path', () => {
     expect(Math.abs(updatedClip?.transform.rotation ?? 0)).toBeGreaterThan(5)
     expect(updatedClip?.transform.x ?? 0).not.toBe(0)
     expect(updatedClip?.transform.y ?? 0).not.toBe(0)
+    const updatedArrowPath = await page.getByTestId('preview-container').getByTestId('shape-arrow-path').getAttribute('d')
+    expect(updatedArrowPath).toBeTruthy()
+    if (!updatedArrowPath) {
+      throw new Error('Updated arrow path was not available')
+    }
+    const pathNumbers = updatedArrowPath.match(/-?\d+(?:\.\d+)?/g)?.map(Number) ?? []
+    const headLength = pathNumbers[6] - pathNumbers[4]
+    expect(headLength).toBeCloseTo(getArrowHeadLength(updatedClip?.shape?.height ?? 48), 2)
 
     await page.reload()
-    await page.waitForLoadState('networkidle')
+    await page.getByTestId('editor-header').waitFor()
+    await page.getByTestId('timeline-area').waitFor()
     await page.getByTestId('timeline-video-clip-' + clipId).click()
     await expect(page.getByTestId('shape-arrow-start-handle')).toBeVisible()
     await expect(page.getByTestId('shape-arrow-end-handle')).toBeVisible()

--- a/frontend/src/components/editor/EditorPreviewShapeClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewShapeClip.tsx
@@ -1,7 +1,7 @@
 import type { MouseEvent as ReactMouseEvent } from 'react'
 import type { PreviewDragHandle } from '@/hooks/usePreviewDragWorkflow'
 import { type ActiveClipInfo, getHandleCursor } from '@/components/editor/editorPreviewStageShared'
-import { ARROW_SOURCE_PATH, getArrowShapeTransform } from '@/components/editor/shapeGeometry'
+import { getArrowShapePath, getMinimumArrowWidth } from '@/components/editor/shapeGeometry'
 
 interface EditorPreviewShapeClipProps {
   activeClip: ActiveClipInfo
@@ -26,6 +26,7 @@ export default function EditorPreviewShapeClip({
   const shape = activeClip.shape
   if (!shape) return null
   const isArrow = shape.type === 'arrow'
+  const displayArrowWidth = isArrow ? Math.max(shape.width, getMinimumArrowWidth(shape.height)) : shape.width
 
   return (
     <div
@@ -40,7 +41,7 @@ export default function EditorPreviewShapeClip({
       }}
     >
       <div className={`relative ${isSelected && !activeClip.locked ? 'ring-2 ring-primary-500 ring-offset-2 ring-offset-transparent' : ''}`} style={{ userSelect: 'none' }}>
-        <svg width={shape.width + shape.strokeWidth} height={shape.height + shape.strokeWidth} className="block pointer-events-none">
+        <svg width={displayArrowWidth + shape.strokeWidth} height={shape.height + shape.strokeWidth} className="block pointer-events-none">
           {shape.type === 'rectangle' && (
             <rect
               x={shape.strokeWidth / 2}
@@ -79,8 +80,7 @@ export default function EditorPreviewShapeClip({
             return (
               <path
                 data-testid="shape-arrow-path"
-                d={ARROW_SOURCE_PATH}
-                transform={getArrowShapeTransform(shape.width, shape.height)}
+                d={getArrowShapePath(shape.width, shape.height)}
                 fill={fillColor}
                 stroke={shape.strokeWidth > 0 ? shape.strokeColor : 'none'}
                 strokeWidth={shape.strokeWidth}
@@ -118,7 +118,7 @@ export default function EditorPreviewShapeClip({
                 <div
                   data-testid="shape-arrow-end-handle"
                   className="absolute"
-                  style={{ left: shape.width, top: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'arrow-end'), padding: 10 }}
+                  style={{ left: displayArrowWidth, top: '50%', transform: 'translate(-50%, -50%)', cursor: getHandleCursor(activeClip.transform.rotation, 'arrow-end'), padding: 10 }}
                   onMouseDown={(event) => { event.stopPropagation(); handlePreviewDragStart(event, 'arrow-end', activeClip.layerId, activeClip.clip.id) }}
                 >
                   <div className="w-5 h-5 rounded-full bg-pink-500 border-2 border-white pointer-events-none" />

--- a/frontend/src/components/editor/ShapeSVGRenderer.tsx
+++ b/frontend/src/components/editor/ShapeSVGRenderer.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import type { Shape } from '@/store/projectStore'
-import { ARROW_SOURCE_PATH, getArrowShapeTransform } from '@/components/editor/shapeGeometry'
+import { getArrowShapePath, getMinimumArrowWidth } from '@/components/editor/shapeGeometry'
 
 interface ShapeSVGRendererProps {
   shape: Shape
@@ -21,11 +21,15 @@ const ShapeSVGRenderer = memo(function ShapeSVGRenderer({
   opacity = 0.7,
   className = '',
 }: ShapeSVGRendererProps) {
+  const viewBoxWidth = shape.type === 'arrow'
+    ? Math.max(shape.width, getMinimumArrowWidth(shape.height))
+    : shape.width
+
   return (
     <svg
       width={width}
       height={height}
-      viewBox={`0 0 ${shape.width} ${shape.height}`}
+      viewBox={`0 0 ${viewBoxWidth} ${shape.height}`}
       style={{ opacity }}
       className={className}
     >
@@ -67,8 +71,7 @@ const ShapeSVGRenderer = memo(function ShapeSVGRenderer({
         return (
           <path
             data-testid="shape-arrow-path"
-            d={ARROW_SOURCE_PATH}
-            transform={getArrowShapeTransform(shape.width, shape.height)}
+            d={getArrowShapePath(shape.width, shape.height)}
             fill={fillColor}
             stroke={shape.strokeWidth > 0 ? shape.strokeColor : 'none'}
             strokeWidth={shape.strokeWidth}

--- a/frontend/src/components/editor/shapeGeometry.ts
+++ b/frontend/src/components/editor/shapeGeometry.ts
@@ -1,14 +1,42 @@
-export const ARROW_VIEWBOX_WIDTH = 300
-export const ARROW_VIEWBOX_HEIGHT = 80
-export const ARROW_PATH_WIDTH = 230
-export const ARROW_PATH_HEIGHT = 40
-export const ARROW_PATH_MIN_Y = 20
+export const ARROW_REFERENCE_HEIGHT = 40
+export const ARROW_REFERENCE_HEAD_LENGTH = 76
+export const ARROW_REFERENCE_SHAFT_JOIN_OFFSET = 70
+export const ARROW_REFERENCE_SHAFT_HALF_THICKNESS = 6
+export const ARROW_REFERENCE_MIN_SHAFT_LENGTH = 24
 
-// The user-provided SVG is the source of truth for the arrow silhouette.
-export const ARROW_SOURCE_PATH = 'M0 40 L160 34 L154 20 L230 40 L154 60 L160 46 Z'
+function getArrowHeightScale(height: number) {
+  return height / ARROW_REFERENCE_HEIGHT
+}
 
-export function getArrowShapeTransform(width: number, height: number): string {
-  return `translate(0 ${-(ARROW_PATH_MIN_Y * height) / ARROW_PATH_HEIGHT}) scale(${width / ARROW_PATH_WIDTH} ${height / ARROW_PATH_HEIGHT})`
+export function getArrowHeadLength(height: number) {
+  return ARROW_REFERENCE_HEAD_LENGTH * getArrowHeightScale(height)
+}
+
+export function getMinimumArrowWidth(height: number) {
+  return getArrowHeadLength(height) + ARROW_REFERENCE_MIN_SHAFT_LENGTH * getArrowHeightScale(height)
+}
+
+export function getArrowShapePath(width: number, height: number): string {
+  const safeHeight = Math.max(1, height)
+  const scale = getArrowHeightScale(safeHeight)
+  const safeWidth = Math.max(getMinimumArrowWidth(safeHeight), width)
+  const centerY = safeHeight / 2
+  const headBaseX = safeWidth - getArrowHeadLength(safeHeight)
+  const shaftJoinX = safeWidth - ARROW_REFERENCE_SHAFT_JOIN_OFFSET * scale
+  const shaftHalfThickness = ARROW_REFERENCE_SHAFT_HALF_THICKNESS * scale
+
+  const points: Array<[number, number]> = [
+    [0, centerY],
+    [shaftJoinX, centerY - shaftHalfThickness],
+    [headBaseX, 0],
+    [safeWidth, centerY],
+    [headBaseX, safeHeight],
+    [shaftJoinX, centerY + shaftHalfThickness],
+  ]
+
+  return `${points
+    .map(([x, y], index) => `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join(' ')} Z`
 }
 
 function rotateOffset(x: number, y: number, rotationDegrees: number) {
@@ -25,9 +53,10 @@ export function getArrowEndpointPositions(
   centerX: number,
   centerY: number,
   width: number,
+  height: number,
   rotationDegrees: number,
 ) {
-  const halfLength = width / 2
+  const halfLength = Math.max(getMinimumArrowWidth(height), width) / 2
   const startOffset = rotateOffset(-halfLength, 0, rotationDegrees)
   const endOffset = rotateOffset(halfLength, 0, rotationDegrees)
   return {

--- a/frontend/src/hooks/usePreviewDragWorkflow.ts
+++ b/frontend/src/hooks/usePreviewDragWorkflow.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type Dispatch, type MouseEvent as ReactMouseEvent, type RefObject, type SetStateAction } from 'react'
 import type { Asset } from '@/api/assets'
 import type { SelectedClipInfo, SelectedVideoClipInfo } from '@/components/editor/Timeline'
-import { getArrowEndpointPositions } from '@/components/editor/shapeGeometry'
+import { getArrowEndpointPositions, getMinimumArrowWidth } from '@/components/editor/shapeGeometry'
 import type { Clip, ProjectDetail, TimelineData } from '@/store/projectStore'
 import { addKeyframe, getInterpolatedTransform } from '@/utils/keyframes'
 
@@ -293,6 +293,7 @@ export function usePreviewDragWorkflow({
         cx,
         cy,
         clip.shape.width * scale,
+        clip.shape.height * scale,
         currentTransform.rotation || 0,
       )
       initialArrowStartX = endpoints.start.x
@@ -461,7 +462,8 @@ export function usePreviewDragWorkflow({
       const draggedY = initialDraggedY + rawLogicalDeltaY
       const vectorX = type === 'arrow-start' ? anchorX - draggedX : draggedX - anchorX
       const vectorY = type === 'arrow-start' ? anchorY - draggedY : draggedY - anchorY
-      const nextWidth = Math.max(10, Math.hypot(vectorX, vectorY))
+      const minimumArrowWidth = getMinimumArrowWidth(previewDrag.initialShapeHeight ?? initialHeight)
+      const nextWidth = Math.max(minimumArrowWidth, Math.hypot(vectorX, vectorY))
       newShapeWidth = nextWidth
       newX = Math.round((anchorX + draggedX) / 2)
       newY = Math.round((anchorY + draggedY) / 2)


### PR DESCRIPTION
## Summary
- replace the arrow geometry with a fixed head plus variable shaft path
- keep start/end editing while clamping short arrows so the head silhouette does not collapse
- extend arrow Playwright coverage to assert the head length stays constant after endpoint edits

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "arrow"

Closes #51