### PR TITLE
feat(dashboard): show canonical last edited timestamp

### DIFF
--- a/backend/src/api/projects.py
+++ b/backend/src/api/projects.py
@@ -1,10 +1,11 @@
 import base64
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm.attributes import flag_modified
 
 from src.api.access import get_accessible_project
@@ -37,6 +38,29 @@ def _get_thumbnail_url(project: Project) -> str | None:
         )  # 7 days
     # Backward compatibility: return legacy thumbnail_url if exists
     return project.thumbnail_url
+
+
+def _resolve_last_edited_at(
+    project_updated_at: datetime,
+    latest_sequence_updated_at: datetime | None,
+) -> datetime:
+    """Pick the dashboard-facing last edited timestamp.
+
+    Prefer sequence activity when present because current editing is sequence-based.
+    Fall back to project.updated_at for older projects or non-sequence flows.
+    """
+    return latest_sequence_updated_at or project_updated_at
+
+
+def _sort_project_responses_by_last_edited(
+    responses: list[ProjectListResponse],
+) -> list[ProjectListResponse]:
+    """Sort dashboard projects by canonical last edited timestamp."""
+    return sorted(
+        responses,
+        key=lambda project: project.last_edited_at or project.updated_at,
+        reverse=True,
+    )
 
 
 @router.get("", response_model=list[ProjectListResponse])
@@ -78,18 +102,34 @@ async def list_projects(
         owner_result = await db.execute(select(User).where(User.id.in_(owner_ids)))
         owner_map = {u.id: u.name for u in owner_result.scalars().all()}
 
+    sequence_last_edited_map: dict[UUID, datetime | None] = {}
+    project_ids = [p.id for p in projects]
+    if project_ids:
+        sequence_result = await db.execute(
+            select(Sequence.project_id, func.max(Sequence.updated_at))
+            .where(Sequence.project_id.in_(project_ids))
+            .group_by(Sequence.project_id)
+        )
+        sequence_last_edited_map = {
+            project_id: updated_at for project_id, updated_at in sequence_result.all()
+        }
+
     # Generate signed URLs for thumbnails and add collaboration info
     responses = []
     for p in projects:
         response = ProjectListResponse.model_validate(p)
         response.thumbnail_url = _get_thumbnail_url(p)
+        response.last_edited_at = _resolve_last_edited_at(
+            p.updated_at,
+            sequence_last_edited_map.get(p.id),
+        )
         is_owner = p.user_id == current_user.id
         response.is_shared = not is_owner
         membership = membership_map.get(p.id)
         response.role = "owner" if is_owner else (membership.role if membership else "editor")
         response.owner_name = owner_map.get(p.user_id) if not is_owner else None
         responses.append(response)
-    return responses
+    return _sort_project_responses_by_last_edited(responses)
 
 
 @router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/src/schemas/project.py
+++ b/backend/src/schemas/project.py
@@ -99,6 +99,7 @@ class ProjectListResponse(BaseModel):
     thumbnail_url: str | None
     created_at: datetime
     updated_at: datetime
+    last_edited_at: datetime | None = None
     is_shared: bool = False
     role: str = "owner"
     owner_name: str | None = None

--- a/backend/tests/test_projects_last_edited.py
+++ b/backend/tests/test_projects_last_edited.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from src.api.projects import _resolve_last_edited_at, _sort_project_responses_by_last_edited
+from src.schemas.project import ProjectListResponse
+
+
+def _project_response(
+    *, updated_at: datetime, last_edited_at: datetime | None = None, name: str
+) -> ProjectListResponse:
+    return ProjectListResponse(
+        id=uuid4(),
+        name=name,
+        description=None,
+        status="draft",
+        duration_ms=0,
+        thumbnail_url=None,
+        created_at=updated_at,
+        updated_at=updated_at,
+        last_edited_at=last_edited_at,
+        is_shared=False,
+        role="owner",
+        owner_name=None,
+    )
+
+
+def test_resolve_last_edited_at_prefers_sequence_timestamp() -> None:
+    project_updated_at = datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc)
+    sequence_updated_at = datetime(2026, 3, 10, 9, 30, tzinfo=timezone.utc)
+
+    resolved = _resolve_last_edited_at(project_updated_at, sequence_updated_at)
+
+    assert resolved == sequence_updated_at
+
+
+def test_sort_project_responses_by_last_edited_uses_canonical_value() -> None:
+    base = datetime(2026, 3, 10, 10, 0, tzinfo=timezone.utc)
+    project_only = _project_response(
+        name="project-only",
+        updated_at=base - timedelta(hours=1),
+        last_edited_at=None,
+    )
+    sequence_recent = _project_response(
+        name="sequence-recent",
+        updated_at=base - timedelta(days=2),
+        last_edited_at=base,
+    )
+
+    ordered = _sort_project_responses_by_last_edited([project_only, sequence_recent])
+
+    assert [project.name for project in ordered] == ["sequence-recent", "project-only"]

