### PR TITLE
fix(frontend): keep image snap on locked aspect axis

### DIFF
--- a/frontend/e2e/image-resize-math.spec.ts
+++ b/frontend/e2e/image-resize-math.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { computeImageResizeRect, resolveImageResizeDominantAxis } from '../src/utils/imageResize'
+import { computeImageResizeRect, resolveImageResizeDominantAxis, resolveImageResizeSnap } from '../src/utils/imageResize'
 
 test.describe('Image Resize Math', () => {
   test('keeps aspect ratio when Shift-resizing from a corner handle', () => {
@@ -90,5 +90,27 @@ test.describe('Image Resize Math', () => {
 
     expect(resized.height).toBe(770)
     expect(resized.width).toBeCloseTo(1368.89, 2)
+  })
+
+  test('prefers the locked X axis when snap candidates exist on both axes', () => {
+    const snap = resolveImageResizeSnap({
+      handleType: 'resize-br',
+      horizontalSnap: { dist: 6, target: 1280 },
+      lockedAxis: 'x',
+      verticalSnap: { dist: 2, target: 720 },
+    })
+
+    expect(snap).toEqual({ axis: 'x', target: 1280 })
+  })
+
+  test('prefers the locked Y axis when snap candidates exist on both axes', () => {
+    const snap = resolveImageResizeSnap({
+      handleType: 'resize-br',
+      horizontalSnap: { dist: 2, target: 1280 },
+      lockedAxis: 'y',
+      verticalSnap: { dist: 6, target: 720 },
+    })
+
+    expect(snap).toEqual({ axis: 'y', target: 720 })
   })
 })

--- a/frontend/src/hooks/usePreviewDragWorkflow.ts
+++ b/frontend/src/hooks/usePreviewDragWorkflow.ts
@@ -3,7 +3,7 @@ import type { Asset } from '@/api/assets'
 import type { SelectedClipInfo, SelectedVideoClipInfo } from '@/components/editor/Timeline'
 import { getArrowEndpointPositions, getMinimumArrowWidth } from '@/components/editor/shapeGeometry'
 import type { Clip, ProjectDetail, TimelineData } from '@/store/projectStore'
-import { computeImageResizeRect, resolveImageResizeDominantAxis } from '@/utils/imageResize'
+import { computeImageResizeRect, resolveImageResizeDominantAxis, resolveImageResizeSnap } from '@/utils/imageResize'
 import { addKeyframe, getInterpolatedTransform } from '@/utils/keyframes'
 
 export type PreviewDragHandle =
@@ -747,20 +747,19 @@ export function usePreviewDragWorkflow({
 
           const guides: PreviewSnapGuide[] = []
 
-          if (['resize-tl', 'resize-tr', 'resize-bl', 'resize-br'].includes(type)) {
-            if (horizontalSnap && (!verticalSnap || horizontalSnap.dist <= verticalSnap.dist)) {
-              applyImageResize(type, { horizontalEdge: horizontalSnap.target, dominantAxis: 'x' })
-              guides.push({ type: 'x', position: horizontalSnap.target })
-            } else if (verticalSnap) {
-              applyImageResize(type, { verticalEdge: verticalSnap.target, dominantAxis: 'y' })
-              guides.push({ type: 'y', position: verticalSnap.target })
-            }
-          } else if (horizontalSnap) {
-            applyImageResize(type, { horizontalEdge: horizontalSnap.target, dominantAxis: 'x' })
-            guides.push({ type: 'x', position: horizontalSnap.target })
-          } else if (verticalSnap) {
-            applyImageResize(type, { verticalEdge: verticalSnap.target, dominantAxis: 'y' })
-            guides.push({ type: 'y', position: verticalSnap.target })
+          const resolvedSnap = resolveImageResizeSnap({
+            handleType: type as Parameters<typeof computeImageResizeRect>[0]['handleType'],
+            horizontalSnap,
+            lockedAxis: lockedImageAxis,
+            verticalSnap,
+          })
+
+          if (resolvedSnap?.axis === 'x') {
+            applyImageResize(type, { horizontalEdge: resolvedSnap.target, dominantAxis: 'x' })
+            guides.push({ type: 'x', position: resolvedSnap.target })
+          } else if (resolvedSnap?.axis === 'y') {
+            applyImageResize(type, { verticalEdge: resolvedSnap.target, dominantAxis: 'y' })
+            guides.push({ type: 'y', position: resolvedSnap.target })
           }
 
           setSnapGuides(guides)

--- a/frontend/src/utils/imageResize.ts
+++ b/frontend/src/utils/imageResize.ts
@@ -29,6 +29,18 @@ export interface ImageResizeRect {
   y: number
 }
 
+export interface ImageResizeSnapCandidate {
+  dist: number
+  target: number
+}
+
+export interface ResolveImageResizeSnapOptions {
+  handleType: ImageResizeHandle
+  horizontalSnap: ImageResizeSnapCandidate | null
+  lockedAxis?: 'x' | 'y'
+  verticalSnap: ImageResizeSnapCandidate | null
+}
+
 export interface ResolveImageResizeDominantAxisOptions {
   fallback?: 'x' | 'y'
   handleType: ImageResizeHandle
@@ -55,6 +67,36 @@ export function resolveImageResizeDominantAxis({
 
   if (widthChange === heightChange) return fallbackAxis
   return widthChange > heightChange ? 'x' : 'y'
+}
+
+export function resolveImageResizeSnap({
+  handleType,
+  horizontalSnap,
+  lockedAxis,
+  verticalSnap,
+}: ResolveImageResizeSnapOptions): { axis: 'x' | 'y'; target: number } | null {
+  if (lockedAxis === 'x') {
+    return horizontalSnap ? { axis: 'x', target: horizontalSnap.target } : null
+  }
+  if (lockedAxis === 'y') {
+    return verticalSnap ? { axis: 'y', target: verticalSnap.target } : null
+  }
+
+  if (handleType === 'resize-l' || handleType === 'resize-r') {
+    return horizontalSnap ? { axis: 'x', target: horizontalSnap.target } : null
+  }
+  if (handleType === 'resize-t' || handleType === 'resize-b') {
+    return verticalSnap ? { axis: 'y', target: verticalSnap.target } : null
+  }
+
+  if (horizontalSnap && (!verticalSnap || horizontalSnap.dist <= verticalSnap.dist)) {
+    return { axis: 'x', target: horizontalSnap.target }
+  }
+  if (verticalSnap) {
+    return { axis: 'y', target: verticalSnap.target }
+  }
+
+  return null
 }
 
 export function computeImageResizeRect({


### PR DESCRIPTION
## Summary\n- keep aspect-preserving image snap aligned with the already locked drag axis\n- stop corner-handle snap from switching to the other axis when a nearer snap target appears\n- add focused snap-selection regression coverage for locked x/y paths\n\n## Verification\n- npm run lint\n- npx tsc -p tsconfig.json --noEmit\n- npm run build\n\nCloses #68