### PR TITLE
fix: release sequence lock when leaving the editor

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -1555,6 +1555,23 @@ test.describe('Editor Critical Path', () => {
     await expect(page.getByText('Seeded Project')).toBeVisible()
   })
 
+  test('releases the sequence lock when leaving the editor', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await page.getByTestId('editor-open-exit-confirm').click()
+    await expect(page.getByTestId('editor-confirm-exit')).toBeVisible()
+    await page.getByTestId('editor-confirm-exit').click()
+
+    await expect(page).toHaveURL(/\/app$/)
+    await expect.poll(() => mock.calls.sequenceUnlocks.length).toBe(1)
+    expect(mock.calls.sequenceUnlocks[0]).toEqual({
+      projectId: mock.projectId,
+      sequenceId: mock.sequenceId,
+    })
+  })
+
   test('does not surface AbortError when stop interrupts a pending audio play()', async ({ page }) => {
     const consoleErrors: string[] = []
     const pageErrors: string[] = []

--- a/frontend/e2e/helpers/editorMockServer.ts
+++ b/frontend/e2e/helpers/editorMockServer.ts
@@ -38,6 +38,10 @@ export interface MockEditorApiState {
   calls: {
     assetListRequestedAt: number[]
     projectCreates: string[]
+    sequenceUnlocks: Array<{
+      projectId: string
+      sequenceId: string
+    }>
     sequenceRequestedAt: number[]
     sequenceRespondedAt: number[]
     sequenceUpdates: Array<{
@@ -172,6 +176,7 @@ export function createMockEditorApiState(): MockEditorApiState {
     calls: {
       assetListRequestedAt: [],
       projectCreates: [],
+      sequenceUnlocks: [],
       sequenceRequestedAt: [],
       sequenceRespondedAt: [],
       sequenceUpdates: [],
@@ -419,6 +424,8 @@ export async function bootstrapMockEditorPage(
 
     const sequenceUnlockMatch = matches(pathname, /^\/api\/projects\/([^/]+)\/sequences\/([^/]+)\/unlock$/)
     if (sequenceUnlockMatch && method === 'POST') {
+      const [, projectId, sequenceId] = sequenceUnlockMatch
+      state.calls.sequenceUnlocks.push({ projectId, sequenceId })
       return json(route, {})
     }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,8 @@ const baseURL = import.meta.env.VITE_API_URL
   ? `${import.meta.env.VITE_API_URL}/api`
   : '/api'
 
+export const API_BASE_URL = baseURL
+
 const apiClient = axios.create({
   baseURL,
   headers: {

--- a/frontend/src/api/sequences.ts
+++ b/frontend/src/api/sequences.ts
@@ -1,5 +1,6 @@
-import apiClient from './client'
+import apiClient, { API_BASE_URL, getEditTokenForClient } from './client'
 import type { TimelineData } from '@/store/projectStore'
+import { useAuthStore } from '@/store/authStore'
 
 export interface SequenceListItem {
   id: string
@@ -44,6 +45,21 @@ export interface SnapshotItem {
   duration_ms: number
   created_at: string
   updated_at: string
+}
+
+function buildUnlockHeaders(): HeadersInit {
+  const headers: Record<string, string> = {}
+  const token = useAuthStore.getState().token
+  const editToken = getEditTokenForClient()
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  if (editToken) {
+    headers['X-Edit-Session'] = editToken
+  }
+
+  return headers
 }
 
 export const sequencesApi = {
@@ -96,6 +112,27 @@ export const sequencesApi = {
 
   unlock: async (projectId: string, sequenceId: string): Promise<void> => {
     await apiClient.post(`/projects/${projectId}/sequences/${sequenceId}/unlock`)
+  },
+
+  unlockBestEffort: async (
+    projectId: string,
+    sequenceId: string,
+    options?: { keepalive?: boolean }
+  ): Promise<void> => {
+    if (options?.keepalive && typeof fetch === 'function') {
+      try {
+        await fetch(`${API_BASE_URL}/projects/${projectId}/sequences/${sequenceId}/unlock`, {
+          method: 'POST',
+          headers: buildUnlockHeaders(),
+          keepalive: true,
+        })
+        return
+      } catch {
+        // Fall back to the normal client request below.
+      }
+    }
+
+    await sequencesApi.unlock(projectId, sequenceId)
   },
 
   listSnapshots: async (projectId: string, sequenceId: string): Promise<SnapshotItem[]> => {

--- a/frontend/src/hooks/useSequenceLock.ts
+++ b/frontend/src/hooks/useSequenceLock.ts
@@ -11,7 +11,7 @@ interface UseSequenceLockResult {
   isReadOnly: boolean      // !isLockedByMe
   lockHolder: string | null // Lock holder's name
   acquireLock: () => Promise<boolean>
-  releaseLock: () => Promise<void>
+  releaseLock: (options?: { keepalive?: boolean }) => Promise<void>
 }
 
 export function useSequenceLock(
@@ -123,6 +123,7 @@ export function useSequenceLock(
         if (result.locked) {
           console.log('[SequenceLock] Immediate retry: lock acquired!')
           setIsLockedByMe(true)
+          isLockedByMeRef.current = true
           if (result.edit_token) {
             useProjectStore.getState().setEditToken(result.edit_token)
           }
@@ -161,6 +162,7 @@ export function useSequenceLock(
         if (result.locked) {
           console.log('[SequenceLock] Retry poll: lock acquired!')
           setIsLockedByMe(true)
+          isLockedByMeRef.current = true
           if (result.edit_token) {
             useProjectStore.getState().setEditToken(result.edit_token)
           }
@@ -193,6 +195,7 @@ export function useSequenceLock(
       if (result.locked) {
         console.log('[SequenceLock] Lock acquired successfully')
         setIsLockedByMe(true)
+        isLockedByMeRef.current = true
         if (result.edit_token) {
           useProjectStore.getState().setEditToken(result.edit_token)
         }
@@ -214,20 +217,21 @@ export function useSequenceLock(
     }
   }, [projectId, sequenceId, startHeartbeat, startRetryPollingInner])
 
-  const releaseLock = useCallback(async () => {
+  const releaseLock = useCallback(async (options?: { keepalive?: boolean }) => {
     stopHeartbeat()
     stopRetry()
-    if (!projectId || !sequenceId || !isLockedByMe) return
-    try {
-      console.log('[SequenceLock] Releasing lock...')
-      await sequencesApi.unlock(projectId, sequenceId)
-    } catch {
-      // Best-effort - lock will expire after 2 minutes
-    }
+    if (!projectId || !sequenceId || !isLockedByMeRef.current) return
+    isLockedByMeRef.current = false
     setIsLockedByMe(false)
     useProjectStore.getState().setEditToken(null)
     setLockState(null)
-  }, [projectId, sequenceId, isLockedByMe, stopHeartbeat, stopRetry])
+    try {
+      console.log('[SequenceLock] Releasing lock...')
+      await sequencesApi.unlockBestEffort(projectId, sequenceId, options)
+    } catch {
+      // Best-effort - lock will expire after 2 minutes
+    }
+  }, [projectId, sequenceId, stopHeartbeat, stopRetry])
 
   // Send immediate heartbeat when tab becomes visible (Chrome throttles setInterval in background tabs)
   useEffect(() => {
@@ -281,6 +285,16 @@ export function useSequenceLock(
     }
   }, [projectId, sequenceId, stopHeartbeat, startHeartbeat, startRetryPollingInner])
 
+  useEffect(() => {
+    const handlePageHide = () => {
+      if (!isLockedByMeRef.current) return
+      void releaseLock({ keepalive: true })
+    }
+
+    window.addEventListener('pagehide', handlePageHide)
+    return () => window.removeEventListener('pagehide', handlePageHide)
+  }, [releaseLock])
+
   // Auto-acquire lock on mount
   useEffect(() => {
     if (projectId && sequenceId) {
@@ -292,7 +306,7 @@ export function useSequenceLock(
       stopRetry()
       useProjectStore.getState().setEditToken(null)
       if (projectId && sequenceId && isLockedByMeRef.current) {
-        sequencesApi.unlock(projectId, sequenceId).catch(() => {})
+        void releaseLock({ keepalive: true })
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -299,11 +299,13 @@ export default function Editor() {
   const isMac = useMemo(() => {
     return typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
   }, [])
+  const { isReadOnly, lockHolder, acquireLock: retryLock, releaseLock } = useSequenceLock(projectId, sequenceId)
   const goToDashboard = useCallback(() => {
+    void releaseLock({ keepalive: true })
     // Force a document navigation so the return path does not depend on the
     // in-memory router state that may have led users back to the landing page.
     window.location.assign('/app')
-  }, [])
+  }, [releaseLock])
   const undoLabel = getUndoLabel()
   const redoLabel = getRedoLabel()
   const undoTooltip = undoLabel
@@ -642,9 +644,6 @@ export default function Editor() {
       fetchSequence(projectId, sequenceId)
     }
   }, [projectId, sequenceId, fetchSequence])
-
-  // Sequence lock management
-  const { isReadOnly, lockHolder, acquireLock: retryLock } = useSequenceLock(projectId, sequenceId)
 
   // Re-fetch sequence data when lock transitions from read-only to editable (debounced)
   const prevIsReadOnlyRef = useRef(isReadOnly)


### PR DESCRIPTION
## Summary
- release the active sequence lock through a keepalive-backed unlock path when leaving the editor
- trigger the same best-effort unlock on `pagehide` and unmount cleanup so full document navigation does not strand the lock
- add an editor exit regression test that asserts the unlock request is sent

## Pre-PR Gate
- Self-review completed and unrelated build artifact noise was removed
- Relevant lint check passed: `npm run lint`
- Relevant type/build check passed: `npm run build`
- Relevant integration/Playwright checks passed:
  - `npx playwright test e2e/editor-critical-path.spec.ts --grep "releases the sequence lock when leaving the editor|returns to the dashboard instead of the landing page from the editor"`

## Behavior Verified
- Leaving the editor via the exit confirmation path now sends the sequence unlock request before the app lands back on `/app`
- The dashboard return flow still lands on the dashboard instead of the landing page

## Residual Risks
- This change hardens document-exit flows; lock loss in other non-exit scenarios still depends on the existing heartbeat/retry lifecycle

Closes #95