### PR TITLE
fix(frontend): preserve snap for freeze-extended video clips

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -165,6 +165,87 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByText('No activity yet')).toBeVisible()
   })
 
+  test('keeps snap behavior when moving a video clip extended with freeze frame', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    const freezeExtendedClip: Clip = {
+      id: 'clip-freeze-snap-a',
+      asset_id: mock.primaryAssetId,
+      start_ms: 0,
+      duration_ms: 1000,
+      in_point_ms: 0,
+      out_point_ms: 1000,
+      speed: 1,
+      freeze_frame_ms: 1000,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    const targetClip: Clip = {
+      id: 'clip-freeze-snap-b',
+      asset_id: mock.primaryAssetId,
+      start_ms: 5000,
+      duration_ms: 1500,
+      in_point_ms: 0,
+      out_point_ms: 1500,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    mock.projectDetails[mock.projectId].timeline_data.layers[0].clips = [freezeExtendedClip, targetClip]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 7000
+    mock.projectDetails[mock.projectId].duration_ms = 7000
+    mock.sequences[mock.sequenceId].timeline_data.layers[0].clips = JSON.parse(JSON.stringify([freezeExtendedClip, targetClip]))
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 7000
+    mock.sequences[mock.sequenceId].duration_ms = 7000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const movingClip = page.getByTestId(`timeline-video-clip-${freezeExtendedClip.id}`)
+    await expect(movingClip).toBeVisible()
+
+    const clipBox = await movingClip.boundingBox()
+    expect(clipBox).not.toBeNull()
+    if (!clipBox) {
+      throw new Error('Freeze-extended clip bounds were not available')
+    }
+
+    const pixelsPerMs = clipBox.width / (freezeExtendedClip.duration_ms + freezeExtendedClip.freeze_frame_ms)
+    const intendedDeltaMsWithoutSnap = 3400
+    const dragDistancePx = pixelsPerMs * intendedDeltaMsWithoutSnap
+
+    await page.mouse.move(clipBox.x + clipBox.width / 2, clipBox.y + clipBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(clipBox.x + clipBox.width / 2 + dragDistancePx, clipBox.y + clipBox.height / 2, { steps: 10 })
+    await page.mouse.up()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const updatedClip = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips.find((clip) => clip.id === freezeExtendedClip.id)
+    expect(updatedClip?.start_ms).toBe(3000)
+    expect(updatedClip?.freeze_frame_ms).toBe(1000)
+  })
+
   test('adds a Skitch-style arrow shape through the existing shape flow', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
 

--- a/frontend/src/components/editor/timeline/types.ts
+++ b/frontend/src/components/editor/timeline/types.ts
@@ -61,6 +61,7 @@ export interface VideoDragState {
   startY: number  // Added for cross-layer drag detection
   initialStartMs: number
   initialDurationMs: number
+  initialVisibleDurationMs: number
   initialInPointMs: number
   initialOutPointMs: number
   initialSpeed: number

--- a/frontend/src/components/editor/timeline/useTimelineDrag.ts
+++ b/frontend/src/components/editor/timeline/useTimelineDrag.ts
@@ -638,6 +638,7 @@ export function useTimelineDrag({
       startY: e.clientY,
       initialStartMs: clip.start_ms,
       initialDurationMs: clip.duration_ms,
+      initialVisibleDurationMs: clip.duration_ms + (clip.freeze_frame_ms ?? 0),
       initialInPointMs: clip.in_point_ms,
       initialOutPointMs: clip.out_point_ms ?? (clip.in_point_ms + clip.duration_ms * (clip.speed || 1)),
       initialSpeed: clip.speed || 1,
@@ -705,7 +706,7 @@ export function useTimelineDrag({
       if (isSnapEnabled) {
         const snapPoints = getSnapPoints(draggingClipIds)
         const newStartMs = videoDragState.initialStartMs + deltaMs
-        const newEndMs = newStartMs + videoDragState.initialDurationMs
+        const newEndMs = newStartMs + videoDragState.initialVisibleDurationMs
 
         const snapStart = findNearestSnapPoint(newStartMs, snapPoints, snapThresholdMs)
         const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
@@ -714,7 +715,7 @@ export function useTimelineDrag({
           deltaMs = snapStart - videoDragState.initialStartMs
           setSnapLineMs(snapStart)
         } else if (snapEnd !== null) {
-          deltaMs = snapEnd - videoDragState.initialDurationMs - videoDragState.initialStartMs
+          deltaMs = snapEnd - videoDragState.initialVisibleDurationMs - videoDragState.initialStartMs
           setSnapLineMs(snapEnd)
         } else {
           setSnapLineMs(null)
@@ -729,7 +730,7 @@ export function useTimelineDrag({
         pendingCrossLayerPreviewRef.current = {
           layerId: detectedTargetLayerId,
           timeMs: snappedStartMs,
-          durationMs: videoDragState.initialDurationMs,
+          durationMs: videoDragState.initialVisibleDurationMs,
         }
       } else {
         pendingCrossLayerPreviewRef.current = null


### PR DESCRIPTION
## Summary
- keep move-snap calculations aligned with the visible duration of freeze-extended video clips
- use the same visible duration for cross-layer drop preview width
- add a Playwright regression test for moving a freeze-extended clip toward a snap target

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "keeps snap behavior when moving a video clip extended with freeze frame"

## Issue
- Closes #66