### PR TITLE
[Issue #83] Fix browser AI telop text visibility

### DIFF
--- a/backend/src/schemas/ai.py
+++ b/backend/src/schemas/ai.py
@@ -289,10 +289,18 @@ class OverviewClip(BaseModel):
     """Clip summary for timeline overview (~2000 tokens total)."""
 
     id: str
+    clip_type: str = Field(
+        default="unknown",
+        description="Timeline clip kind, e.g. text, shape, video, image, asset, unknown",
+    )
     asset_name: str | None = None  # UUID→name resolved
     start_ms: int
     end_ms: int
-    text_content: str | None = None  # Telop content (truncated to 100 chars)
+    text_state: str = Field(
+        default="not_text",
+        description="Text availability state: present, empty, unavailable, or not_text",
+    )
+    text_content: str | None = None  # Telop content (truncated to 100 chars when present)
     effects_summary: str | None = None  # e.g., "chroma_key(#00FF00), opacity(0.8)"
     group_id: str | None = None
 

--- a/backend/src/services/ai_service.py
+++ b/backend/src/services/ai_service.py
@@ -474,6 +474,8 @@ class AIService:
                 start = clip.get("start_ms", 0)
                 dur = clip.get("duration_ms", 0)
                 aid = clip.get("asset_id")
+                clip_type = self._detect_clip_type(clip)
+                text_state, text_preview = self._summarize_text_content(clip, max_length=100)
 
                 # Build effects summary (non-default effects only)
                 effects_parts: list[str] = []
@@ -489,17 +491,15 @@ class AIService:
                     if blend != "normal":
                         effects_parts.append(f"blend({blend})")
 
-                text = clip.get("text_content")
-                if text and len(text) > 100:
-                    text = text[:100] + "..."
-
                 overview_clips.append(
                     OverviewClip(
                         id=clip.get("id", "")[:8],
+                        clip_type=clip_type,
                         asset_name=asset_name_map.get(aid) if aid else None,
                         start_ms=start,
                         end_ms=start + dur,
-                        text_content=text,
+                        text_state=text_state,
+                        text_content=text_preview,
                         effects_summary=", ".join(effects_parts) if effects_parts else None,
                         group_id=clip.get("group_id"),
                     )
@@ -569,13 +569,18 @@ class AIService:
                 start = clip.get("start_ms", 0)
                 dur = clip.get("duration_ms", 0)
                 aid = clip.get("asset_id")
+                clip_type = self._detect_clip_type(clip)
+                text_state, text_preview = self._summarize_text_content(clip, max_length=100)
 
                 overview_clips.append(
                     OverviewClip(
                         id=clip.get("id", "")[:8],
+                        clip_type=clip_type,
                         asset_name=asset_name_map.get(aid) if aid else None,
                         start_ms=start,
                         end_ms=start + dur,
+                        text_state=text_state,
+                        text_content=text_preview,
                         group_id=clip.get("group_id"),
                     )
                 )
@@ -4694,6 +4699,70 @@ class AIService:
         )
         return list(result.scalars().all())
 
+    @staticmethod
+    def _detect_clip_type(clip: dict[str, Any]) -> str:
+        """Classify a timeline clip so AI can reason about text objects explicitly."""
+        clip_type = clip.get("type")
+        if isinstance(clip_type, str) and clip_type:
+            return clip_type
+        if clip.get("text_content") is not None:
+            return "text"
+        if clip.get("shape"):
+            return "shape"
+        if clip.get("asset_id"):
+            return "asset"
+        return "unknown"
+
+    @classmethod
+    def _summarize_text_content(
+        cls, clip: dict[str, Any], *, max_length: int | None = None
+    ) -> tuple[str, str | None]:
+        """Return text availability state and preview text for AI-facing responses."""
+        if cls._detect_clip_type(clip) != "text":
+            return "not_text", None
+
+        raw_text = clip.get("text_content")
+        if raw_text is None or not isinstance(raw_text, str):
+            return "unavailable", None
+        if raw_text.strip() == "":
+            return "empty", ""
+        if max_length is not None and len(raw_text) > max_length:
+            return "present", raw_text[:max_length] + "..."
+        return "present", raw_text
+
+    @classmethod
+    def _build_context_clip_summary(cls, clip: dict[str, Any]) -> str:
+        """Serialize a clip into a compact line for the browser AI prompt."""
+        clip_id = str(clip.get("id", "?"))[:8]
+        clip_type = cls._detect_clip_type(clip)
+        start_ms = clip.get("start_ms", 0)
+        duration_ms = clip.get("duration_ms", 0)
+
+        summary_parts = [
+            f"id={clip_id}",
+            f"type={clip_type}",
+            f"start={start_ms}ms",
+            f"dur={duration_ms}ms",
+        ]
+
+        asset_id = clip.get("asset_id")
+        if asset_id:
+            summary_parts.append(f"asset={str(asset_id)[:8]}")
+
+        text_state, text_preview = cls._summarize_text_content(clip, max_length=160)
+        if text_state != "not_text":
+            summary_parts.append(f"text_state={text_state}")
+            if text_state == "unavailable":
+                summary_parts.append("text=<unavailable>")
+            elif text_preview is not None:
+                summary_parts.append(f"text={json.dumps(text_preview, ensure_ascii=False)}")
+
+        shape = clip.get("shape")
+        if clip_type == "shape" and isinstance(shape, dict) and shape.get("type"):
+            summary_parts.append(f"shape={shape.get('type')}")
+
+        return "  - " + " ".join(summary_parts)
+
     def _build_chat_context(
         self, project: Project, timeline: dict, assets: list[Asset] | None = None
     ) -> str:
@@ -4707,13 +4776,7 @@ class AIService:
         layers_info = []
         for layer in timeline.get("layers", []):
             clips = layer.get("clips", [])
-            clip_summaries = []
-            for c in clips:
-                clip_summaries.append(
-                    f"  - id={c.get('id', '?')[:8]} start={c.get('start_ms', 0)}ms "
-                    f"dur={c.get('duration_ms', 0)}ms "
-                    f"asset={c.get('asset_id', 'none')[:8] if c.get('asset_id') else 'shape/text'}"
-                )
+            clip_summaries = [self._build_context_clip_summary(c) for c in clips]
             layers_info.append(
                 f"Layer '{layer.get('name', '')}' (id={layer.get('id', '')[:8]}, "
                 f"clips={len(clips)}, locked={layer.get('locked', False)}):\n"
@@ -4817,6 +4880,11 @@ class AIService:
 - ファイル名（例: "video.mp4"）は使用できません
 - 上記「Available Assets」セクションからファイル名に対応する asset_id を確認してください
 - ユーザーがファイル名で指定した場合は、対応する asset_id を使用してください
+
+## 重要: テキストオブジェクトの読み方
+- `type=text` の行がテキストオブジェクトです
+- `text_state=present` のときだけ `text="..."` を本文として扱ってください
+- `text_state=empty` は空文字、`text_state=unavailable` は取得不能です。推測で補完しないでください
 
 ## 重要: dataフィールドの形式
 - add操作: {{"layer_id": "ID", "start_ms": ミリ秒, "duration_ms": ミリ秒, "asset_id": "UUID"}}

--- a/backend/tests/test_ai_api.py
+++ b/backend/tests/test_ai_api.py
@@ -6,8 +6,8 @@ Run with: pytest tests/test_ai_api.py -v
 """
 
 import uuid
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -19,18 +19,16 @@ from src.exceptions import ClipNotFoundError, LayerNotFoundError
 from src.schemas.ai import (
     AddAudioClipRequest,
     AddClipRequest,
-    ChatResponse,
     ChatRequest,
+    ChatResponse,
     L1ProjectOverview,
     L2TimelineStructure,
     L3ClipDetails,
     MoveClipRequest,
     SemanticOperation,
-    UpdateClipEffectsRequest,
     UpdateClipTransformRequest,
 )
 from src.services.ai_service import AIService
-
 
 # =============================================================================
 # Fixtures
@@ -160,7 +158,7 @@ def mock_project(sample_timeline_data):
     project.height = 1080
     project.fps = 30
     project.status = "draft"
-    project.updated_at = datetime.now(timezone.utc)
+    project.updated_at = datetime.now(UTC)
     project.timeline_data = sample_timeline_data
     return project
 
@@ -378,10 +376,66 @@ class TestGetTimelineStructure:
         result = await ai_service.get_timeline_structure(mock_project)
 
         # Avatar layer has gap between 30000 and 60000
-        avatar_layer = next(l for l in result.layers if l.id == "layer-avatar")
+        avatar_layer = next(layer for layer in result.layers if layer.id == "layer-avatar")
         assert avatar_layer.clip_count == 2
         # Should have 2 separate time ranges due to gap
         assert len(avatar_layer.time_coverage) == 2
+
+
+class TestGetTimelineOverview:
+    """Tests for L2.5 timeline overview endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_preserves_text_clip_content_states(self, ai_service):
+        """Should expose text clip contents and explicit empty/unavailable states."""
+        project = MagicMock()
+        project.id = uuid.uuid4()
+        project.duration_ms = 9000
+        project.timeline_data = {
+            "layers": [
+                {
+                    "id": "layer-text",
+                    "name": "Telops",
+                    "type": "text",
+                    "visible": True,
+                    "locked": False,
+                    "clips": [
+                        {
+                            "id": "text-one-aaa",
+                            "type": "text",
+                            "start_ms": 0,
+                            "duration_ms": 1000,
+                            "text_content": "最初のテロップ",
+                        },
+                        {
+                            "id": "text-two-bbb",
+                            "type": "text",
+                            "start_ms": 1500,
+                            "duration_ms": 1000,
+                            "text_content": "   ",
+                        },
+                        {
+                            "id": "text-thr-ccc",
+                            "type": "text",
+                            "start_ms": 3000,
+                            "duration_ms": 1000,
+                        },
+                    ],
+                }
+            ],
+            "audio_tracks": [],
+        }
+
+        result = await ai_service.get_timeline_overview(project)
+
+        clips = result.layers[0].clips
+        assert clips[0].clip_type == "text"
+        assert clips[0].text_state == "present"
+        assert clips[0].text_content == "最初のテロップ"
+        assert clips[1].text_state == "empty"
+        assert clips[1].text_content == ""
+        assert clips[2].text_state == "unavailable"
+        assert clips[2].text_content is None
 
 
 # =============================================================================
@@ -536,7 +590,7 @@ class TestDeleteClip:
 
         # Verify clip is removed
         avatar_layer = next(
-            l for l in mock_project.timeline_data["layers"] if l["id"] == "layer-avatar"
+            layer for layer in mock_project.timeline_data["layers"] if layer["id"] == "layer-avatar"
         )
         clip_ids = [c["id"] for c in avatar_layer["clips"]]
         assert "clip-avatar-1" not in clip_ids
@@ -716,6 +770,91 @@ class TestChatSequenceContext:
         assert "Duration: 20000ms" in prompt
 
     @pytest.mark.asyncio
+    async def test_handle_chat_includes_text_clip_content_states(
+        self, ai_service, mock_project, monkeypatch
+    ):
+        """Chat prompt should expose text clip content plus empty/unavailable states."""
+        mock_project.ai_provider = None
+        mock_project.ai_api_key = "test-key"
+        context_project = MagicMock()
+        context_project.name = mock_project.name
+        context_project.duration_ms = 12000
+        context_project.width = mock_project.width
+        context_project.height = mock_project.height
+        context_project.timeline_data = {
+            "duration_ms": 12000,
+            "layers": [
+                {
+                    "id": "layer-text",
+                    "name": "Telops",
+                    "type": "text",
+                    "visible": True,
+                    "locked": False,
+                    "clips": [
+                        {
+                            "id": "text-one-aaa",
+                            "type": "text",
+                            "start_ms": 0,
+                            "duration_ms": 2000,
+                            "text_content": "一つ目のテロップ",
+                        },
+                        {
+                            "id": "text-two-bbb",
+                            "type": "text",
+                            "start_ms": 2500,
+                            "duration_ms": 2000,
+                            "text_content": "",
+                        },
+                        {
+                            "id": "text-thr-ccc",
+                            "type": "text",
+                            "start_ms": 5000,
+                            "duration_ms": 2000,
+                        },
+                    ],
+                }
+            ],
+            "audio_tracks": [],
+        }
+
+        captured: dict[str, object] = {}
+
+        async def fake_chat_with_openai(
+            _self,
+            project,
+            message,
+            history,
+            system_prompt,
+            api_key,
+            *,
+            timeline_target=None,
+        ):
+            captured["project_id"] = project.id
+            captured["message"] = message
+            captured["history"] = history
+            captured["system_prompt"] = system_prompt
+            captured["timeline_target"] = timeline_target
+            captured["api_key"] = api_key
+            return ChatResponse(message="ok", actions=[])
+
+        monkeypatch.setattr(AIService, "_chat_with_openai", fake_chat_with_openai)
+        monkeypatch.setattr(AIService, "_get_project_assets", AsyncMock(return_value=[]))
+
+        result = await ai_service.handle_chat(
+            mock_project,
+            "今表示されているテキストを確認して",
+            [],
+            provider="openai",
+            context_project=context_project,
+        )
+
+        assert result.message == "ok"
+        prompt = str(captured["system_prompt"])
+        assert 'id=text-one type=text start=0ms dur=2000ms text_state=present text="一つ目のテロップ"' in prompt
+        assert 'id=text-two type=text start=2500ms dur=2000ms text_state=empty text=""' in prompt
+        assert "id=text-thr type=text start=5000ms dur=2000ms text_state=unavailable text=<unavailable>" in prompt
+
+    @pytest.mark.asyncio
     async def test_execute_chat_operations_updates_sequence_target_only(self, ai_service, mock_project):
         """Chat operations in sequence mode should write back to the active sequence timeline."""
         mock_project.timeline_data = {
@@ -840,6 +979,111 @@ class TestAIRouteResolverWiring:
     """Tests for resolver selection in AI API routes."""
 
     @pytest.mark.asyncio
+    async def test_chat_route_passes_text_clip_context_to_provider(self, monkeypatch):
+        """Browser chat route should serialize text clip bodies into the provider prompt."""
+        project_id = uuid.uuid4()
+        current_user = MagicMock()
+        db = AsyncMock()
+
+        project = MagicMock()
+        project.id = project_id
+        project.name = "Project"
+        project.width = 1920
+        project.height = 1080
+        project.fps = 30
+        project.status = "draft"
+        project.updated_at = datetime.now(UTC)
+        project.ai_provider = None
+        project.ai_api_key = "test-key"
+
+        sequence = MagicMock()
+        sequence.duration_ms = 12000
+        sequence.timeline_data = {
+            "duration_ms": 12000,
+            "layers": [
+                {
+                    "id": "layer-text",
+                    "name": "Telops",
+                    "type": "text",
+                    "visible": True,
+                    "locked": False,
+                    "clips": [
+                        {
+                            "id": "text-one-aaa",
+                            "type": "text",
+                            "start_ms": 0,
+                            "duration_ms": 2000,
+                            "text_content": "一つ目のテロップ",
+                        },
+                        {
+                            "id": "text-two-bbb",
+                            "type": "text",
+                            "start_ms": 2500,
+                            "duration_ms": 2000,
+                            "text_content": "",
+                        },
+                        {
+                            "id": "text-thr-ccc",
+                            "type": "text",
+                            "start_ms": 5000,
+                            "duration_ms": 2000,
+                        },
+                    ],
+                }
+            ],
+            "audio_tracks": [],
+        }
+
+        edit_ctx = MagicMock()
+        edit_ctx.project = project
+        edit_ctx.sequence = sequence
+        edit_ctx.timeline_data = sequence.timeline_data
+
+        captured: dict[str, object] = {}
+
+        async def fake_chat_write_resolver(*args, **kwargs):
+            return edit_ctx
+
+        async def fake_chat_with_openai(
+            _self,
+            resolved_project,
+            message,
+            history,
+            system_prompt,
+            api_key,
+            *,
+            timeline_target=None,
+        ):
+            captured["project"] = resolved_project
+            captured["message"] = message
+            captured["history"] = history
+            captured["system_prompt"] = system_prompt
+            captured["api_key"] = api_key
+            captured["timeline_target"] = timeline_target
+            return ChatResponse(message="ok", actions=[], actions_applied=False)
+
+        monkeypatch.setattr(ai_api, "get_edit_context_for_chat_write", fake_chat_write_resolver)
+        monkeypatch.setattr(AIService, "_get_project_assets", AsyncMock(return_value=[]))
+        monkeypatch.setattr(AIService, "_chat_with_openai", fake_chat_with_openai)
+
+        result = await ai_api.chat(
+            project_id=project_id,
+            request=ChatRequest(message="今表示されているテキストを確認して", history=[]),
+            current_user=current_user,
+            db=db,
+            x_edit_session="edit-token",
+        )
+
+        assert result.message == "ok"
+        assert captured["project"] is project
+        assert captured["timeline_target"] is sequence
+        assert captured["api_key"] == "test-key"
+        prompt = str(captured["system_prompt"])
+        assert 'id=text-one type=text start=0ms dur=2000ms text_state=present text="一つ目のテロップ"' in prompt
+        assert 'id=text-two type=text start=2500ms dur=2000ms text_state=empty text=""' in prompt
+        assert "id=text-thr type=text start=5000ms dur=2000ms text_state=unavailable text=<unavailable>" in prompt
+
+    @pytest.mark.asyncio
     async def test_chat_uses_strict_write_resolver(self, monkeypatch):
         """Mutating chat routes must use the strict chat-write resolver."""
         project_id = uuid.uuid4()
@@ -853,7 +1097,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
         project.ai_provider = None
         project.ai_api_key = None
 
@@ -921,7 +1165,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
 
         sequence = MagicMock()
         sequence.duration_ms = 5000
@@ -974,7 +1218,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
 
         sequence = MagicMock()
         sequence.duration_ms = 5000
@@ -1028,7 +1272,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
 
         sequence = MagicMock()
         sequence.duration_ms = 5000
@@ -1083,7 +1327,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
 
         sequence = MagicMock()
         sequence.duration_ms = 5000
@@ -1137,7 +1381,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
 
         sequence = MagicMock()
         sequence.duration_ms = 5000
@@ -1193,7 +1437,7 @@ class TestAIRouteResolverWiring:
         project.height = 1080
         project.fps = 30
         project.status = "draft"
-        project.updated_at = datetime.now(timezone.utc)
+        project.updated_at = datetime.now(UTC)
 
         sequence = MagicMock()
         sequence.duration_ms = 5000

--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -165,6 +165,114 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByText('No activity yet')).toBeVisible()
   })
 
