### PR TITLE
ci: cache Playwright browsers in frontend checks

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,14 +30,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+
       - name: Run ESLint
         run: npm run lint
 
       - name: Build
         run: npm run build
 
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
 
       - name: Run Playwright tests
         run: npm run test

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 
 ---
 
+## ✅ CI
+
+- Pull requests run the `PR Check` workflow against `main`.
+- Frontend Checks cache Playwright browser binaries under `~/.cache/ms-playwright`, keyed by `frontend/package-lock.json`, so Chromium is only downloaded again when the Playwright dependency set changes.
+- Linux browser dependencies are still installed during CI because they are not part of the cached browser bundle.
+
+---
+
 ## 🛠️ Tech Stack
 
 | Layer | Technology | Purpose |


### PR DESCRIPTION
## Summary
- cache Playwright browser binaries in `Frontend Checks` using `actions/cache`
- keep installing Linux browser dependencies on every run, but skip Chromium download when the cache is warm
- document the new CI behavior in `README.md`

## Self-Review
- completed

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-check.yml'); puts 'YAML OK'"`
- `git diff --check`

## Playwright Coverage
- unchanged: `npm run test` in `frontend` still runs the existing Playwright suite in CI
- no Playwright spec files were modified for this workflow-only change

## Manual Verification
- none; this change only affects GitHub Actions workflow behavior

## Residual Risks
- browser cache effectiveness needs confirmation from the first PR run on GitHub-hosted runners
- Linux system dependencies are still installed per run because they are outside the cached browser bundle

Closes #113
