### PR TITLE
fix(frontend): recover sequence save after stale lock

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 import type { Asset } from '../src/api/assets'
 import { getArrowHeadLength, getArrowShapePath } from '../src/components/editor/shapeGeometry'
-import type { AudioTrack, Clip } from '../src/store/projectStore'
+import type { AudioTrack, Clip, TimelineData } from '../src/store/projectStore'
 import { bootstrapMockEditorPage } from './helpers/editorMockServer'
 import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
 
@@ -70,6 +70,95 @@ test.describe('Editor Critical Path', () => {
     await expect(clipLocator).toHaveCount(1)
     await clipLocator.first().click()
     await expect(page.getByTestId('video-scale-input')).toHaveValue('150')
+  })
+
+  test('recovers sequence save after a stale lock rejects the first save', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    let rejectedSaveCount = 0
+    let lockRefreshCount = 0
+
+    await page.route(`**/api/projects/${mock.projectId}/sequences/${mock.sequenceId}`, async (route) => {
+      const request = route.request()
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mock.sequences[mock.sequenceId]),
+        })
+        return
+      }
+
+      if (request.method() !== 'PUT') {
+        await route.abort()
+        return
+      }
+
+      if (rejectedSaveCount === 0) {
+        rejectedSaveCount += 1
+        await route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            detail: 'Sequence is not locked by you. Acquire a lock before saving.',
+          }),
+        })
+        return
+      }
+
+      const body = request.postDataJSON() as { timeline_data: TimelineData; version: number }
+      const sequence = mock.sequences[mock.sequenceId]
+      sequence.timeline_data = JSON.parse(JSON.stringify(body.timeline_data))
+      sequence.duration_ms = body.timeline_data.duration_ms
+      sequence.version += 1
+      sequence.updated_at = new Date().toISOString()
+
+      mock.calls.sequenceUpdates.push({
+        projectId: mock.projectId,
+        sequenceId: mock.sequenceId,
+        timelineData: JSON.parse(JSON.stringify(body.timeline_data)),
+        version: sequence.version,
+      })
+
+      mock.projectDetails[mock.projectId].timeline_data = JSON.parse(JSON.stringify(sequence.timeline_data))
+      mock.projectDetails[mock.projectId].duration_ms = sequence.duration_ms
+      mock.projectDetails[mock.projectId].version = sequence.version
+      mock.projectDetails[mock.projectId].updated_at = sequence.updated_at
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(sequence),
+      })
+    })
+
+    await page.route(`**/api/projects/${mock.projectId}/sequences/${mock.sequenceId}/lock`, async (route) => {
+      lockRefreshCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          locked: true,
+          locked_by: 'dev-user-123',
+          lock_holder_name: 'Dev User',
+          locked_at: new Date().toISOString(),
+          edit_token: `mock-edit-token-${lockRefreshCount}`,
+        }),
+      })
+    })
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await dragAssetToVideoLayer(page, {
+      assetId: mock.primaryAssetId,
+      layerId: 'layer-1',
+      offsetX: 220,
+    })
+
+    await expect.poll(() => rejectedSaveCount).toBe(1)
+    await expect.poll(() => lockRefreshCount).toBeGreaterThan(1)
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+    await expect(page.locator('[data-testid^="timeline-video-clip-"]')).toHaveCount(1)
+    await expect(page.getByText('最新のタイムライン変更を保存できていません。')).toHaveCount(0)
   })
 
   test('prioritizes current sequence before full asset catalog hydration', async ({ page }) => {

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -891,13 +891,63 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           const result = await sequencesApi.update(projectId, sequenceId, latestTimeline, currentVersion)
           set((state) => ({
             currentSequence: state.currentSequence?.id === sequenceId
-              ? { ...state.currentSequence, version: result.version, duration_ms: result.duration_ms }
+              ? {
+                  ...state.currentSequence,
+                  version: result.version,
+                  duration_ms: result.duration_ms,
+                  updated_at: result.updated_at,
+                  locked_by: result.locked_by,
+                  lock_holder_name: result.lock_holder_name,
+                  locked_at: result.locked_at,
+                }
               : state.currentSequence,
           }))
           return // Success
         } catch (error) {
-          const axiosError = error as { response?: { status?: number; data?: { detail?: { code?: string; server_version?: number } } } }
-          if (axiosError.response?.status === 409 && axiosError.response?.data?.detail?.code === 'CONCURRENT_MODIFICATION') {
+          const axiosError = error as {
+            response?: {
+              status?: number
+              data?: {
+                detail?: string | { code?: string; message?: string; server_version?: number }
+              }
+            }
+          }
+          const detail = axiosError.response?.data?.detail
+          const detailMessage = typeof detail === 'string' ? detail : detail?.message
+          const detailCode = typeof detail === 'object' ? detail?.code : undefined
+          const serverVersion = typeof detail === 'object' ? detail?.server_version : undefined
+
+          if (axiosError.response?.status === 403 && detailMessage?.includes('not locked by you')) {
+            if (attempt < MAX_RETRIES) {
+              console.warn(`[saveSequence] Save rejected without lock, attempting to re-acquire (${attempt + 1}/${MAX_RETRIES})...`)
+              const lockState = await sequencesApi.lock(projectId, sequenceId)
+              set((state) => ({
+                currentSequence: state.currentSequence?.id === sequenceId
+                  ? {
+                      ...state.currentSequence,
+                      locked_by: lockState.locked_by,
+                      lock_holder_name: lockState.lock_holder_name,
+                      locked_at: lockState.locked_at,
+                    }
+                  : state.currentSequence,
+              }))
+
+              if (!lockState.locked) {
+                get().setEditToken(null)
+                throw new Error(lockState.lock_holder_name
+                  ? `Sequence is locked by ${lockState.lock_holder_name}.`
+                  : 'Sequence lock could not be re-acquired.')
+              }
+
+              if (lockState.edit_token) {
+                get().setEditToken(lockState.edit_token)
+              }
+              await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)))
+              continue
+            }
+          }
+
+          if (axiosError.response?.status === 409 && detailCode === 'CONCURRENT_MODIFICATION') {
             if (attempt < MAX_RETRIES) {
               // Fetch latest sequence to get the current server version, then retry
               console.warn(`[saveSequence] 409 conflict, retrying (${attempt + 1}/${MAX_RETRIES})...`)
@@ -923,7 +973,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
               conflictState: {
                 isConflicting: true,
                 localTimeline: latestTimeline,
-                serverVersion: axiosError.response.data.detail.server_version ?? null,
+                serverVersion: serverVersion ?? null,
               }
             })
             return


### PR DESCRIPTION
## Summary
- retry sequence save after a `403 Sequence is not locked by you` response by re-acquiring the lock and updating the edit token in the client store
- keep current sequence metadata in sync after successful save / re-lock so the editor state reflects the latest lock holder and timestamps
- add a Playwright regression that forces the first save to fail with a stale-lock `403` and verifies the editor recovers without surfacing the persistent save-failed banner

## Self-Review
- Self-review completed
- Diff is limited to the sequence save path and one focused editor regression test

## Verification
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/eslint src/store/projectStore.ts e2e/editor-critical-path.spec.ts`
- `npm run build`
- `npx playwright test e2e/editor-critical-path.spec.ts --grep "recovers sequence save after a stale lock rejects the first save|adds an asset clip, edits it, and keeps the change after reload"`

## Behavior Verified
- If the first sequence save fails with `403 Sequence is not locked by you`, the client re-locks and retries the save instead of leaving the editor in a persistent save-failed state
- The regression path still persists the timeline update after the retry succeeds
- The existing asset-add/edit/reload critical path still passes after the save recovery change

## Residual Risks
- Verification used the mocked editor flow rather than a live multi-tab backend race
- Recovery depends on the backend lock endpoint remaining available when the stale-lock save failure occurs

Closes #92