--- a/frontend/e2e/dashboard-i18n.spec.ts
+++ b/frontend/e2e/dashboard-i18n.spec.ts
@@ -10,6 +10,7 @@ const mockProjects = [
     thumbnail_url: null,
     created_at: '2026-03-07T00:00:00.000Z',
     updated_at: '2026-03-07T00:00:00.000Z',
+    last_edited_at: '2026-03-09T00:00:00.000Z',
     is_shared: false,
     role: 'owner',
     owner_name: 'Dev User',
@@ -47,10 +48,12 @@ test.describe('Dashboard i18n', () => {
     await expect(page.getByRole('heading', { name: 'プロジェクト' })).toBeVisible()
     await expect(page.getByRole('button', { name: '新規プロジェクト' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+    await expect(page.getByText(/最終編集/)).toBeVisible()
 
     await expect(page.getByText('projects.sectionTitle')).toHaveCount(0)
     await expect(page.getByText('projects.newProject')).toHaveCount(0)
     await expect(page.getByText('header.signOut')).toHaveCount(0)
+    await expect(page.getByText('projects.lastEdited')).toHaveCount(0)
   })
 
   test('shows translated dashboard labels in English without raw i18n keys', async ({ page }) => {
@@ -65,9 +68,11 @@ test.describe('Dashboard i18n', () => {
     await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'New Project' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible()
+    await expect(page.getByText(/Last edited/)).toBeVisible()
 
     await expect(page.getByText('projects.sectionTitle')).toHaveCount(0)
     await expect(page.getByText('projects.newProject')).toHaveCount(0)
     await expect(page.getByText('header.signOut')).toHaveCount(0)
+    await expect(page.getByText('projects.lastEdited')).toHaveCount(0)
   })
 })

--- a/frontend/src/i18n/locales/en/dashboard.json
+++ b/frontend/src/i18n/locales/en/dashboard.json
@@ -11,7 +11,9 @@
     "emptyTitle": "No projects yet",
     "emptyMessage": "Create a new project to start editing videos.",
     "deleteConfirm": "Are you sure you want to delete this project?",
-    "shared": "Shared"
+    "shared": "Shared",
+    "lastEdited": "Last edited {{relative}}",
+    "lastEditedAt": "Last edited at {{value}}"
   },
   "newProjectModal": {
     "title": "Create New Project",

--- a/frontend/src/i18n/locales/ja/dashboard.json
+++ b/frontend/src/i18n/locales/ja/dashboard.json
@@ -11,7 +11,9 @@
     "emptyTitle": "プロジェクトがまだありません",
     "emptyMessage": "新しいプロジェクトを作成して動画編集を始めましょう。",
     "deleteConfirm": "このプロジェクトを削除しますか？",
-    "shared": "共有"
+    "shared": "共有",
+    "lastEdited": "最終編集 {{relative}}",
+    "lastEditedAt": "最終編集日時: {{value}}"
   },
   "newProjectModal": {
     "title": "新規プロジェクトを作成",

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -79,6 +79,10 @@ export default function Dashboard() {
   }
 
   const dateFnsLocale = i18n.language === 'ja' ? ja : enUS
+  const absoluteDateFormatter = new Intl.DateTimeFormat(i18n.language === 'ja' ? 'ja-JP' : 'en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
 
   return (
     <div className="min-h-screen bg-gray-900">
@@ -221,92 +225,104 @@ export default function Dashboard() {
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {projects.map((project) => (
-              <div
-                key={project.id}
-                onClick={() => navigate(`/project/${project.id}`)}
-                className="bg-gray-800 rounded-lg overflow-hidden cursor-pointer hover:ring-2 hover:ring-primary-500/50 hover:bg-gray-800/80 transition-all duration-200 group"
-              >
-                {/* Thumbnail */}
-                <div className="aspect-video bg-gray-700 flex items-center justify-center relative overflow-hidden">
-                  {project.thumbnail_url ? (
-                    <img
-                      src={project.thumbnail_url}
-                      alt={project.name}
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <svg
-                      className="w-12 h-12 text-gray-600"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
-                      />
-                    </svg>
-                  )}
-                  {/* Hover overlay with play icon */}
-                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors flex items-center justify-center">
-                    <svg className="w-12 h-12 text-white opacity-0 group-hover:opacity-80 transition-opacity" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M8 5v14l11-7z" />
-                    </svg>
-                  </div>
-                </div>
+            {projects.map((project) => {
+              const lastEditedAt = project.last_edited_at ?? project.updated_at
+              const lastEditedDate = new Date(lastEditedAt)
+              const lastEditedRelative = formatDistanceToNow(lastEditedDate, {
+                addSuffix: true,
+                locale: dateFnsLocale,
+              })
+              const lastEditedAbsolute = absoluteDateFormatter.format(lastEditedDate)
 
-                {/* Info */}
-                <div className="p-4">
-                  <div className="flex justify-between items-start">
-                    <div>
-                      <h3 className="font-medium text-white truncate">{project.name}</h3>
-                      {project.is_shared && (
-                        <div className="flex items-center gap-1.5 mt-1">
-                          <span className="px-1.5 py-0.5 bg-blue-500/20 text-blue-400 rounded text-xs">
-                            {t('projects.shared')}
-                          </span>
-                          {project.owner_name && (
-                            <span className="text-gray-500 text-xs">
-                              {project.owner_name}
-                            </span>
-                          )}
-                        </div>
-                      )}
-                      <p className="text-sm text-gray-400 mt-1">
-                        {formatDuration(project.duration_ms)} •{' '}
-                        {formatDistanceToNow(new Date(project.updated_at), {
-                          addSuffix: true,
-                          locale: dateFnsLocale,
-                        })}
-                      </p>
-                    </div>
-                    {(!project.is_shared || project.role === 'owner') && (
-                      <button
-                        onClick={(e) => handleDeleteProject(project.id, e)}
-                        className="p-1.5 text-gray-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors"
+              return (
+                <div
+                  key={project.id}
+                  onClick={() => navigate(`/project/${project.id}`)}
+                  className="bg-gray-800 rounded-lg overflow-hidden cursor-pointer hover:ring-2 hover:ring-primary-500/50 hover:bg-gray-800/80 transition-all duration-200 group"
+                >
+                  {/* Thumbnail */}
+                  <div className="aspect-video bg-gray-700 flex items-center justify-center relative overflow-hidden">
+                    {project.thumbnail_url ? (
+                      <img
+                        src={project.thumbnail_url}
+                        alt={project.name}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <svg
+                        className="w-12 h-12 text-gray-600"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
                       >
-                        <svg
-                          className="w-5 h-5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                          />
-                        </svg>
-                      </button>
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+                        />
+                      </svg>
                     )}
+                    {/* Hover overlay with play icon */}
+                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors flex items-center justify-center">
+                      <svg className="w-12 h-12 text-white opacity-0 group-hover:opacity-80 transition-opacity" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M8 5v14l11-7z" />
+                      </svg>
+                    </div>
+                  </div>
+
+                  {/* Info */}
+                  <div className="p-4">
+                    <div className="flex justify-between items-start">
+                      <div>
+                        <h3 className="font-medium text-white truncate">{project.name}</h3>
+                        {project.is_shared && (
+                          <div className="flex items-center gap-1.5 mt-1">
+                            <span className="px-1.5 py-0.5 bg-blue-500/20 text-blue-400 rounded text-xs">
+                              {t('projects.shared')}
+                            </span>
+                            {project.owner_name && (
+                              <span className="text-gray-500 text-xs">
+                                {project.owner_name}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                        <p className="text-sm text-gray-400 mt-1">
+                          {formatDuration(project.duration_ms)}
+                        </p>
+                        <p
+                          className="text-sm text-gray-500 mt-1"
+                          title={t('projects.lastEditedAt', { value: lastEditedAbsolute })}
+                        >
+                          {t('projects.lastEdited', { relative: lastEditedRelative })}
+                        </p>
+                      </div>
+                      {(!project.is_shared || project.role === 'owner') && (
+                        <button
+                          onClick={(e) => handleDeleteProject(project.id, e)}
+                          className="p-1.5 text-gray-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                        >
+                          <svg
+                            className="w-5 h-5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                            />
+                          </svg>
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </main>

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -17,6 +17,7 @@ export interface Project {
   thumbnail_url: string | null
   created_at: string
   updated_at: string
+  last_edited_at?: string | null
   is_shared?: boolean
   role?: string
   owner_name?: string


### PR DESCRIPTION
Closes #61

## Summary
- add a dashboard-facing `last_edited_at` field to project list responses
- derive it from the latest sequence update when present, falling back to `project.updated_at`
- display an explicit localized "Last edited" label in dashboard cards and keep the raw i18n keys covered by Playwright

## Verification
- ENVIRONMENT=test uv run --python 3.11 pytest tests/test_projects_last_edited.py -q
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/dashboard-i18n.spec.ts