### PR TITLE
fix(frontend): snap only selected clips to previous clip

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -246,6 +246,95 @@ test.describe('Editor Critical Path', () => {
     expect(updatedClip?.freeze_frame_ms).toBe(1000)
   })
 
+  test('snaps only the selected clip to the previous clip end', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    const leadingClip: Clip = {
+      id: 'clip-snap-prev-a',
+      asset_id: mock.primaryAssetId,
+      start_ms: 0,
+      duration_ms: 1000,
+      in_point_ms: 0,
+      out_point_ms: 1000,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    const selectedClip: Clip = {
+      id: 'clip-snap-prev-b',
+      asset_id: mock.primaryAssetId,
+      start_ms: 2000,
+      duration_ms: 1000,
+      in_point_ms: 0,
+      out_point_ms: 1000,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    const trailingClip: Clip = {
+      id: 'clip-snap-prev-c',
+      asset_id: mock.primaryAssetId,
+      start_ms: 4000,
+      duration_ms: 1000,
+      in_point_ms: 0,
+      out_point_ms: 1000,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    mock.projectDetails[mock.projectId].timeline_data.layers[0].clips = [leadingClip, selectedClip, trailingClip]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 5000
+    mock.projectDetails[mock.projectId].duration_ms = 5000
+    mock.sequences[mock.sequenceId].timeline_data.layers[0].clips = JSON.parse(JSON.stringify([leadingClip, selectedClip, trailingClip]))
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 5000
+    mock.sequences[mock.sequenceId].duration_ms = 5000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await page.getByTestId(`timeline-video-clip-${selectedClip.id}`).click()
+    await page.getByTestId('timeline-snap-to-previous').click()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const updatedClips = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips
+    expect(updatedClips.find((clip) => clip.id === leadingClip.id)?.start_ms).toBe(0)
+    expect(updatedClips.find((clip) => clip.id === selectedClip.id)?.start_ms).toBe(1000)
+    expect(updatedClips.find((clip) => clip.id === trailingClip.id)?.start_ms).toBe(4000)
+  })
+
   test('keeps Shift image resize snap from jumping to an oversized frame', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
 

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -4074,9 +4074,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     }
   }, [selectedVideoClip, selectedClip, timeline, projectId, currentTimeMs, updateTimeline])
 
-  // Snap selected clip to end of previous clip, with trailing clips following
-  // Trailing clips (clips starting at or after the selected clip's start position) move together,
-  // maintaining their relative spacing (no ripple/push effect)
+  // Snap the selected clip set to the nearest previous clip end without moving unrelated trailing clips.
   const handleSnapToPrevious = useCallback(async () => {
     console.log('[handleSnapToPrevious] called')
 
@@ -4200,13 +4198,11 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
 
     console.log('[handleSnapToPrevious] minStartMs:', minStartMs, 'snapTargetMs:', snapTargetMs, 'deltaMs:', deltaMs)
 
-    // Step 4: Move all clips that start at or after minStartMs by deltaMs
-    // This includes selected clips AND trailing clips (maintains spacing)
+    // Step 4: Move only the selected clips (including explicit group members) by deltaMs
     const updatedLayers = timeline.layers.map(layer => ({
       ...layer,
       clips: layer.clips.map(clip => {
-        // Move clips starting at or after minStartMs
-        if (clip.start_ms >= minStartMs) {
+        if (selectedVideoClipIds.has(clip.id)) {
           return { ...clip, start_ms: Math.max(0, clip.start_ms + deltaMs) }
         }
         return clip
@@ -4216,16 +4212,15 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     const updatedTracks = timeline.audio_tracks.map(track => ({
       ...track,
       clips: track.clips.map(clip => {
-        // Move clips starting at or after minStartMs
-        if (clip.start_ms >= minStartMs) {
+        if (selectedAudioClipIds.has(clip.id)) {
           return { ...clip, start_ms: Math.max(0, clip.start_ms + deltaMs) }
         }
         return clip
       }),
     }))
 
-    await updateTimeline(projectId, { ...timeline, layers: updatedLayers, audio_tracks: updatedTracks }, i18n.t('editor:undo.packClips'))
-    console.log('[handleSnapToPrevious] Snapped clips to', snapTargetMs, 'with', selectedVideoClipIds.size, 'video and', selectedAudioClipIds.size, 'audio clips selected, trailing clips also moved')
+    await updateTimeline(projectId, { ...timeline, layers: updatedLayers, audio_tracks: updatedTracks }, i18n.t('editor:undo.snapToPrev'))
+    console.log('[handleSnapToPrevious] Snapped clips to', snapTargetMs, 'with', selectedVideoClipIds.size, 'video and', selectedAudioClipIds.size, 'audio clips selected')
 
   }, [selectedVideoClip, selectedClip, selectedVideoClips, selectedAudioClips, timeline, projectId, updateTimeline])
 
@@ -4885,6 +4880,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
             </svg>
           </button>
           <button
+            data-testid="timeline-snap-to-previous"
             onClick={handleSnapToPrevious}
             disabled={!selectedClip && !selectedVideoClip}
             className="p-1.5 bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"

--- a/frontend/src/i18n/locales/en/editor.json
+++ b/frontend/src/i18n/locales/en/editor.json
@@ -204,6 +204,7 @@
   "undo": {
     "layerColorChange": "Change layer color",
     "packClips": "Pack clips",
+    "snapToPrev": "Snap to previous clip",
     "shapeLayerAdd": "Add shape layer",
     "videoLayerAdd": "Add video layer",
     "trackVolumeChange": "Change track volume",

--- a/frontend/src/i18n/locales/ja/editor.json
+++ b/frontend/src/i18n/locales/ja/editor.json
@@ -99,6 +99,7 @@
     "arrowScaleLocked": "矢印の scale は固定されています。長さと幅で調整してください。"
   },
   "undo": {
-    "audioClipNormalize": "音声クリップを正規化"
+    "audioClipNormalize": "音声クリップを正規化",
+    "snapToPrev": "前のクリップにスナップ"
   }
 }


### PR DESCRIPTION
## Summary
- limit snap-to-previous to the selected clip set instead of moving all trailing clips
- add a browser-level regression test that keeps the trailing clip in place
- add a dedicated undo label and test id for the snap action

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npx playwright test e2e/editor-critical-path.spec.ts -g "snaps only the selected clip to the previous clip end"

## Links
- Closes #75
