### PR TITLE
fix(render): clamp trim in_point when export falls within freeze portion (#107)

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1482,6 +1482,7 @@ class RenderPipeline:
         out_point_ms = clip.get("out_point_ms")
         duration_ms = clip.get("duration_ms", 0)
         start_ms = clip.get("start_ms", 0)
+        freeze_frame_ms = clip.get("freeze_frame_ms", 0)
 
         # Validate and calculate duration_ms if needed
         if duration_ms <= 0:
@@ -1508,7 +1509,7 @@ class RenderPipeline:
 
         # Adjust in_point and out_point based on export range
         # If clip starts before export_start_ms, we need to advance the in_point
-        clip_end_ms = start_ms + duration_ms + clip.get("freeze_frame_ms", 0)
+        clip_end_ms = start_ms + duration_ms + freeze_frame_ms
         adjusted_in_point_ms = in_point_ms
         adjusted_out_point_ms = out_point_ms
 
@@ -1516,15 +1517,25 @@ class RenderPipeline:
             # Clip starts before export range - advance in_point to skip the beginning
             offset_ms = export_start_ms - start_ms
             adjusted_in_point_ms = in_point_ms + offset_ms
-            logger.info(
-                f"[CLIP DEBUG] Clip starts before export range, advancing in_point by {offset_ms}ms"
-            )
+            # When export range falls within the freeze portion, the adjusted
+            # in_point can exceed out_point (there is no more source content).
+            # Clamp to just before out_point so trim captures the last frame
+            # that tpad will then clone for the freeze duration.
+            if adjusted_in_point_ms >= out_point_ms and freeze_frame_ms > 0:
+                adjusted_in_point_ms = max(in_point_ms, out_point_ms - 1)
+                logger.info(
+                    f"[CLIP DEBUG] Export range within freeze portion, clamping in_point to {adjusted_in_point_ms}ms (last frame)"
+                )
+            else:
+                logger.info(
+                    f"[CLIP DEBUG] Clip starts before export range, advancing in_point by {offset_ms}ms"
+                )
 
         if clip_end_ms > export_end_ms:
             # Clip extends beyond export range - reduce out_point
             trim_end_ms = clip_end_ms - export_end_ms
             # First trim from freeze frame portion, then from source video
-            freeze_trim = min(trim_end_ms, clip.get("freeze_frame_ms", 0))
+            freeze_trim = min(trim_end_ms, freeze_frame_ms)
             remaining_trim = trim_end_ms - freeze_trim
             adjusted_out_point_ms = out_point_ms - remaining_trim
             logger.info(
@@ -1557,7 +1568,6 @@ class RenderPipeline:
         clip_filters.append("format=yuva420p")
 
         # Freeze frame extension (applied after setpts, before crop/scale)
-        freeze_frame_ms = clip.get("freeze_frame_ms", 0)
         if freeze_frame_ms > 0:
             clip_filters.append(f"tpad=stop_mode=clone:stop_duration={freeze_frame_ms / 1000}")
 
@@ -1773,7 +1783,7 @@ class RenderPipeline:
         # Adjust timing relative to export_start_ms
         # Original clip timing is in absolute timeline coordinates
         # We need to offset by export_start_ms to get the position in the exported video
-        clip_end_ms = start_ms + duration_ms + clip.get("freeze_frame_ms", 0)
+        clip_end_ms = start_ms + duration_ms + freeze_frame_ms
         adjusted_start_ms = max(0, start_ms - export_start_ms)
         adjusted_end_ms = min(total_duration_ms, clip_end_ms - export_start_ms)
 

--- a/backend/tests/test_render_pipeline.py
+++ b/backend/tests/test_render_pipeline.py
@@ -624,6 +624,19 @@ class TestRenderPipeline:
         assert "tpad=" in filter_complex_str, (
             "tpad filter missing — freeze frame extension not applied"
         )
+        # The trim filter must NOT have start > end (which produces zero frames).
+        # When export range is entirely within freeze, in_point must be clamped
+        # to just before out_point so at least one frame exists for tpad to clone.
+        import re
+
+        trim_match = re.search(r"trim=start=([\d.]+):end=([\d.]+)", filter_complex_str)
+        assert trim_match is not None, "trim filter not found in filter_complex"
+        trim_start = float(trim_match.group(1))
+        trim_end = float(trim_match.group(2))
+        assert trim_start < trim_end, (
+            f"trim start ({trim_start}) >= end ({trim_end}) — "
+            "export within freeze portion caused invalid trim range"
+        )
 
 
 class TestUndoableAction:


### PR DESCRIPTION
## Summary
- Export range がクリップの freeze-frame 部分に完全に含まれる場合、`adjusted_in_point` が `out_point` を超え、`trim=start=3.0:end=2.0` のような無効なフィルターが生成されて黒フレームになるバグを修正
- `out_point - 1ms` にクランプして tpad がクローンするフレームを最低1つ確保
- `freeze_frame_ms` を早期に変数化して散在する `clip.get()` を統一

## Files changed
- `backend/src/render/pipeline.py` — freeze portion クランプロジック追加、変数整理
- `backend/tests/test_render_pipeline.py` — trim start < end のリグレッションテスト追加

## Test plan
- [x] trim start < end アサーション追加（freeze-only overlap ケース）
- [ ] 対象 sequence (`動画3_セクション2-2`) で render 実行して黒フレームが出ないことを確認

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)