### PR TITLE
fix: frame_sampler preview parity with browser (#115)

### DIFF
--- a/backend/src/services/frame_sampler.py
+++ b/backend/src/services/frame_sampler.py
@@ -50,7 +50,8 @@ def _interpolate_transform_at(clip: dict[str, Any], time_ms: int) -> dict[str, A
         kf_t = kf.get("transform") or {}
         kf_o = kf.get("opacity")
         return {
-            "x": kf_t.get("x") or 0, "y": kf_t.get("y") or 0,
+            "x": kf_t.get("x") or 0,
+            "y": kf_t.get("y") or 0,
             "scale": kf_t.get("scale") if kf_t.get("scale") is not None else 1.0,
             "rotation": kf_t.get("rotation") or 0,
             "opacity": kf_o if kf_o is not None else base["opacity"],
@@ -82,27 +83,210 @@ def _calculate_fade_opacity(time_in_clip_ms, duration_ms, fade_in_ms, fade_out_m
     return max(0.0, min(1.0, mult))
 
 
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _get_clip_fade_durations_ms(clip: dict[str, Any]) -> tuple[int, int]:
+    effects = clip.get("effects") or {}
     ti = clip.get("transition_in") or {}
     to = clip.get("transition_out") or {}
-    fi = ti.get("duration_ms", 0) if ti.get("type") == "fade" else clip.get("fade_in_ms", 0)
-    fo = to.get("duration_ms", 0) if to.get("type") == "fade" else clip.get("fade_out_ms", 0)
+
+    if clip.get("shape"):
+        fade_in_sources = (
+            clip.get("fade_in_ms"),
+            effects.get("fade_in_ms"),
+            ti.get("duration_ms") if ti.get("type") == "fade" else None,
+        )
+        fade_out_sources = (
+            clip.get("fade_out_ms"),
+            effects.get("fade_out_ms"),
+            to.get("duration_ms") if to.get("type") == "fade" else None,
+        )
+    else:
+        fade_in_sources = (
+            effects.get("fade_in_ms"),
+            clip.get("fade_in_ms"),
+            ti.get("duration_ms") if ti.get("type") == "fade" else None,
+        )
+        fade_out_sources = (
+            effects.get("fade_out_ms"),
+            clip.get("fade_out_ms"),
+            to.get("duration_ms") if to.get("type") == "fade" else None,
+        )
+
+    fi = next((value for value in fade_in_sources if value is not None), 0)
+    fo = next((value for value in fade_out_sources if value is not None), 0)
     return max(0, int(fi or 0)), max(0, int(fo or 0))
 
 
-def _resolve_font(font_size: int):
-    """Load a CJK-capable font, trying multiple paths."""
+def _normalize_font_weight(value: Any) -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "bold":
+            return "bold"
+        if normalized == "normal":
+            return "normal"
+        parsed = _coerce_int(normalized, default=-1)
+        if parsed >= 0:
+            return "bold" if parsed >= 600 else "normal"
+    if isinstance(value, (int, float)):
+        return "bold" if value >= 600 else "normal"
+    return "normal"
+
+
+_FONT_CANDIDATES: dict[str, dict[str, list[str]]] = {
+    "sans": {
+        "normal": [
+            "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
+            "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "DejaVuSans.ttf",
+        ],
+        "bold": [
+            "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc",
+            "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
+            "DejaVuSans-Bold.ttf",
+            "DejaVuSans.ttf",
+        ],
+    },
+    "serif": {
+        "normal": [
+            "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc",
+            "/usr/share/fonts/opentype/noto/NotoSerifCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/noto/NotoSerifCJK-Regular.ttc",
+            "DejaVuSerif.ttf",
+            "DejaVuSans.ttf",
+        ],
+        "bold": [
+            "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc",
+            "/usr/share/fonts/opentype/noto/NotoSerifCJK-Bold.ttc",
+            "/usr/share/fonts/truetype/noto/NotoSerifCJK-Bold.ttc",
+            "DejaVuSerif-Bold.ttf",
+            "DejaVuSerif.ttf",
+            "DejaVuSans.ttf",
+        ],
+    },
+    "rounded": {
+        "normal": [
+            "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+            "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
+            "DejaVuSans.ttf",
+        ],
+        "bold": [
+            "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc",
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc",
+            "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc",
+            "DejaVuSans-Bold.ttf",
+            "DejaVuSans.ttf",
+        ],
+    },
+}
+
+_FONT_FAMILY_GROUPS = {
+    "Noto Sans JP": "sans",
+    "M PLUS 1p": "sans",
+    "Sawarabi Gothic": "sans",
+    "BIZ UDPGothic": "sans",
+    "Noto Serif JP": "serif",
+    "Sawarabi Mincho": "serif",
+    "Shippori Mincho": "serif",
+    "Kosugi Maru": "rounded",
+    "M PLUS Rounded 1c": "rounded",
+    "Zen Maru Gothic": "rounded",
+}
+
+
+def _resolve_font(font_size: int, font_family: Any = None, font_weight: Any = "normal"):
+    """Load a preview font close to the browser's selected family/weight."""
     from PIL import ImageFont
-    for path in [
-        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-        "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
-        "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
-    ]:
+
+    family = str(font_family or "Noto Sans JP").strip() or "Noto Sans JP"
+    family_group = _FONT_FAMILY_GROUPS.get(family, "sans")
+    weight = _normalize_font_weight(font_weight)
+    candidates = _FONT_CANDIDATES[family_group][weight]
+
+    if family_group != "sans":
+        fallback_candidates = _FONT_CANDIDATES["sans"][weight]
+        candidates = candidates + [path for path in fallback_candidates if path not in candidates]
+
+    for path in candidates:
         try:
             return ImageFont.truetype(path, font_size)
         except Exception:
             continue
     return ImageFont.load_default()
+
+
+def _get_text_bbox(
+    font: Any, text: str, stroke_width: int = 0
+) -> tuple[float, float, float, float]:
+    sample_text = text or " "
+    try:
+        bbox = font.getbbox(sample_text, stroke_width=stroke_width)
+    except TypeError:
+        bbox = font.getbbox(sample_text)
+    return tuple(float(value) for value in bbox)
+
+
+def _get_text_line_width(
+    font: Any,
+    text: str,
+    stroke_width: int = 0,
+    letter_spacing: float = 0.0,
+) -> float:
+    bbox_left, _, bbox_right, _ = _get_text_bbox(font, text, stroke_width=stroke_width)
+    extra_spacing = max(len(text) - 1, 0) * letter_spacing
+    return max(0.0, (bbox_right - bbox_left) + extra_spacing)
+
+
+def _measure_text_lines(
+    text: str,
+    font: Any,
+    font_size: int,
+    line_height: float,
+    stroke_width: int,
+    letter_spacing: float,
+) -> tuple[list[dict[str, float | str]], float]:
+    lines = text.split("\n") or [""]
+    metrics: list[dict[str, float | str]] = []
+    max_visual_height = 0.0
+
+    for line in lines:
+        bbox_left, bbox_top, bbox_right, bbox_bottom = _get_text_bbox(
+            font,
+            line,
+            stroke_width=stroke_width,
+        )
+        metrics.append(
+            {
+                "line": line,
+                "bbox_left": bbox_left,
+                "bbox_top": bbox_top,
+                "width": _get_text_line_width(
+                    font,
+                    line,
+                    stroke_width=stroke_width,
+                    letter_spacing=letter_spacing,
+                ),
+            }
+        )
+        max_visual_height = max(max_visual_height, bbox_bottom - bbox_top)
+
+    line_box_height = max(float(font_size) * line_height, max_visual_height, 1.0)
+    return metrics, line_box_height
 
 
 class FrameSampler:
@@ -499,7 +683,9 @@ class FrameSampler:
         # Rotation
         if abs(rotation) > 0.01:
             target_list.append("format=rgba")
-            target_list.append(f"rotate=({rotation})*PI/180:ow=hypot(iw,ih):oh=hypot(iw,ih):fillcolor=none")
+            target_list.append(
+                f"rotate=({rotation})*PI/180:ow=hypot(iw,ih):oh=hypot(iw,ih):fillcolor=none"
+            )
 
         # Opacity with fade
         if opacity < 1.0:
@@ -535,12 +721,16 @@ class FrameSampler:
                 sw = int(w * scale)
                 crop_offset_x_expr = str(int(sw * (crop_left - crop_right) / (2 * width_ratio)))
             elif width_ratio > 0:
-                crop_offset_x_expr = f"(overlay_w*{(crop_left - crop_right) / (2 * width_ratio):.6f})"
+                crop_offset_x_expr = (
+                    f"(overlay_w*{(crop_left - crop_right) / (2 * width_ratio):.6f})"
+                )
             if height_ratio > 0 and (w and h):
                 sh = int(h * scale)
                 crop_offset_y_expr = str(int(sh * (crop_top - crop_bottom) / (2 * height_ratio)))
             elif height_ratio > 0:
-                crop_offset_y_expr = f"(overlay_h*{(crop_top - crop_bottom) / (2 * height_ratio):.6f})"
+                crop_offset_y_expr = (
+                    f"(overlay_h*{(crop_top - crop_bottom) / (2 * height_ratio):.6f})"
+                )
         overlay_x = f"(main_w/2)+({int(x)})+({crop_offset_x_expr})-(overlay_w/2)"
         overlay_y = f"(main_h/2)+({int(y)})+({crop_offset_y_expr})-(overlay_h/2)"
 
@@ -614,45 +804,70 @@ class FrameSampler:
                     if filled and fill_rgba[3] > 0:
                         draw.ellipse([(0, 0), (rw - 1, rh - 1)], fill=fill_rgba)
                     if not filled or stroke_width > 0:
-                        draw.ellipse([(0, 0), (rw - 1, rh - 1)], outline=stroke_rgba, width=stroke_width)
+                        draw.ellipse(
+                            [(0, 0), (rw - 1, rh - 1)], outline=stroke_rgba, width=stroke_width
+                        )
                 else:
                     if filled and fill_rgba[3] > 0:
                         draw.rectangle([(0, 0), (rw - 1, rh - 1)], fill=fill_rgba)
                     if not filled or stroke_width > 0:
-                        draw.rectangle([(0, 0), (rw - 1, rh - 1)], outline=stroke_rgba, width=stroke_width)
+                        draw.rectangle(
+                            [(0, 0), (rw - 1, rh - 1)], outline=stroke_rgba, width=stroke_width
+                        )
 
             elif clip.get("text_content") is not None:
                 text = clip["text_content"]
                 text_style = clip.get("text_style") or {}
                 color = text_style.get("color") or "#ffffff"
                 r, g, b = _parse_hex_color(color, "ffffff")
-                font_size = int(text_style.get("fontSize") or 24)
-                stroke_width_text = int(text_style.get("strokeWidth") or 0)
+                font_family = text_style.get("fontFamily") or "Noto Sans JP"
+                font_size = _coerce_int(text_style.get("fontSize"), default=48)
+                font_weight = text_style.get("fontWeight") or "bold"
+                stroke_width_text = max(0, _coerce_int(text_style.get("strokeWidth"), default=2))
                 stroke_color_str = text_style.get("strokeColor") or "#000000"
                 s_r, s_g, s_b = _parse_hex_color(stroke_color_str, "000000")
-                line_height = float(text_style.get("lineHeight") or 1.4)
+                line_height = _coerce_float(text_style.get("lineHeight"), default=1.4)
+                letter_spacing = _coerce_float(text_style.get("letterSpacing"), default=0.0)
+                text_align = str(text_style.get("textAlign") or "center")
+                bg_color_str = text_style.get("backgroundColor") or "#000000"
+                bg_opacity = max(
+                    0.0,
+                    min(1.0, _coerce_float(text_style.get("backgroundOpacity"), default=0.4)),
+                )
+                has_bg = bg_color_str.lower() not in ("transparent", "none", "") and bg_opacity > 0
 
-                font = _resolve_font(font_size)
+                font = _resolve_font(font_size, font_family, font_weight)
 
                 # Auto-size if no explicit dimensions
                 if width <= 0 or height <= 0:
-                    bg_color_str = text_style.get("backgroundColor")
-                    bg_opacity = float(text_style.get("backgroundOpacity", 1.0))
-                    has_bg = bg_color_str and bg_color_str.lower() not in ("transparent", "none", "") and bg_opacity > 0
                     pad_x = 16 if has_bg else 0
                     pad_y = 8 if has_bg else 0
-
-                    bbox = font.getbbox("Ag")
-                    char_h = bbox[3] - bbox[1] if bbox else font_size
-                    lines = text.split("\n")
-                    max_line_w = 0
-                    for line in lines:
-                        lb = font.getbbox(line)
-                        lw = (lb[2] - lb[0]) if lb else len(line) * font_size
-                        max_line_w = max(max_line_w, lw)
-                    text_h = int(char_h * line_height * len(lines))
-                    width = max(50, int(max_line_w + pad_x * 2 + stroke_width_text * 2))
-                    height = int(text_h + pad_y * 2)
+                    line_metrics, line_box_height = _measure_text_lines(
+                        text,
+                        font,
+                        font_size,
+                        line_height,
+                        stroke_width_text,
+                        letter_spacing,
+                    )
+                    max_line_w = max(
+                        (float(metric["width"]) for metric in line_metrics),
+                        default=0.0,
+                    )
+                    width = max(
+                        50,
+                        int(round(max_line_w + pad_x * 2 + stroke_width_text * 2)),
+                    )
+                    height = max(
+                        1,
+                        int(
+                            round(
+                                line_box_height * max(len(line_metrics), 1)
+                                + pad_y * 2
+                                + stroke_width_text * 2
+                            )
+                        ),
+                    )
 
                 width = max(width, 1)
                 height = max(height, 1)
@@ -662,45 +877,72 @@ class FrameSampler:
                 draw = ImageDraw.Draw(img)
 
                 # Background
-                bg_color_str = text_style.get("backgroundColor")
-                if bg_color_str and bg_color_str.lower() not in ("transparent", "none", ""):
-                    bg_opacity = float(text_style.get("backgroundOpacity", 1.0))
+                if has_bg:
                     br, bg_c, bb = _parse_hex_color(bg_color_str, "000000")
                     bg_alpha = int(255 * bg_opacity)
                     draw.rectangle([(0, 0), (rw - 1, rh - 1)], fill=(br, bg_c, bb, bg_alpha))
 
                 # Text positioning
-                text_align = text_style.get("textAlign") or "left"
-                is_multiline = "\n" in text
-                has_bg = bg_color_str and bg_color_str.lower() not in ("transparent", "none", "") and float(text_style.get("backgroundOpacity", 1.0)) > 0
                 text_pad_x = int(16 * scale) if has_bg else 0
                 text_pad_y = int(8 * scale) if has_bg else 0
-
-                draw_kwargs: dict[str, Any] = {}
-                if is_multiline:
-                    draw_x = text_pad_x if text_align == "left" else 0
-                    draw_kwargs = {"align": text_align}
-                else:
-                    if text_align == "center":
-                        draw_x = rw // 2
-                        draw_kwargs = {"anchor": "mt"}
-                    elif text_align == "right":
-                        draw_x = rw - text_pad_x
-                        draw_kwargs = {"anchor": "rt"}
-                    else:
-                        draw_x = text_pad_x
-                        draw_kwargs = {"anchor": "lt"}
-
-                draw_y = text_pad_y
+                scaled_stroke_width = max(0, int(round(stroke_width_text * scale)))
+                scaled_letter_spacing = letter_spacing * scale
                 scaled_font_size = max(1, int(font_size * scale))
-                if scale != 1.0:
-                    font = _resolve_font(scaled_font_size)
+                font = _resolve_font(scaled_font_size, font_family, font_weight)
 
-                if stroke_width_text > 0:
-                    draw.text((draw_x, draw_y), text, font=font, fill=(r, g, b, 255),
-                              stroke_width=stroke_width_text, stroke_fill=(s_r, s_g, s_b, 255), **draw_kwargs)
-                else:
-                    draw.text((draw_x, draw_y), text, font=font, fill=(r, g, b, 255), **draw_kwargs)
+                line_metrics, line_box_height = _measure_text_lines(
+                    text,
+                    font,
+                    scaled_font_size,
+                    line_height,
+                    scaled_stroke_width,
+                    scaled_letter_spacing,
+                )
+
+                for line_index, metric in enumerate(line_metrics):
+                    line = str(metric["line"])
+                    visual_width = float(metric["width"])
+                    bbox_left = float(metric["bbox_left"])
+                    bbox_top = float(metric["bbox_top"])
+
+                    if text_align == "right":
+                        line_left = rw - text_pad_x - scaled_stroke_width - visual_width
+                    elif text_align == "left":
+                        line_left = text_pad_x + scaled_stroke_width
+                    else:
+                        line_left = (rw - visual_width) / 2
+
+                    line_top = text_pad_y + scaled_stroke_width + line_index * line_box_height
+                    line_draw_x = line_left - bbox_left
+                    line_draw_y = line_top - bbox_top
+
+                    draw_kwargs: dict[str, Any] = {
+                        "font": font,
+                        "fill": (r, g, b, 255),
+                    }
+                    if scaled_stroke_width > 0:
+                        draw_kwargs["stroke_width"] = scaled_stroke_width
+                        draw_kwargs["stroke_fill"] = (s_r, s_g, s_b, 255)
+
+                    if abs(scaled_letter_spacing) < 0.01 or len(line) <= 1:
+                        draw.text((line_draw_x, line_draw_y), line, **draw_kwargs)
+                        continue
+
+                    cursor_x = line_left
+                    for char in line:
+                        char_bbox_left, _, char_bbox_right, _ = _get_text_bbox(
+                            font,
+                            char,
+                            stroke_width=scaled_stroke_width,
+                        )
+                        draw.text(
+                            (cursor_x - char_bbox_left, line_draw_y),
+                            char,
+                            **draw_kwargs,
+                        )
+                        cursor_x += (
+                            max(0.0, char_bbox_right - char_bbox_left) + scaled_letter_spacing
+                        )
             else:
                 return None
 

--- a/backend/tests/test_frame_sampler_parity.py
+++ b/backend/tests/test_frame_sampler_parity.py
@@ -5,10 +5,12 @@ helpers mirror the TypeScript logic in:
   - frontend/src/utils/keyframes.ts  (getInterpolatedTransform)
   - frontend/src/components/editor/editorPreviewStageShared.ts (calculateFadeOpacity)
 """
+
 import sys
 import types
 
 import pytest
+from PIL import Image, ImageDraw
 
 # Stub out heavy service imports that require GCP/DB connections at import time,
 # so we can import only the frame_sampler helpers without the full service layer.
@@ -19,6 +21,7 @@ sys.modules.setdefault("src.services.storage_service", _storage_stub)
 from src.services.frame_sampler import (  # noqa: E402
     FrameSampler,
     _calculate_fade_opacity,
+    _get_clip_fade_durations_ms,
     _interpolate_transform_at,
 )
 
@@ -40,7 +43,14 @@ def _make_clip(
     return {
         "start_ms": start_ms,
         "duration_ms": duration_ms,
-        "transform": {"x": x, "y": y, "scale": scale, "rotation": rotation, "width": 100, "height": 50},
+        "transform": {
+            "x": x,
+            "y": y,
+            "scale": scale,
+            "rotation": rotation,
+            "width": 100,
+            "height": 50,
+        },
         "effects": {"opacity": opacity},
         "keyframes": keyframes or [],
     }
@@ -61,7 +71,11 @@ class TestInterpolateTransformAt:
     def test_single_keyframe_returns_keyframe_values(self):
         clip = _make_clip(x=0, y=0, opacity=1.0)
         clip["keyframes"] = [
-            {"time_ms": 1000, "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0}, "opacity": 0.5}
+            {
+                "time_ms": 1000,
+                "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0},
+                "opacity": 0.5,
+            }
         ]
         result = _interpolate_transform_at(clip, time_ms=1000)
         assert result["x"] == 100
@@ -73,8 +87,16 @@ class TestInterpolateTransformAt:
     def test_two_keyframes_linear_interpolation(self):
         clip = _make_clip(start_ms=0, x=0, y=0, opacity=1.0)
         clip["keyframes"] = [
-            {"time_ms": 0, "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0}, "opacity": 0.0},
-            {"time_ms": 1000, "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0}, "opacity": 1.0},
+            {
+                "time_ms": 0,
+                "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0},
+                "opacity": 0.0,
+            },
+            {
+                "time_ms": 1000,
+                "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0},
+                "opacity": 1.0,
+            },
         ]
         # At t=500ms (midpoint), should be halfway between the two keyframes
         result = _interpolate_transform_at(clip, time_ms=500)
@@ -87,8 +109,16 @@ class TestInterpolateTransformAt:
     def test_before_first_keyframe_clamps_to_first(self):
         clip = _make_clip(start_ms=0, x=0, y=0, opacity=1.0)
         clip["keyframes"] = [
-            {"time_ms": 500, "transform": {"x": 10, "y": 20, "scale": 1.0, "rotation": 0.0}, "opacity": 0.3},
-            {"time_ms": 1000, "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0}, "opacity": 1.0},
+            {
+                "time_ms": 500,
+                "transform": {"x": 10, "y": 20, "scale": 1.0, "rotation": 0.0},
+                "opacity": 0.3,
+            },
+            {
+                "time_ms": 1000,
+                "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0},
+                "opacity": 1.0,
+            },
         ]
         # time_ms=100 is before the first keyframe at 500ms
         result = _interpolate_transform_at(clip, time_ms=100)
@@ -99,8 +129,16 @@ class TestInterpolateTransformAt:
     def test_after_last_keyframe_clamps_to_last(self):
         clip = _make_clip(start_ms=0, x=0, y=0, opacity=1.0)
         clip["keyframes"] = [
-            {"time_ms": 0, "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0}, "opacity": 0.0},
-            {"time_ms": 1000, "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0}, "opacity": 1.0},
+            {
+                "time_ms": 0,
+                "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0},
+                "opacity": 0.0,
+            },
+            {
+                "time_ms": 1000,
+                "transform": {"x": 100, "y": 200, "scale": 2.0, "rotation": 90.0},
+                "opacity": 1.0,
+            },
         ]
         # time_ms=5000 (absolute) is well past the last keyframe at 1000ms
         result = _interpolate_transform_at(clip, time_ms=5000)
@@ -112,7 +150,11 @@ class TestInterpolateTransformAt:
         """When keyframe.opacity is None, fall back to clip.effects.opacity."""
         clip = _make_clip(start_ms=0, x=0, y=0, opacity=0.7)
         clip["keyframes"] = [
-            {"time_ms": 0, "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0}, "opacity": None},
+            {
+                "time_ms": 0,
+                "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0},
+                "opacity": None,
+            },
         ]
         result = _interpolate_transform_at(clip, time_ms=0)
         assert result["opacity"] == pytest.approx(0.7)
@@ -120,8 +162,16 @@ class TestInterpolateTransformAt:
     def test_interpolation_at_exact_keyframe_boundary(self):
         clip = _make_clip(start_ms=0, x=0, y=0, opacity=1.0)
         clip["keyframes"] = [
-            {"time_ms": 0, "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0}, "opacity": 0.0},
-            {"time_ms": 1000, "transform": {"x": 100, "y": 0, "scale": 1.0, "rotation": 0.0}, "opacity": 1.0},
+            {
+                "time_ms": 0,
+                "transform": {"x": 0, "y": 0, "scale": 1.0, "rotation": 0.0},
+                "opacity": 0.0,
+            },
+            {
+                "time_ms": 1000,
+                "transform": {"x": 100, "y": 0, "scale": 1.0, "rotation": 0.0},
+                "opacity": 1.0,
+            },
         ]
         result_start = _interpolate_transform_at(clip, time_ms=0)
         assert result_start["x"] == pytest.approx(0.0)
@@ -181,6 +231,163 @@ class TestCalculateFadeOpacity:
 
     def test_clamp_max_1(self):
         assert _calculate_fade_opacity(500, 1000, 0, 0) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# fade duration resolution
+# ---------------------------------------------------------------------------
+
+
+class TestClipFadeDurationResolution:
+    def test_video_clip_prefers_effects_fades(self):
+        clip = {
+            "effects": {"fade_in_ms": 150, "fade_out_ms": 250},
+            "fade_in_ms": 10,
+            "fade_out_ms": 20,
+            "transition_in": {"type": "fade", "duration_ms": 30},
+            "transition_out": {"type": "fade", "duration_ms": 40},
+        }
+
+        assert _get_clip_fade_durations_ms(clip) == (150, 250)
+
+    def test_shape_clip_prefers_top_level_fades_like_preview(self):
+        clip = {
+            "shape": {"type": "rectangle", "width": 100, "height": 50},
+            "effects": {"fade_in_ms": 150, "fade_out_ms": 250},
+            "fade_in_ms": 10,
+            "fade_out_ms": 20,
+            "transition_in": {"type": "fade", "duration_ms": 30},
+            "transition_out": {"type": "fade", "duration_ms": 40},
+        }
+
+        assert _get_clip_fade_durations_ms(clip) == (10, 20)
+
+    def test_transition_fades_are_used_only_as_final_fallback(self):
+        clip = {
+            "effects": {},
+            "transition_in": {"type": "fade", "duration_ms": 70},
+            "transition_out": {"type": "fade", "duration_ms": 90},
+        }
+
+        assert _get_clip_fade_durations_ms(clip) == (70, 90)
+
+
+# ---------------------------------------------------------------------------
+# text overlay sizing/font selection
+# ---------------------------------------------------------------------------
+
+
+class _FakeFont:
+    def __init__(self, char_width: int, height: int) -> None:
+        self.char_width = char_width
+        self.height = height
+
+    def getbbox(self, text: str, stroke_width: int = 0):
+        width = max(len(text), 1) * self.char_width + stroke_width * 2
+        return (0, 0, width, self.height + stroke_width * 2)
+
+
+class TestTextOverlaySizing:
+    def _make_sampler(self) -> FrameSampler:
+        return FrameSampler(
+            timeline_data={"duration_ms": 10000, "layers": []},
+            assets={},
+        )
+
+    def test_auto_size_uses_selected_font_family_and_weight(self, monkeypatch, tmp_path):
+        resolve_calls: list[tuple[int, str, str]] = []
+        regular_font = _FakeFont(char_width=10, height=24)
+        bold_font = _FakeFont(char_width=22, height=24)
+
+        def fake_resolve_font(font_size: int, font_family: str, font_weight: str):
+            resolve_calls.append((font_size, font_family, font_weight))
+            return bold_font if font_weight == "bold" else regular_font
+
+        monkeypatch.setattr("src.services.frame_sampler._resolve_font", fake_resolve_font)
+        monkeypatch.setattr(ImageDraw.ImageDraw, "text", lambda self, xy, text, **kwargs: None)
+
+        clip = {
+            "id": "text-1",
+            "start_ms": 0,
+            "duration_ms": 2000,
+            "transform": {
+                "x": 0,
+                "y": 0,
+                "scale": 1.0,
+                "rotation": 0,
+                "width": None,
+                "height": None,
+            },
+            "effects": {"opacity": 1.0, "fade_in_ms": 0, "fade_out_ms": 0},
+            "text_content": "ABCD",
+            "text_style": {
+                "fontFamily": "Noto Serif JP",
+                "fontSize": 48,
+                "fontWeight": "bold",
+                "color": "#ffffff",
+                "backgroundColor": "transparent",
+                "backgroundOpacity": 0,
+                "textAlign": "center",
+                "lineHeight": 1.4,
+                "letterSpacing": 0,
+                "strokeColor": "#000000",
+                "strokeWidth": 0,
+            },
+        }
+
+        output_path = self._make_sampler()._generate_simple_overlay(clip, 0, str(tmp_path), 0)
+        assert output_path is not None
+        assert resolve_calls[0] == (48, "Noto Serif JP", "bold")
+
+        with Image.open(output_path) as image:
+            width, height = image.size
+
+        assert width == 88
+        assert height == 67
+
+    def test_letter_spacing_is_included_in_auto_size(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "src.services.frame_sampler._resolve_font",
+            lambda font_size, font_family, font_weight: _FakeFont(char_width=10, height=24),
+        )
+        monkeypatch.setattr(ImageDraw.ImageDraw, "text", lambda self, xy, text, **kwargs: None)
+
+        clip = {
+            "id": "text-2",
+            "start_ms": 0,
+            "duration_ms": 2000,
+            "transform": {
+                "x": 0,
+                "y": 0,
+                "scale": 1.0,
+                "rotation": 0,
+                "width": None,
+                "height": None,
+            },
+            "effects": {"opacity": 1.0, "fade_in_ms": 0, "fade_out_ms": 0},
+            "text_content": "ABCD",
+            "text_style": {
+                "fontFamily": "Noto Sans JP",
+                "fontSize": 48,
+                "fontWeight": "normal",
+                "color": "#ffffff",
+                "backgroundColor": "transparent",
+                "backgroundOpacity": 0,
+                "textAlign": "center",
+                "lineHeight": 1.4,
+                "letterSpacing": 4,
+                "strokeColor": "#000000",
+                "strokeWidth": 0,
+            },
+        }
+
+        output_path = self._make_sampler()._generate_simple_overlay(clip, 0, str(tmp_path), 0)
+        assert output_path is not None
+
+        with Image.open(output_path) as image:
+            width, _ = image.size
+
+        assert width == 52
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- apply the clean #115 frame_sampler parity changes on top of current `origin/main`
- align API snapshot rendering with browser preview for transform interpolation, fade, freeze-frame visibility, text sizing/padding, font resolution, and shape rendering
- add focused backend parity coverage in `backend/tests/test_frame_sampler_parity.py`

## Self-Review
- Self-review completed
- Scope is limited to `backend/src/services/frame_sampler.py` and `backend/tests/test_frame_sampler_parity.py`
- No unrelated `#116` API contract changes or other stale branch diffs are included

## Verification
- `uv run --project backend --python 3.11 ruff check backend/src/services/frame_sampler.py backend/tests/test_frame_sampler_parity.py`
- `uv run --project backend --python 3.11 pytest backend/tests/test_frame_sampler_parity.py -q`

## Playwright
- Not applicable; backend-only preview snapshot parity fix

## Manual Check
- Not run in browser; this PR is limited to backend API snapshot parity and is covered with focused backend parity tests

## Residual Risks
- This fixes the backend frame sampler side only; if parity gaps remain in browser preview they may require follow-up issue-specific coverage
