### PR TITLE
Fix audio drops onto empty tracks

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -4,7 +4,7 @@ import type { Asset } from '../src/api/assets'
 import { getArrowHeadLength, getArrowShapePath } from '../src/components/editor/shapeGeometry'
 import type { AudioTrack, Clip, TimelineData } from '../src/store/projectStore'
 import { bootstrapMockEditorPage } from './helpers/editorMockServer'
-import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
+import { dragAssetToAudioTrack, dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
 
 async function measureCanvasInkHeight(locator: Locator) {
   return locator.evaluate((element: HTMLCanvasElement) => {
@@ -70,6 +70,186 @@ test.describe('Editor Critical Path', () => {
     await expect(clipLocator).toHaveCount(1)
     await clipLocator.first().click()
     await expect(page.getByTestId('video-scale-input')).toHaveValue('150')
+  })
+
+  test('drops an audio asset onto an empty track at the hovered snapped time', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAsset: Asset = {
+      id: 'asset-audio-empty-track-drop',
+      project_id: mock.projectId,
+      name: 'Voice Line',
+      type: 'audio',
+      subtype: 'mock',
+      storage_key: 'mock/voice-line.wav',
+      storage_url: 'https://example.com/voice-line.wav',
+      thumbnail_url: null,
+      duration_ms: 2000,
+      width: null,
+      height: null,
+      file_size: 4096,
+      mime_type: 'audio/wav',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+
+    const sourceTrack: AudioTrack = {
+      id: 'track-source',
+      name: 'Narration 1',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [
+        {
+          id: 'audio-source-clip',
+          asset_id: audioAsset.id,
+          start_ms: 5000,
+          duration_ms: 2000,
+          in_point_ms: 0,
+          out_point_ms: 2000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+        },
+      ],
+    }
+
+    const emptyTrack: AudioTrack = {
+      id: 'track-empty',
+      name: 'Narration 2',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [],
+    }
+
+    mock.assetsByProject[mock.projectId].push(audioAsset)
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [sourceTrack, emptyTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 12000
+    mock.projectDetails[mock.projectId].duration_ms = 12000
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = JSON.parse(JSON.stringify([sourceTrack, emptyTrack]))
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 12000
+    mock.sequences[mock.sequenceId].duration_ms = 12000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await expect(page.getByTestId(`asset-item-${audioAsset.id}`)).toBeVisible()
+    await dragAssetToAudioTrack(page, {
+      assetId: audioAsset.id,
+      trackId: 'track-empty',
+      offsetX: 67,
+    })
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const updatedEmptyTrack = mock.calls.sequenceUpdates[0].timelineData.audio_tracks.find(
+      (track) => track.id === 'track-empty'
+    )
+
+    expect(updatedEmptyTrack?.clips).toHaveLength(1)
+    expect(updatedEmptyTrack?.clips[0].start_ms).toBe(7000)
+    expect(updatedEmptyTrack?.clips[0].duration_ms).toBe(2000)
+  })
+
+  test('moves an existing audio clip onto an empty track without losing it', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAsset: Asset = {
+      id: 'asset-audio-cross-track',
+      project_id: mock.projectId,
+      name: 'Cross Track Voice',
+      type: 'audio',
+      subtype: 'mock',
+      storage_key: 'mock/cross-track.wav',
+      storage_url: 'https://example.com/cross-track.wav',
+      thumbnail_url: null,
+      duration_ms: 2000,
+      width: null,
+      height: null,
+      file_size: 4096,
+      mime_type: 'audio/wav',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+
+    const sourceTrack: AudioTrack = {
+      id: 'track-cross-source',
+      name: 'Narration 1',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [
+        {
+          id: 'audio-cross-source-clip',
+          asset_id: audioAsset.id,
+          start_ms: 5000,
+          duration_ms: 2000,
+          in_point_ms: 0,
+          out_point_ms: 2000,
+          volume: 1,
+          fade_in_ms: 0,
+          fade_out_ms: 0,
+        },
+      ],
+    }
+
+    const emptyTrack: AudioTrack = {
+      id: 'track-cross-empty',
+      name: 'Narration 2',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [],
+    }
+
+    mock.assetsByProject[mock.projectId].push(audioAsset)
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [sourceTrack, emptyTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 12000
+    mock.projectDetails[mock.projectId].duration_ms = 12000
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = JSON.parse(JSON.stringify([sourceTrack, emptyTrack]))
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 12000
+    mock.sequences[mock.sequenceId].duration_ms = 12000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const clip = page.getByTestId('timeline-audio-clip-audio-cross-source-clip')
+    const clipBox = await clip.boundingBox()
+    const targetTrack = page.getByTestId('timeline-audio-track-row-track-cross-empty')
+    const targetTrackBox = await targetTrack.boundingBox()
+
+    expect(clipBox).toBeTruthy()
+    expect(targetTrackBox).toBeTruthy()
+
+    await page.mouse.move(clipBox!.x + clipBox!.width / 2, clipBox!.y + clipBox!.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(
+      clipBox!.x + clipBox!.width / 2 + 30,
+      targetTrackBox!.y + targetTrackBox!.height / 2,
+      { steps: 10 }
+    )
+    await page.mouse.up()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const updatedSourceTrack = mock.calls.sequenceUpdates[0].timelineData.audio_tracks.find(
+      (track) => track.id === 'track-cross-source'
+    )
+    const updatedEmptyTrack = mock.calls.sequenceUpdates[0].timelineData.audio_tracks.find(
+      (track) => track.id === 'track-cross-empty'
+    )
+
+    expect(updatedSourceTrack?.clips).toHaveLength(0)
+    expect(updatedEmptyTrack?.clips).toHaveLength(1)
+    expect(updatedEmptyTrack?.clips[0].id).toBe('audio-cross-source-clip')
+    expect(updatedEmptyTrack?.clips[0].start_ms).toBeGreaterThan(5000)
   })
 
   test('recovers sequence save after a stale lock rejects the first save', async ({ page }) => {

--- a/frontend/e2e/helpers/editorPage.ts
+++ b/frontend/e2e/helpers/editorPage.ts
@@ -38,3 +38,34 @@ export async function dragAssetToVideoLayer(
     clientY: layerBox.y + layerBox.height / 2,
   })
 }
+
+export async function dragAssetToAudioTrack(
+  page: Page,
+  options: {
+    assetId: string
+    trackId: string
+    offsetX?: number
+  }
+) {
+  const asset = page.getByTestId(`asset-item-${options.assetId}`)
+  const track = page.getByTestId(`timeline-audio-track-row-${options.trackId}`)
+  const trackBox = await track.boundingBox()
+
+  if (!trackBox) {
+    throw new Error(`Could not resolve bounds for track ${options.trackId}`)
+  }
+
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer())
+
+  await asset.dispatchEvent('dragstart', { dataTransfer })
+  await track.dispatchEvent('dragover', {
+    dataTransfer,
+    clientX: trackBox.x + (options.offsetX ?? 180),
+    clientY: trackBox.y + trackBox.height / 2,
+  })
+  await track.dispatchEvent('drop', {
+    dataTransfer,
+    clientX: trackBox.x + (options.offsetX ?? 180),
+    clientY: trackBox.y + trackBox.height / 2,
+  })
+}

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -202,6 +202,11 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     timeMs: number
     durationMs: number
   } | null>(null)
+  const [audioDropPreview, setAudioDropPreview] = useState<{
+    trackId: string
+    timeMs: number
+    durationMs: number
+  } | null>(null)
   const [snapLineMs, setSnapLineMs] = useState<number | null>(null) // Snap line position in ms
   const [isSnapEnabled, setIsSnapEnabled] = useState(true) // Snap on/off state
   const [isDraggingPlayhead, setIsDraggingPlayhead] = useState(false)
@@ -2463,14 +2468,95 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     return timeline.groups?.find(g => g.id === groupId)
   }, [timeline.groups])
 
+  const calculateAudioDropPlacement = useCallback((
+    trackId: string,
+    clientX: number,
+    durationMs: number
+  ): { timeMs: number; snapLineMs: number | null } | null => {
+    const trackEl = trackRefs.current[trackId]
+    if (!trackEl) return null
+
+    const rect = trackEl.getBoundingClientRect()
+    const offsetX = clientX - rect.left + (tracksScrollRef.current?.scrollLeft || 0)
+    let dropTimeMs = Math.max(0, Math.round((offsetX / pixelsPerSecond) * 1000))
+    let snappedTimeMs: number | null = null
+    let snapLinePosition: number | null = null
+
+    if (isSnapEnabled) {
+      const snapPoints = getSnapPoints(new Set())
+      const snappedStart = findNearestSnapPoint(dropTimeMs, snapPoints, SNAP_THRESHOLD_MS)
+      const snappedEnd = findNearestSnapPoint(dropTimeMs + durationMs, snapPoints, SNAP_THRESHOLD_MS)
+
+      if (snappedStart !== null) {
+        snappedTimeMs = snappedStart
+        snapLinePosition = snappedStart
+      } else if (snappedEnd !== null) {
+        snappedTimeMs = snappedEnd - durationMs
+        snapLinePosition = snappedEnd
+      }
+    }
+
+    if (snappedTimeMs !== null) {
+      dropTimeMs = snappedTimeMs
+    }
+
+    return {
+      timeMs: dropTimeMs,
+      snapLineMs: snapLinePosition,
+    }
+  }, [findNearestSnapPoint, getSnapPoints, isSnapEnabled, pixelsPerSecond, trackRefs])
+
+  const getDraggedAudioDurationMs = useCallback((e: React.DragEvent): number | null => {
+    const assetId = e.dataTransfer.types.includes('application/x-asset-id')
+      ? e.dataTransfer.getData('application/x-asset-id')
+      : null
+    const assetType = e.dataTransfer.getData('application/x-asset-type')
+
+    if (assetId && assetType === 'audio') {
+      return assets.find(a => a.id === assetId)?.duration_ms || 5000
+    }
+
+    const hasAudioFile = Array.from(e.dataTransfer.items ?? []).some(
+      (item) => item.kind === 'file' && item.type.startsWith('audio/')
+    )
+    if (hasAudioFile || e.dataTransfer.types.includes('Files')) {
+      return 5000
+    }
+
+    return null
+  }, [assets])
+
   const handleDragOver = useCallback((e: React.DragEvent, trackId: string) => {
     e.preventDefault()
     e.dataTransfer.dropEffect = 'copy'
     setDragOverTrack(trackId)
-  }, [])
+
+    const durationMs = getDraggedAudioDurationMs(e)
+    if (durationMs === null) {
+      setAudioDropPreview(null)
+      setSnapLineMs(null)
+      return
+    }
+
+    const placement = calculateAudioDropPlacement(trackId, e.clientX, durationMs)
+    if (!placement) {
+      setAudioDropPreview(null)
+      setSnapLineMs(null)
+      return
+    }
+
+    setAudioDropPreview({
+      trackId,
+      timeMs: placement.timeMs,
+      durationMs,
+    })
+    setSnapLineMs(placement.snapLineMs)
+  }, [calculateAudioDropPlacement, getDraggedAudioDurationMs])
 
   const handleDragLeave = useCallback(() => {
     setDragOverTrack(null)
+    setAudioDropPreview(null)
+    setSnapLineMs(null)
   }, [])
 
   // Helper to determine asset type from MIME type
@@ -2511,6 +2597,8 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
   const handleDrop = useCallback(async (e: React.DragEvent, trackId: string) => {
     e.preventDefault()
     setDragOverTrack(null)
+    setAudioDropPreview(null)
+    setSnapLineMs(null)
     console.log('[handleDrop] START - trackId:', trackId)
 
     // Check for file drop from desktop
@@ -2547,12 +2635,10 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
         return
       }
 
-      // Snap to end of last clip in the track (or 0 if empty)
-      const lastClipEndMs = track.clips.length > 0
-        ? Math.max(...track.clips.map(c => c.start_ms + c.duration_ms))
-        : 0
-      const startMs = lastClipEndMs
-      console.log('[handleDrop] Snapping to end of last clip:', startMs)
+      const startMs = audioDropPreview?.trackId === trackId
+        ? audioDropPreview.timeMs
+        : (calculateAudioDropPlacement(trackId, e.clientX, uploadedAsset.duration_ms || 5000)?.timeMs ?? 0)
+      console.log('[handleDrop] Using drop position:', startMs)
 
       // Create new clip
       const newClip: AudioClip = {
@@ -2611,12 +2697,10 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
       return
     }
 
-    // Snap to end of last clip in the track (or 0 if empty)
-    const lastClipEndMs = track.clips.length > 0
-      ? Math.max(...track.clips.map(c => c.start_ms + c.duration_ms))
-      : 0
-    const startMs = lastClipEndMs
-    console.log('[handleDrop] Snapping to end of last clip:', startMs)
+    const startMs = audioDropPreview?.trackId === trackId
+      ? audioDropPreview.timeMs
+      : (calculateAudioDropPlacement(trackId, e.clientX, asset.duration_ms || 5000)?.timeMs ?? 0)
+    console.log('[handleDrop] Using drop position:', startMs)
 
     // Create new clip
     const newClip: AudioClip = {
@@ -2649,7 +2733,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
       duration_ms: newDuration,
     }, i18n.t('editor:undo.audioClipAdd'))
     console.log('[handleDrop] DONE')
-  }, [assets, timeline, projectId, updateTimeline, uploadFileToAsset, getAssetTypeFromMime, t])
+  }, [assets, audioDropPreview, calculateAudioDropPlacement, timeline, projectId, updateTimeline, uploadFileToAsset, getAssetTypeFromMime, t])
 
   // Video layer drag handlers
   const handleLayerDragOver = useCallback((e: React.DragEvent, layerId: string) => {
@@ -5846,6 +5930,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
               handleVolumeKeyframeRemove={handleVolumeKeyframeRemove}
               getAssetName={getAssetName}
               dragOverTrack={dragOverTrack}
+              assetDropPreview={audioDropPreview}
               handleDragOver={handleDragOver}
               handleDragLeave={handleDragLeave}
               handleDrop={handleDrop}
@@ -5918,7 +6003,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
             <div
               className={`absolute top-0 bottom-0 z-[15] transition-opacity ${
                 isPlaying ? 'opacity-100' : 'opacity-70'
-              } ${dragOverLayer || dropPreview ? 'pointer-events-none' : 'pointer-events-auto'} ${isDraggingPlayhead ? 'cursor-grabbing' : 'cursor-ew-resize'}`}
+              } ${dragOverLayer || dropPreview || dragOverTrack || audioDropPreview ? 'pointer-events-none' : 'pointer-events-auto'} ${isDraggingPlayhead ? 'cursor-grabbing' : 'cursor-ew-resize'}`}
               style={{
                 left: (currentTimeMs / 1000) * pixelsPerSecond - 8,
                 width: 16,

--- a/frontend/src/components/editor/timeline/AudioTracks.tsx
+++ b/frontend/src/components/editor/timeline/AudioTracks.tsx
@@ -39,6 +39,11 @@ interface AudioTracksProps {
   handleVolumeKeyframeRemove: (trackId: string, clipId: string, index: number) => void
   getAssetName: (assetId: string) => string
   dragOverTrack: string | null
+  assetDropPreview: {
+    trackId: string
+    timeMs: number
+    durationMs: number
+  } | null
   handleDragOver: (e: React.DragEvent, trackId: string) => void
   handleDragLeave: (e: React.DragEvent) => void
   handleDrop: (e: React.DragEvent, trackId: string) => void
@@ -70,6 +75,7 @@ function AudioTracks({
   handleVolumeKeyframeRemove,
   getAssetName,
   dragOverTrack,
+  assetDropPreview,
   handleDragOver,
   handleDragLeave,
   handleDrop,
@@ -301,6 +307,16 @@ function AudioTracks({
                 left: (crossTrackDropPreview.timeMs / 1000) * pixelsPerSecond,
                 width: Math.max((crossTrackDropPreview.durationMs / 1000) * pixelsPerSecond, 2),
                 backgroundColor: 'rgba(59, 130, 246, 0.15)',
+              }}
+            />
+          )}
+          {assetDropPreview && assetDropPreview.trackId === track.id && (
+            <div
+              className="absolute top-1 bottom-1 rounded pointer-events-none z-[4] border-2 border-dashed border-green-400"
+              style={{
+                left: (assetDropPreview.timeMs / 1000) * pixelsPerSecond,
+                width: Math.max((assetDropPreview.durationMs / 1000) * pixelsPerSecond, 40),
+                backgroundColor: 'rgba(74, 222, 128, 0.15)',
               }}
             />
           )}


### PR DESCRIPTION
## Summary
- use hovered X position and timeline snap rules when dropping audio assets onto audio tracks
- render an audio-track drop preview and ignore the playhead hit area during audio asset drags
- add Playwright coverage for empty-track asset drop and existing audio clip cross-track move

## Self-review
- completed

## Verification
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/editor-critical-path.spec.ts -g "drops an audio asset onto an empty track at the hovered snapped time|moves an existing audio clip onto an empty track without losing it"`

## Playwright Cases
- `Editor Critical Path > drops an audio asset onto an empty track at the hovered snapped time`
- `Editor Critical Path > moves an existing audio clip onto an empty track without losing it`

## User-visible verification
- Verified the issue symptom at the behavior level via Playwright: dropping an audio asset onto an empty track now lands at the hovered snapped time instead of `0ms`, and moving an existing audio clip onto an empty track no longer loses the clip.

## Residual Risks
- File drags from the desktop use a fallback preview duration before upload metadata is known, so preview width can differ from the final clip width until drop completes.

Closes #105