### PR TITLE
fix(backend): enforce single active sequence lock per user

### DIFF
--- a/backend/src/api/sequences.py
+++ b/backend/src/api/sequences.py
@@ -84,6 +84,30 @@ def _is_lock_expired(locked_at: datetime | None) -> bool:
     return now - locked_at > LOCK_TIMEOUT
 
 
+async def _lock_user_scope(db: AsyncSession, user_id: UUID) -> None:
+    """Serialize lock acquisition attempts per user."""
+    await db.execute(select(User.id).where(User.id == user_id).with_for_update())
+
+
+async def _load_other_user_locked_sequences(
+    db: AsyncSession,
+    user_id: UUID,
+    sequence_id: UUID,
+) -> list[Sequence]:
+    """Load and lock any other sequences currently owned by the same user."""
+    result = await db.execute(
+        select(Sequence)
+        .where(Sequence.locked_by == user_id, Sequence.id != sequence_id)
+        .with_for_update()
+    )
+    return list(result.scalars().all())
+
+
+def _clear_sequence_lock(seq: Sequence) -> None:
+    seq.locked_by = None
+    seq.locked_at = None
+
+
 async def _auto_snapshot_if_needed(
     db: AsyncSession,
     sequence_id: UUID,
@@ -478,8 +502,16 @@ async def acquire_lock(
     - No one holds the lock (locked_by is NULL)
     - The existing lock has expired (locked_at > 2 minutes ago)
     - The current user already holds the lock (refresh)
+
+    Policy:
+    - A user may hold at most one active sequence lock at a time.
+    - When the same user successfully acquires another sequence lock, any
+      other sequence locks they still hold are released first.
+    - If another user still holds the requested sequence lock, acquisition
+      fails and the caller keeps any existing lock they already hold.
     """
     await get_accessible_project(project_id, current_user.id, db)
+    await _lock_user_scope(db, current_user.id)
 
     result = await db.execute(
         select(Sequence)
@@ -510,6 +542,12 @@ async def acquire_lock(
                 lock_holder_name=lock_holder_name,
                 locked_at=seq.locked_at,
             )
+
+    # Enforce single-lock semantics per user. The latest successful lock
+    # acquisition wins and atomically releases any other sequence locks
+    # still owned by this user, including stale duplicates from older bugs.
+    for other_seq in await _load_other_user_locked_sequences(db, current_user.id, sequence_id):
+        _clear_sequence_lock(other_seq)
 
     # Grant lock
     seq.locked_by = current_user.id

--- a/backend/tests/test_sequence_locks.py
+++ b/backend/tests/test_sequence_locks.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from collections.abc import Sequence as TypingSequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api import sequences as sequences_api
+from src.models.sequence import Sequence
+from src.models.user import User
+
+
+class _FakeScalars:
+    def __init__(self, items: TypingSequence[object]):
+        self._items = items
+
+    def all(self) -> list[object]:
+        return list(self._items)
+
+
+class _FakeResult:
+    def __init__(
+        self,
+        *,
+        scalar: object | None = None,
+        scalar_items: TypingSequence[object] | None = None,
+    ):
+        self._scalar = scalar
+        self._scalar_items = scalar_items or []
+
+    def scalar_one_or_none(self) -> object | None:
+        return self._scalar
+
+    def scalars(self) -> _FakeScalars:
+        return _FakeScalars(self._scalar_items)
+
+
+@dataclass
+class _FakeSession:
+    sequences: dict[UUID, Sequence]
+    user_names: dict[UUID, str]
+    flush_count: int = 0
+
+    async def execute(self, query: Any) -> _FakeResult:
+        column_name = query.column_descriptions[0]["name"]
+        conditions = {
+            criterion.left.name: (criterion.operator.__name__, criterion.right.value)
+            for criterion in query._where_criteria
+        }
+
+        if column_name == "id":
+            user_id = conditions["id"][1]
+            return _FakeResult(scalar=user_id if user_id in self.user_names else None)
+
+        if column_name == "name":
+            user_id = conditions["id"][1]
+            return _FakeResult(scalar=self.user_names.get(user_id))
+
+        if column_name != "Sequence":
+            raise AssertionError(f"Unexpected query shape: {query}")
+
+        if "project_id" in conditions:
+            sequence_id = conditions["id"][1]
+            project_id = conditions["project_id"][1]
+            seq = self.sequences.get(sequence_id)
+            if seq is None or seq.project_id != project_id:
+                return _FakeResult()
+            return _FakeResult(scalar=seq)
+
+        locked_by = conditions["locked_by"][1]
+        excluded_sequence_id = conditions["id"][1]
+        other_sequences = [
+            seq
+            for seq in self.sequences.values()
+            if seq.locked_by == locked_by and seq.id != excluded_sequence_id
+        ]
+        return _FakeResult(scalar_items=other_sequences)
+
+    async def flush(self) -> None:
+        self.flush_count += 1
+
+
+def _make_sequence(
+    project_id: UUID,
+    *,
+    sequence_id: UUID | None = None,
+    locked_by: UUID | None = None,
+    locked_at: datetime | None = None,
+) -> Sequence:
+    return Sequence(
+        id=sequence_id or uuid4(),
+        project_id=project_id,
+        name="Sequence",
+        timeline_data={"version": "1.0", "layers": [], "audio_tracks": []},
+        version=1,
+        duration_ms=0,
+        is_default=False,
+        locked_by=locked_by,
+        locked_at=locked_at,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_get_accessible_project(
+        project_id: UUID,
+        user_id: UUID,
+        db: Any,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(id=project_id, user_id=user_id)
+
+    monkeypatch.setattr(sequences_api, "get_accessible_project", _fake_get_accessible_project)
+    monkeypatch.setattr(
+        sequences_api,
+        "create_edit_token",
+        lambda **kwargs: f"token:{kwargs['sequence_id']}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_releases_other_sequence_locks_for_same_user() -> None:
+    project_id = uuid4()
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    current_user = cast(User, SimpleNamespace(id=user_id, name="Current User"))
+
+    previous_sequence = _make_sequence(
+        project_id,
+        locked_by=user_id,
+        locked_at=now - timedelta(seconds=15),
+    )
+    target_sequence = _make_sequence(project_id)
+    db = _FakeSession(
+        sequences={
+            previous_sequence.id: previous_sequence,
+            target_sequence.id: target_sequence,
+        },
+        user_names={user_id: current_user.name},
+    )
+
+    response = await sequences_api.acquire_lock(
+        project_id,
+        target_sequence.id,
+        current_user,
+        cast(AsyncSession, db),
+    )
+
+    assert response.locked is True
+    assert response.locked_by == user_id
+    assert response.lock_holder_name == current_user.name
+    assert response.edit_token == f"token:{target_sequence.id}"
+    assert previous_sequence.locked_by is None
+    assert previous_sequence.locked_at is None
+    assert target_sequence.locked_by == user_id
+    assert target_sequence.locked_at is not None
+    assert db.flush_count == 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_does_not_drop_existing_lock_when_target_is_owned_by_other_user() -> None:
+    project_id = uuid4()
+    current_user_id = uuid4()
+    other_user_id = uuid4()
+    now = datetime.now(UTC)
+    current_user = cast(User, SimpleNamespace(id=current_user_id, name="Current User"))
+
+    existing_sequence = _make_sequence(
+        project_id,
+        locked_by=current_user_id,
+        locked_at=now - timedelta(seconds=20),
+    )
+    target_sequence = _make_sequence(
+        project_id,
+        locked_by=other_user_id,
+        locked_at=now - timedelta(seconds=10),
+    )
+    db = _FakeSession(
+        sequences={
+            existing_sequence.id: existing_sequence,
+            target_sequence.id: target_sequence,
+        },
+        user_names={
+            current_user_id: current_user.name,
+            other_user_id: "Other User",
+        },
+    )
+
+    response = await sequences_api.acquire_lock(
+        project_id,
+        target_sequence.id,
+        current_user,
+        cast(AsyncSession, db),
+    )
+
+    assert response.locked is False
+    assert response.locked_by == other_user_id
+    assert response.lock_holder_name == "Other User"
+    assert existing_sequence.locked_by == current_user_id
+    assert target_sequence.locked_by == other_user_id
+    assert db.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_refresh_clears_stale_duplicate_owned_locks() -> None:
+    project_id = uuid4()
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    current_user = cast(User, SimpleNamespace(id=user_id, name="Current User"))
+
+    duplicate_sequence = _make_sequence(
+        project_id,
+        locked_by=user_id,
+        locked_at=now - timedelta(seconds=25),
+    )
+    target_sequence = _make_sequence(
+        project_id,
+        locked_by=user_id,
+        locked_at=now - timedelta(seconds=5),
+    )
+    previous_target_lock_time = target_sequence.locked_at
+    assert previous_target_lock_time is not None
+    db = _FakeSession(
+        sequences={
+            duplicate_sequence.id: duplicate_sequence,
+            target_sequence.id: target_sequence,
+        },
+        user_names={user_id: current_user.name},
+    )
+
+    response = await sequences_api.acquire_lock(
+        project_id,
+        target_sequence.id,
+        current_user,
+        cast(AsyncSession, db),
+    )
+
+    assert response.locked is True
+    assert duplicate_sequence.locked_by is None
+    assert duplicate_sequence.locked_at is None
+    assert target_sequence.locked_by == user_id
+    assert target_sequence.locked_at is not None
+    assert target_sequence.locked_at >= previous_target_lock_time
+    assert db.flush_count == 1
+
+
+@pytest.mark.asyncio
+async def test_previous_sequence_heartbeat_is_rejected_after_lock_moves_to_new_sequence() -> None:
+    project_id = uuid4()
+    user_id = uuid4()
+    now = datetime.now(UTC)
+    current_user = cast(User, SimpleNamespace(id=user_id, name="Current User"))
+
+    previous_sequence = _make_sequence(
+        project_id,
+        locked_by=user_id,
+        locked_at=now - timedelta(seconds=10),
+    )
+    target_sequence = _make_sequence(project_id)
+    db = _FakeSession(
+        sequences={
+            previous_sequence.id: previous_sequence,
+            target_sequence.id: target_sequence,
+        },
+        user_names={user_id: current_user.name},
+    )
+
+    await sequences_api.acquire_lock(
+        project_id,
+        target_sequence.id,
+        current_user,
+        cast(AsyncSession, db),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sequences_api.heartbeat(
+            project_id,
+            previous_sequence.id,
+            current_user,
+            cast(AsyncSession, db),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "do not hold the lock" in exc_info.value.detail


### PR DESCRIPTION
## Summary
- enforce a backend single-lock policy so one user can hold at most one active sequence lock at a time
- release any other locks held by the same user when a new lock acquisition succeeds, including stale duplicate locks left behind by older behavior
- add regression tests for lock handoff, failed acquisition preserving the existing lock, duplicate cleanup, and rejecting heartbeat on the old sequence after handoff

## Self-Review
- Self-review completed
- Diff is scoped to the sequence lock API and dedicated regression tests

## Verification
- `uv run --python 3.11 ruff check src/api/sequences.py tests/test_sequence_locks.py`
- `uv run --python 3.11 pytest tests/test_sequence_locks.py -q`
- `uv run --python 3.11 --with mypy mypy src/api/sequences.py`
- `uv build`

## Playwright
- N/A; backend sequence-lock policy change only

## Behavior Verified
- Re-locking a different sequence as the same user moves ownership to the new sequence
- If another user still owns the requested sequence, acquisition fails and the caller keeps their existing lock
- Duplicate locks already held by the same user are cleared when the user refreshes/acquires a valid target lock
- Heartbeat on the old sequence is rejected after lock handoff

## Residual Risks
- Verification here is backend-focused and does not yet cover full frontend multi-tab navigation flows end-to-end
- The chosen policy is latest-lock-wins; if product expectations change, the frontend handoff UX may need follow-up

Closes #96