### PR TITLE
fix(render): normalize pixel format to yuva420p for all clips (#107)

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1275,6 +1275,7 @@ class RenderPipeline:
                             duration_ms,
                             export_start_ms,
                             export_end_ms,
+                            is_still_image=True,
                         )
                         filter_parts.append(shape_filter)
                         current_output = f"layer{input_idx}"
@@ -1296,6 +1297,7 @@ class RenderPipeline:
                             duration_ms,
                             export_start_ms,
                             export_end_ms,
+                            is_still_image=True,
                         )
                         filter_parts.append(text_filter)
                         current_output = f"layer{input_idx}"
@@ -1310,7 +1312,8 @@ class RenderPipeline:
                 asset_path = assets[asset_id]
                 # Static images need -loop 1 to generate continuous frames
                 ext = asset_path.rsplit(".", 1)[-1].lower() if "." in asset_path else ""
-                if ext in ("png", "jpg", "jpeg", "bmp", "webp", "tiff", "gif"):
+                is_image = ext in ("png", "jpg", "jpeg", "bmp", "webp", "tiff", "gif")
+                if is_image:
                     inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", asset_path])
                 else:
                     inputs.extend(["-i", asset_path])
@@ -1323,6 +1326,7 @@ class RenderPipeline:
                     duration_ms,
                     export_start_ms,
                     export_end_ms,
+                    is_still_image=is_image,
                 )
                 filter_parts.append(clip_filter)
                 current_output = f"layer{input_idx}"
@@ -1454,12 +1458,14 @@ class RenderPipeline:
         total_duration_ms: int,
         export_start_ms: int = 0,
         export_end_ms: int | None = None,
+        is_still_image: bool = False,
     ) -> str:
         """Build FFmpeg filter for a single clip.
 
         Args:
             export_start_ms: Start of export range in ms (clips are offset relative to this)
             export_end_ms: End of export range in ms (clips extending beyond are trimmed)
+            is_still_image: True for image/shape/text inputs (needs format normalization)
         """
         if export_end_ms is None:
             export_end_ms = total_duration_ms + export_start_ms
@@ -1542,6 +1548,13 @@ class RenderPipeline:
             clip_filters.append(f"setpts=PTS-STARTPTS+{start_time_offset}/TB")
         clip_elapsed_expr = f"(t-{start_time_offset:.6f})"
         clip_elapsed_alpha_expr = f"(T-{start_time_offset:.6f})"
+
+        # Normalize pixel format after trim+setpts.
+        # Still images may have exotic formats (pal8, gray, rgb24) and videos
+        # may use yuvj420p (JPEG full range) or other variants. Both can cause
+        # silent overlay failures resulting in black frames.
+        # yuva420p ensures alpha channel support for chroma key, opacity, etc.
+        clip_filters.append("format=yuva420p")
 
         # Freeze frame extension (applied after setpts, before crop/scale)
         freeze_frame_ms = clip.get("freeze_frame_ms", 0)


### PR DESCRIPTION
## Summary
- FFmpegレンダリングで画像クリップが真っ黒になる問題を修正
- 全クリップの`trim`+`setpts`直後に`format=yuva420p`を追加し、overlayフィルタとのピクセルフォーマット互換性を保証
- 静止画（pal8, gray, rgb24等）と動画（yuvj420p等）の両方で発生しうるformat不整合を解消

## Root Cause
背景ストリーム(`color=c=black`)は`yuv420p`だが、入力クリップのフォーマットは多様（PNG=rgba/pal8、JPEG=yuvj420p等）。フォーマット不整合時にFFmpegのoverlayフィルタが無言で失敗し、黒フレームが出力されていた。

## Changes
- `_build_clip_filter()`に`is_still_image`パラメータ追加（ログ用途）
- trim+setpts直後に`format=yuva420p`を全クリップに適用
- shape、text、画像アセットの呼び出し箇所で`is_still_image=True`を渡す

## Test plan
- [ ] 画像クリップ（PNG/JPG）を含むシーケンスのエクスポートで画像が正しく表示されること
- [ ] 動画クリップのエクスポートが引き続き正常に動作すること
- [ ] クロマキー付き動画のエクスポートが正常に動作すること
- [ ] freeze frame付きクリップのエクスポートで末端延長が正常に動作すること
- [ ] テキスト/シェイプクリップのレンダリングが正常に動作すること
- [ ] `pytest tests/test_render_pipeline.py` 全パス ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)