### PR TITLE
Fix audio drop placement after horizontal scroll

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -252,6 +252,86 @@ test.describe('Editor Critical Path', () => {
     expect(updatedEmptyTrack?.clips[0].start_ms).toBeGreaterThan(5000)
   })
 
+  test('keeps audio asset drop placement aligned with the cursor after horizontal scroll', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const audioAsset: Asset = {
+      id: 'asset-audio-scrolled-drop',
+      project_id: mock.projectId,
+      name: 'Scrolled Voice',
+      type: 'audio',
+      subtype: 'mock',
+      storage_key: 'mock/scrolled-drop.wav',
+      storage_url: 'https://example.com/scrolled-drop.wav',
+      thumbnail_url: null,
+      duration_ms: 2000,
+      width: null,
+      height: null,
+      file_size: 4096,
+      mime_type: 'audio/wav',
+      chroma_key_color: null,
+      hash: null,
+      folder_id: null,
+      created_at: '2026-03-07T00:00:00.000Z',
+      metadata: null,
+    }
+
+    const emptyTrack: AudioTrack = {
+      id: 'track-scroll-empty',
+      name: 'Narration 1',
+      type: 'narration',
+      volume: 1,
+      muted: false,
+      visible: true,
+      clips: [],
+    }
+
+    mock.assetsByProject[mock.projectId].push(audioAsset)
+    mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [emptyTrack]
+    mock.projectDetails[mock.projectId].timeline_data.duration_ms = 120000
+    mock.projectDetails[mock.projectId].duration_ms = 120000
+    mock.sequences[mock.sequenceId].timeline_data.audio_tracks = JSON.parse(JSON.stringify([emptyTrack]))
+    mock.sequences[mock.sequenceId].timeline_data.duration_ms = 120000
+    mock.sequences[mock.sequenceId].duration_ms = 120000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const scrollArea = page.getByTestId('timeline-area').locator('div.overflow-x-scroll').first()
+    await scrollArea.evaluate((element: HTMLDivElement) => {
+      element.scrollLeft = 400
+      element.dispatchEvent(new Event('scroll'))
+    })
+    await expect.poll(() => scrollArea.evaluate((element: HTMLDivElement) => element.scrollLeft)).toBe(400)
+
+    await expect(page.getByTestId(`asset-item-${audioAsset.id}`)).toBeVisible()
+    const asset = page.getByTestId(`asset-item-${audioAsset.id}`)
+    const targetTrack = page.getByTestId('timeline-audio-track-row-track-scroll-empty')
+    const scrollAreaBox = await scrollArea.boundingBox()
+
+    expect(scrollAreaBox).toBeTruthy()
+
+    const dataTransfer = await page.evaluateHandle(() => new DataTransfer())
+    await asset.dispatchEvent('dragstart', { dataTransfer })
+    await targetTrack.dispatchEvent('dragover', {
+      dataTransfer,
+      clientX: scrollAreaBox!.x + 80,
+      clientY: scrollAreaBox!.y + 160,
+    })
+    await targetTrack.dispatchEvent('drop', {
+      dataTransfer,
+      clientX: scrollAreaBox!.x + 80,
+      clientY: scrollAreaBox!.y + 160,
+    })
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const updatedTrack = mock.calls.sequenceUpdates[0].timelineData.audio_tracks.find(
+      (track) => track.id === 'track-scroll-empty'
+    )
+
+    expect(updatedTrack?.clips).toHaveLength(1)
+    expect(updatedTrack?.clips[0].start_ms).toBe(48000)
+  })
+
   test('recovers sequence save after a stale lock rejects the first save', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
     let rejectedSaveCount = 0

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -2477,7 +2477,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     if (!trackEl) return null
 
     const rect = trackEl.getBoundingClientRect()
-    const offsetX = clientX - rect.left + (tracksScrollRef.current?.scrollLeft || 0)
+    const offsetX = clientX - rect.left
     let dropTimeMs = Math.max(0, Math.round((offsetX / pixelsPerSecond) * 1000))
     let snappedTimeMs: number | null = null
     let snapLinePosition: number | null = null
@@ -2749,7 +2749,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
 
     if (layerEl) {
       const rect = layerEl.getBoundingClientRect()
-      const offsetX = e.clientX - rect.left + (tracksScrollRef.current?.scrollLeft || 0)
+      const offsetX = e.clientX - rect.left
       let dropTimeMs = Math.max(0, Math.round((offsetX / pixelsPerSecond) * 1000))
 
       // Get asset duration for preview width (default to 5000ms if unknown)
@@ -2880,7 +2880,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
       const fileLayerEl = layerRefs.current[fileTargetLayerId]
       if (fileLayerEl) {
         const rect = fileLayerEl.getBoundingClientRect()
-        const offsetX = e.clientX - rect.left + (tracksScrollRef.current?.scrollLeft || 0)
+        const offsetX = e.clientX - rect.left
         fileStartMs = Math.max(0, Math.round((offsetX / pixelsPerSecond) * 1000))
         console.log('[handleLayerDrop] Drop position calculated:', fileStartMs, 'ms')
       }
@@ -3068,7 +3068,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
       const layerEl = layerRefs.current[targetLayerId]
       if (layerEl) {
         const rect = layerEl.getBoundingClientRect()
-        const offsetX = e.clientX - rect.left + (tracksScrollRef.current?.scrollLeft || 0)
+        const offsetX = e.clientX - rect.left
         startMs = Math.max(0, Math.round((offsetX / pixelsPerSecond) * 1000))
         console.log('[handleLayerDrop] Drop position calculated:', startMs, 'ms')
       }


### PR DESCRIPTION
## Summary
- fix audio drop placement on scrolled timelines by removing the extra scrollLeft offset
- add browser-level regression coverage for drop placement after horizontal scroll
- continue issue #105 because the original fix was incomplete after scroll

## Verification
- implemented and validated on branch before PR handoff
- follow-up commit: `194070a`

Closes #105