### PR TITLE
fix(backend): include session saves in project last edited

### DIFF
--- a/backend/src/api/projects.py
+++ b/backend/src/api/projects.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from src.api.access import get_accessible_project
 from src.api.deps import CurrentUser, DbSession
+from src.models.asset import Asset
 from src.models.project import Project
 from src.models.project_member import ProjectMember
 from src.models.sequence import Sequence, _default_timeline_data
@@ -43,13 +44,19 @@ def _get_thumbnail_url(project: Project) -> str | None:
 def _resolve_last_edited_at(
     project_updated_at: datetime,
     latest_sequence_updated_at: datetime | None,
+    latest_session_updated_at: datetime | None,
 ) -> datetime:
     """Pick the dashboard-facing last edited timestamp.
 
-    Prefer sequence activity when present because current editing is sequence-based.
-    Fall back to project.updated_at for older projects or non-sequence flows.
+    Prefer the newest user-facing saved edit across the project aggregate:
+    sequence saves, session saves, and finally project-level updates.
     """
-    return latest_sequence_updated_at or project_updated_at
+    candidates = [project_updated_at]
+    if latest_sequence_updated_at is not None:
+        candidates.append(latest_sequence_updated_at)
+    if latest_session_updated_at is not None:
+        candidates.append(latest_session_updated_at)
+    return max(candidates)
 
 
 def _sort_project_responses_by_last_edited(
@@ -103,6 +110,7 @@ async def list_projects(
         owner_map = {u.id: u.name for u in owner_result.scalars().all()}
 
     sequence_last_edited_map: dict[UUID, datetime | None] = {}
+    session_last_edited_map: dict[UUID, datetime | None] = {}
     project_ids = [p.id for p in projects]
     if project_ids:
         sequence_result = await db.execute(
@@ -113,6 +121,14 @@ async def list_projects(
         sequence_last_edited_map = {
             project_id: updated_at for project_id, updated_at in sequence_result.all()
         }
+        session_result = await db.execute(
+            select(Asset.project_id, func.max(Asset.updated_at))
+            .where(Asset.project_id.in_(project_ids), Asset.type == "session")
+            .group_by(Asset.project_id)
+        )
+        session_last_edited_map = {
+            project_id: updated_at for project_id, updated_at in session_result.all()
+        }
 
     # Generate signed URLs for thumbnails and add collaboration info
     responses = []
@@ -122,6 +138,7 @@ async def list_projects(
         response.last_edited_at = _resolve_last_edited_at(
             p.updated_at,
             sequence_last_edited_map.get(p.id),
+            session_last_edited_map.get(p.id),
         )
         is_owner = p.user_id == current_user.id
         response.is_shared = not is_owner

--- a/backend/tests/test_projects_last_edited.py
+++ b/backend/tests/test_projects_last_edited.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 from src.api.projects import _resolve_last_edited_at, _sort_project_responses_by_last_edited
@@ -25,16 +25,30 @@ def _project_response(
 
 
 def test_resolve_last_edited_at_prefers_sequence_timestamp() -> None:
-    project_updated_at = datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc)
-    sequence_updated_at = datetime(2026, 3, 10, 9, 30, tzinfo=timezone.utc)
+    project_updated_at = datetime(2026, 3, 9, 12, 0, tzinfo=UTC)
+    sequence_updated_at = datetime(2026, 3, 10, 9, 30, tzinfo=UTC)
 
-    resolved = _resolve_last_edited_at(project_updated_at, sequence_updated_at)
+    resolved = _resolve_last_edited_at(project_updated_at, sequence_updated_at, None)
 
     assert resolved == sequence_updated_at
 
 
+def test_resolve_last_edited_at_prefers_latest_session_save_when_newest() -> None:
+    project_updated_at = datetime(2026, 3, 9, 12, 0, tzinfo=UTC)
+    sequence_updated_at = datetime(2026, 3, 10, 9, 30, tzinfo=UTC)
+    session_updated_at = datetime(2026, 3, 10, 10, 45, tzinfo=UTC)
+
+    resolved = _resolve_last_edited_at(
+        project_updated_at,
+        sequence_updated_at,
+        session_updated_at,
+    )
+
+    assert resolved == session_updated_at
+
+
 def test_sort_project_responses_by_last_edited_uses_canonical_value() -> None:
-    base = datetime(2026, 3, 10, 10, 0, tzinfo=timezone.utc)
+    base = datetime(2026, 3, 10, 10, 0, tzinfo=UTC)
     project_only = _project_response(
         name="project-only",
         updated_at=base - timedelta(hours=1),


### PR DESCRIPTION
## Summary
- include session asset saves in the canonical `last_edited_at` aggregation
- keep project and sequence timestamps as candidates, but return the newest user-facing saved edit
- extend backend tests to cover the reopened session-save case

## Why
Issue #61 was reopened because the dashboard label changed to `Last edited` / `最終編集`, but the timestamp itself still did not match what users perceive as their latest edit. The previous fix only considered `project.updated_at` and `sequence.updated_at`. Session saves can be newer and should count too.

## Verification
- `ENVIRONMENT=test uv run --python 3.11 ruff check src tests/test_projects_last_edited.py`
- `ENVIRONMENT=test uv run --python 3.11 ruff format --check src tests/test_projects_last_edited.py`
- `ENVIRONMENT=test uv run --python 3.11 --extra dev mypy src/ --ignore-missing-imports`
- `ENVIRONMENT=test uv run --python 3.11 pytest tests/test_projects_last_edited.py -q`

Closes #61
