### PR TITLE
fix(frontend): stabilize shift image resize flicker

### DIFF
--- a/frontend/e2e/image-resize-math.spec.ts
+++ b/frontend/e2e/image-resize-math.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { computeImageResizeRect } from '../src/utils/imageResize'
+import { computeImageResizeRect, resolveImageResizeDominantAxis } from '../src/utils/imageResize'
 
 test.describe('Image Resize Math', () => {
   test('keeps aspect ratio when Shift-resizing from a corner handle', () => {
@@ -36,5 +36,59 @@ test.describe('Image Resize Math', () => {
     expect(resized.height).toBe(720)
     expect(resized.x).toBe(320)
     expect(resized.y).toBe(0)
+  })
+
+  test('locks the dominant axis from the initial drag delta for Shift-resize', () => {
+    const lockedAxis = resolveImageResizeDominantAxis({
+      handleType: 'resize-br',
+      initialHeight: 720,
+      initialWidth: 1280,
+      logicalDeltaX: 260,
+      logicalDeltaY: 30,
+    })
+
+    expect(lockedAxis).toBe('x')
+
+    const resized = computeImageResizeRect({
+      dominantAxis: lockedAxis,
+      handleType: 'resize-br',
+      initialHeight: 720,
+      initialWidth: 1280,
+      initialX: 0,
+      initialY: 0,
+      logicalDeltaX: 20,
+      logicalDeltaY: 180,
+      maintainAspect: true,
+    })
+
+    expect(resized.width).toBe(1300)
+    expect(resized.height).toBeCloseTo(731.25, 2)
+  })
+
+  test('keeps vertical handles locked to the Y axis during Shift-resize', () => {
+    const lockedAxis = resolveImageResizeDominantAxis({
+      handleType: 'resize-b',
+      initialHeight: 720,
+      initialWidth: 1280,
+      logicalDeltaX: 400,
+      logicalDeltaY: 50,
+    })
+
+    expect(lockedAxis).toBe('y')
+
+    const resized = computeImageResizeRect({
+      dominantAxis: lockedAxis,
+      handleType: 'resize-b',
+      initialHeight: 720,
+      initialWidth: 1280,
+      initialX: 0,
+      initialY: 0,
+      logicalDeltaX: 400,
+      logicalDeltaY: 50,
+      maintainAspect: true,
+    })
+
+    expect(resized.height).toBe(770)
+    expect(resized.width).toBeCloseTo(1368.89, 2)
   })
 })

--- a/frontend/src/hooks/usePreviewDragWorkflow.ts
+++ b/frontend/src/hooks/usePreviewDragWorkflow.ts
@@ -3,7 +3,7 @@ import type { Asset } from '@/api/assets'
 import type { SelectedClipInfo, SelectedVideoClipInfo } from '@/components/editor/Timeline'
 import { getArrowEndpointPositions, getMinimumArrowWidth } from '@/components/editor/shapeGeometry'
 import type { Clip, ProjectDetail, TimelineData } from '@/store/projectStore'
-import { computeImageResizeRect } from '@/utils/imageResize'
+import { computeImageResizeRect, resolveImageResizeDominantAxis } from '@/utils/imageResize'
 import { addKeyframe, getInterpolatedTransform } from '@/utils/keyframes'
 
 export type PreviewDragHandle =
@@ -42,6 +42,7 @@ export interface PreviewDragState {
   initialImageWidth?: number
   initialImageHeight?: number
   isImageClip?: boolean
+  aspectLockAxis?: 'x' | 'y'
   initialRotateHandleX?: number
   initialRotateHandleY?: number
   initialArrowStartX?: number
@@ -348,6 +349,7 @@ export function usePreviewDragWorkflow({
       initialImageWidth: isImageClip ? width : undefined,
       initialImageHeight: isImageClip ? height : undefined,
       isImageClip,
+      aspectLockAxis: undefined,
       initialRotateHandleX,
       initialRotateHandleY,
       initialArrowStartX,
@@ -442,13 +444,28 @@ export function usePreviewDragWorkflow({
     const anchorY = previewDrag.anchorY ?? previewDrag.initialY
     let newRotation = previewDrag.initialRotation || 0
     const maintainImageAspect = Boolean(isImageClip && event.shiftKey && type.startsWith('resize-') && initialHeight > 0)
+    const lockedImageAxis = maintainImageAspect
+      ? (previewDrag.aspectLockAxis ?? resolveImageResizeDominantAxis({
+          handleType: type as Parameters<typeof computeImageResizeRect>[0]['handleType'],
+          initialHeight,
+          initialWidth,
+          logicalDeltaX,
+          logicalDeltaY,
+        }))
+      : undefined
+
+    if (!maintainImageAspect && previewDrag.aspectLockAxis) {
+      setPreviewDrag((previous) => previous ? { ...previous, aspectLockAxis: undefined } : previous)
+    } else if (maintainImageAspect && !previewDrag.aspectLockAxis && lockedImageAxis) {
+      setPreviewDrag((previous) => previous ? { ...previous, aspectLockAxis: lockedImageAxis } : previous)
+    }
 
     const applyImageResize = (
       handleType: PreviewDragHandle,
       overrides?: { horizontalEdge?: number; verticalEdge?: number; dominantAxis?: 'x' | 'y' },
     ) => {
       const nextRect = computeImageResizeRect({
-        dominantAxis: overrides?.dominantAxis,
+        dominantAxis: overrides?.dominantAxis ?? lockedImageAxis,
         handleType: handleType as Parameters<typeof computeImageResizeRect>[0]['handleType'],
         horizontalEdge: overrides?.horizontalEdge,
         initialHeight,

--- a/frontend/src/utils/imageResize.ts
+++ b/frontend/src/utils/imageResize.ts
@@ -29,6 +29,34 @@ export interface ImageResizeRect {
   y: number
 }
 
+export interface ResolveImageResizeDominantAxisOptions {
+  fallback?: 'x' | 'y'
+  handleType: ImageResizeHandle
+  initialHeight: number
+  initialWidth: number
+  logicalDeltaX: number
+  logicalDeltaY: number
+}
+
+export function resolveImageResizeDominantAxis({
+  fallback,
+  handleType,
+  initialHeight,
+  initialWidth,
+  logicalDeltaX,
+  logicalDeltaY,
+}: ResolveImageResizeDominantAxisOptions): 'x' | 'y' {
+  if (handleType === 'resize-t' || handleType === 'resize-b') return 'y'
+  if (handleType === 'resize-l' || handleType === 'resize-r') return 'x'
+
+  const fallbackAxis = fallback ?? 'x'
+  const widthChange = initialWidth > 0 ? Math.abs(logicalDeltaX) / initialWidth : 0
+  const heightChange = initialHeight > 0 ? Math.abs(logicalDeltaY) / initialHeight : 0
+
+  if (widthChange === heightChange) return fallbackAxis
+  return widthChange > heightChange ? 'x' : 'y'
+}
+
 export function computeImageResizeRect({
   dominantAxis,
   handleType,
@@ -53,12 +81,16 @@ export function computeImageResizeRect({
   const clampWidth = (value: number) => Math.max(maintainAspect ? minimumWidth : 10, value)
   const clampHeight = (value: number) => Math.max(maintainAspect ? minimumHeight : 10, value)
 
-  const chooseAxis = (width: number, height: number, fallback: 'x' | 'y' = 'x'): 'x' | 'y' => {
+  const chooseAxis = (fallback: 'x' | 'y' = 'x'): 'x' | 'y' => {
     if (dominantAxis) return dominantAxis
-    const widthChange = initialWidth > 0 ? Math.abs(width - initialWidth) / initialWidth : 0
-    const heightChange = initialHeight > 0 ? Math.abs(height - initialHeight) / initialHeight : 0
-    if (widthChange === heightChange) return fallback
-    return widthChange > heightChange ? 'x' : 'y'
+    return resolveImageResizeDominantAxis({
+      fallback,
+      handleType,
+      initialHeight,
+      initialWidth,
+      logicalDeltaX,
+      logicalDeltaY,
+    })
   }
 
   switch (handleType) {
@@ -68,7 +100,7 @@ export function computeImageResizeRect({
       let width = clampWidth(draggedRight - initialLeft)
       let height = clampHeight(draggedBottom - initialTop)
       if (maintainAspect) {
-        const axis = chooseAxis(width, height)
+        const axis = chooseAxis()
         if (axis === 'x') {
           width = clampWidth(draggedRight - initialLeft)
           height = width / aspectRatio
@@ -85,7 +117,7 @@ export function computeImageResizeRect({
       let width = clampWidth(initialRight - draggedLeft)
       let height = clampHeight(initialBottom - draggedTop)
       if (maintainAspect) {
-        const axis = chooseAxis(width, height)
+        const axis = chooseAxis()
         if (axis === 'x') {
           width = clampWidth(initialRight - draggedLeft)
           height = width / aspectRatio
@@ -102,7 +134,7 @@ export function computeImageResizeRect({
       let width = clampWidth(draggedRight - initialLeft)
       let height = clampHeight(initialBottom - draggedTop)
       if (maintainAspect) {
-        const axis = chooseAxis(width, height)
+        const axis = chooseAxis()
         if (axis === 'x') {
           width = clampWidth(draggedRight - initialLeft)
           height = width / aspectRatio
@@ -119,7 +151,7 @@ export function computeImageResizeRect({
       let width = clampWidth(initialRight - draggedLeft)
       let height = clampHeight(draggedBottom - initialTop)
       if (maintainAspect) {
-        const axis = chooseAxis(width, height)
+        const axis = chooseAxis()
         if (axis === 'x') {
           width = clampWidth(initialRight - draggedLeft)
           height = width / aspectRatio


### PR DESCRIPTION
## Summary\n- lock Shift-based image resize to a single dominant axis for the duration of the drag\n- reuse the locked axis when applying aspect-preserving resize math\n- add focused regression coverage for axis stability and vertical-handle locking\n\n## Verification\n- npm run lint\n- npx tsc -p tsconfig.json --noEmit\n- npm run build\n- npx playwright test e2e/image-resize-math.spec.ts\n\nCloses #68