+  test('streams AI chat responses inside the editor panel without breaking the workflow', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page, {
+      layout: {
+        isAIChatOpen: true,
+      },
+    })
+
+    const textClip: Clip = {
+      id: 'clip-seeded-text-ai',
+      asset_id: null,
+      text_content: 'Seeded telop',
+      text_style: {
+        fontFamily: 'Noto Sans JP',
+        fontSize: 42,
+        fontWeight: 'bold',
+        fontStyle: 'normal',
+        color: '#ffffff',
+        backgroundColor: '#000000',
+        backgroundOpacity: 0.4,
+        textAlign: 'center',
+        verticalAlign: 'middle',
+        lineHeight: 1.4,
+        letterSpacing: 0,
+        strokeColor: '#000000',
+        strokeWidth: 2,
+      },
+      start_ms: 0,
+      duration_ms: 3000,
+      in_point_ms: 0,
+      out_point_ms: null,
+      speed: 1,
+      freeze_frame_ms: 0,
+      transform: {
+        x: 0,
+        y: 0,
+        width: null,
+        height: null,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+
+    mock.projectDetails[mock.projectId].timeline_data.layers = [
+      {
+        id: 'layer-text-ai',
+        name: 'Telops',
+        type: 'text',
+        order: 0,
+        visible: true,
+        locked: false,
+        clips: [textClip],
+      },
+    ]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 3000
+    mock.projectDetails[mock.projectId].duration_ms = 3000
+    mock.sequences[mock.sequenceId].timeline_data.layers = [
+      {
+        id: 'layer-text-ai',
+        name: 'Telops',
+        type: 'text',
+        order: 0,
+        visible: true,
+        locked: false,
+        clips: [textClip],
+      },
+    ]
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 3000
+    mock.sequences[mock.sequenceId].duration_ms = 3000
+
+    const chatRequests: Array<{ message: string; history: Array<{ role: string; content: string }>; provider?: string }> = []
+
+    await page.route(`**/api/ai/project/${mock.projectId}/chat/stream`, async (route) => {
+      chatRequests.push(route.request().postDataJSON() as { message: string; history: Array<{ role: string; content: string }>; provider?: string })
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        headers: {
+          'cache-control': 'no-cache',
+        },
+        body: [
+          'event: chunk',
+          'data: {"text":"既存テキストは「Seeded telop」です。"}',
+          '',
+          'event: done',
+          'data: {}',
+          '',
+        ].join('\n'),
+      })
+    })
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+    await expect(page.getByTestId('ai-chat-panel')).toBeVisible()
+    await expect(page.getByTestId('ai-chat-input')).toBeVisible()
+
+    await page.getByTestId('ai-chat-input').fill('今表示されているテキストを確認して')
+    await page.getByTestId('ai-chat-input').press('Enter')
+
+    await expect.poll(() => chatRequests.length).toBe(1)
+    expect(chatRequests[0]?.message).toBe('今表示されているテキストを確認して')
+    expect(chatRequests[0]?.history).toEqual([])
+
+    await expect(page.getByText('今表示されているテキストを確認して')).toBeVisible()
+    await expect(page.getByText('既存テキストは「Seeded telop」です。')).toBeVisible()
+  })
+
   test('auto-generate telop uses an explicitly selected audio track source', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
     const audioAsset: Asset = {


### PR DESCRIPTION
## Summary
- expose browser AI chat context with explicit clip `type` plus `text_state` / `text_content` for text clips
- carry the same text visibility metadata into timeline overview responses so multiple telops stay distinguishable
- add route-level backend coverage and an editor Playwright smoke for the browser AI chat workflow

## Self-review
- Completed

## Verification
- `cd backend && /Users/hgs/devel/douga_root/main/backend/.venv/bin/ruff check src/services/ai_service.py src/schemas/ai.py tests/test_ai_api.py`
- `cd backend && /Users/hgs/devel/douga_root/main/backend/.venv/bin/pytest tests/test_ai_api.py`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && ./node_modules/.bin/playwright test e2e/editor-critical-path.spec.ts -g "streams AI chat responses inside the editor panel without breaking the workflow"`

## Playwright
- `frontend/e2e/editor-critical-path.spec.ts`
- `Editor Critical Path › streams AI chat responses inside the editor panel without breaking the workflow`

## Behavior verification
- automated route-level verification confirms `/api/ai/project/{id}/chat` passes telop text and explicit `present|empty|unavailable` states into the provider prompt
- automated browser verification confirms the editor AI panel can send a chat request and render the streamed response without breaking the workflow
- manual browser verification against a live AI provider was not run locally

## Residual risks / gaps
- live-provider behavior on a real project still needs a manual smoke check before merge confidence is maximal

Closes #83.
