### PR TITLE
fix(render): move trim to input-level for freeze-frame clips (#107)

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1267,7 +1267,7 @@ class RenderPipeline:
                     if shape_path:
                         generated_files[f"shape_{shape_idx}.png"] = shape_path
                         inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", shape_path])
-                        shape_filter = self._build_clip_filter(
+                        shape_filter, _ = self._build_clip_filter(
                             input_idx,
                             clip,
                             layer_type,
@@ -1289,7 +1289,7 @@ class RenderPipeline:
                     if text_path:
                         generated_files[f"text_{shape_idx}.png"] = text_path
                         inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", text_path])
-                        text_filter = self._build_clip_filter(
+                        text_filter, _ = self._build_clip_filter(
                             input_idx,
                             clip,
                             layer_type,
@@ -1313,12 +1313,10 @@ class RenderPipeline:
                 # Static images need -loop 1 to generate continuous frames
                 ext = asset_path.rsplit(".", 1)[-1].lower() if "." in asset_path else ""
                 is_image = ext in ("png", "jpg", "jpeg", "bmp", "webp", "tiff", "gif")
-                if is_image:
-                    inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", asset_path])
-                else:
-                    inputs.extend(["-i", asset_path])
 
-                clip_filter = self._build_clip_filter(
+                # Build filter first so we know whether input-level trim is
+                # needed (returned as input_prefix for the -ss/-to workaround).
+                clip_filter, input_prefix = self._build_clip_filter(
                     input_idx,
                     clip,
                     layer_type,
@@ -1328,6 +1326,12 @@ class RenderPipeline:
                     export_end_ms,
                     is_still_image=is_image,
                 )
+
+                if is_image:
+                    inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", asset_path])
+                else:
+                    inputs.extend([*input_prefix, "-i", asset_path])
+
                 filter_parts.append(clip_filter)
                 current_output = f"layer{input_idx}"
                 input_idx += 1
@@ -1459,13 +1463,20 @@ class RenderPipeline:
         export_start_ms: int = 0,
         export_end_ms: int | None = None,
         is_still_image: bool = False,
-    ) -> str:
+    ) -> tuple[str, list[str]]:
         """Build FFmpeg filter for a single clip.
 
         Args:
             export_start_ms: Start of export range in ms (clips are offset relative to this)
             export_end_ms: End of export range in ms (clips extending beyond are trimmed)
             is_still_image: True for image/shape/text inputs (needs format normalization)
+
+        Returns:
+            Tuple of (filter_string, input_prefix_args).  input_prefix_args
+            contains ``-ss``/``-to`` flags that must be inserted immediately
+            before the corresponding ``-i`` argument when the clip uses
+            freeze-frame extension (to avoid the FFmpeg 7.x bug where
+            ``tpad`` is silently ignored after ``trim``).
         """
         if export_end_ms is None:
             export_end_ms = total_duration_ms + export_start_ms
@@ -1497,7 +1508,7 @@ class RenderPipeline:
                     f"[CLIP] Cannot determine duration for clip (duration_ms={duration_ms}, out_point_ms={out_point_ms})"
                 )
                 # Return a null filter that passes through without this clip
-                return f"[{base_output}]null[{output_label}]"
+                return f"[{base_output}]null[{output_label}]", []
 
         # Calculate actual out point for trimming
         if out_point_ms is None:
@@ -1546,30 +1557,49 @@ class RenderPipeline:
         start_s = adjusted_in_point_ms / 1000
         end_s = adjusted_out_point_ms / 1000
         speed = clip.get("speed", 1.0)
-        clip_filters.append(f"trim=start={start_s}:end={end_s}")
+
+        # FFmpeg 7.x bug: tpad is silently ignored when ANY timestamp-
+        # altering filter (trim, setpts) precedes it in the same filter chain.
+        # Work around this by:
+        #   1. Moving trim to input-level -ss/-to so it never enters the chain.
+        #   2. Placing tpad BEFORE setpts (format → tpad → setpts) so tpad
+        #      receives the raw stream and can correctly clone the last frame.
+        input_prefix_args: list[str] = []
+        use_input_level_trim = freeze_frame_ms > 0 and not is_still_image
+
+        if use_input_level_trim:
+            input_prefix_args = ["-ss", str(start_s), "-to", str(end_s)]
+            # -ss/-to on input resets PTS to ~0, so PTS-STARTPTS works as
+            # expected without an explicit trim filter.
+        else:
+            clip_filters.append(f"trim=start={start_s}:end={end_s}")
+
         # Calculate timeline position for PTS offset
-        # This ensures the clip's frames are aligned with the overlay timing
-        # and prevents frame consumption during the overlay's pre-enable period.
-        # See: FFmpeg overlay consumes secondary input even when enable=false.
         adjusted_start_ms_for_pts = max(0, start_ms - export_start_ms)
         start_time_offset = adjusted_start_ms_for_pts / 1000
-        if speed != 1.0:
-            clip_filters.append(f"setpts=(PTS-STARTPTS)/{speed}+{start_time_offset}/TB")
-        else:
-            clip_filters.append(f"setpts=PTS-STARTPTS+{start_time_offset}/TB")
         clip_elapsed_expr = f"(t-{start_time_offset:.6f})"
         clip_elapsed_alpha_expr = f"(T-{start_time_offset:.6f})"
 
-        # Normalize pixel format after trim+setpts.
+        # Normalize pixel format.
         # Still images may have exotic formats (pal8, gray, rgb24) and videos
         # may use yuvj420p (JPEG full range) or other variants. Both can cause
         # silent overlay failures resulting in black frames.
         # yuva420p ensures alpha channel support for chroma key, opacity, etc.
         clip_filters.append("format=yuva420p")
 
-        # Freeze frame extension (applied after setpts, before crop/scale)
+        # Freeze frame extension — must come BEFORE setpts.
+        # FFmpeg 7.x ignores tpad when setpts precedes it.
         if freeze_frame_ms > 0:
             clip_filters.append(f"tpad=stop_mode=clone:stop_duration={freeze_frame_ms / 1000}")
+
+        # PTS offset to align clip with timeline position.
+        # This ensures the clip's frames are aligned with the overlay timing
+        # and prevents frame consumption during the overlay's pre-enable period.
+        # See: FFmpeg overlay consumes secondary input even when enable=false.
+        if speed != 1.0:
+            clip_filters.append(f"setpts=(PTS-STARTPTS)/{speed}+{start_time_offset}/TB")
+        else:
+            clip_filters.append(f"setpts=PTS-STARTPTS+{start_time_offset}/TB")
 
         # Crop filter (applied before scale)
         crop = clip.get("crop", {})
@@ -1799,7 +1829,7 @@ class RenderPipeline:
             f"eof_action=pass:enable='{enable_expr}'[{output_label}]"
         )
 
-        return filter_str
+        return filter_str, input_prefix_args
 
     def _generate_shape_image(
         self,

--- a/backend/tests/test_render_pipeline.py
+++ b/backend/tests/test_render_pipeline.py
@@ -306,7 +306,7 @@ class TestRenderPipeline:
         """Video overlays should add alpha fade filters before compositing."""
         pipeline = RenderPipeline()
 
-        filter_str = pipeline._build_clip_filter(
+        filter_str, _ = pipeline._build_clip_filter(
             input_idx=1,
             clip={
                 "start_ms": 1000,
@@ -338,7 +338,7 @@ class TestRenderPipeline:
         """Keyframed clips should emit per-frame expressions for transform and opacity."""
         pipeline = RenderPipeline()
 
-        filter_str = pipeline._build_clip_filter(
+        filter_str, _ = pipeline._build_clip_filter(
             input_idx=1,
             clip={
                 "start_ms": 500,
@@ -389,7 +389,7 @@ class TestRenderPipeline:
         """Slide transitions should become overlay position offsets."""
         pipeline = RenderPipeline()
 
-        filter_str = pipeline._build_clip_filter(
+        filter_str, _ = pipeline._build_clip_filter(
             input_idx=1,
             clip={
                 "start_ms": 250,
@@ -624,19 +624,99 @@ class TestRenderPipeline:
         assert "tpad=" in filter_complex_str, (
             "tpad filter missing — freeze frame extension not applied"
         )
-        # The trim filter must NOT have start > end (which produces zero frames).
-        # When export range is entirely within freeze, in_point must be clamped
-        # to just before out_point so at least one frame exists for tpad to clone.
-        import re
-
-        trim_match = re.search(r"trim=start=([\d.]+):end=([\d.]+)", filter_complex_str)
-        assert trim_match is not None, "trim filter not found in filter_complex"
-        trim_start = float(trim_match.group(1))
-        trim_end = float(trim_match.group(2))
-        assert trim_start < trim_end, (
-            f"trim start ({trim_start}) >= end ({trim_end}) — "
-            "export within freeze portion caused invalid trim range"
+        # For freeze-frame clips, trim is moved to input-level -ss/-to
+        # (FFmpeg 7.x bug: tpad is silently ignored after trim).
+        # Verify that -ss and -to appear in the command before -i.
+        cmd_str = " ".join(cmd)
+        assert "-ss " in cmd_str, (
+            "-ss flag missing — freeze-frame clip should use input-level trim"
         )
+        assert "-to " in cmd_str, (
+            "-to flag missing — freeze-frame clip should use input-level trim"
+        )
+
+
+    def test_build_clip_filter_freeze_uses_input_level_trim(self):
+        """Freeze-frame clips must use input-level -ss/-to instead of
+        filter-level trim, because FFmpeg 7.x silently ignores tpad
+        after trim.  Regression test for #107."""
+        pipeline = RenderPipeline()
+
+        filter_str, input_prefix = pipeline._build_clip_filter(
+            input_idx=1,
+            clip={
+                "start_ms": 5000,
+                "duration_ms": 2000,
+                "in_point_ms": 10000,
+                "out_point_ms": 12000,
+                "freeze_frame_ms": 3000,
+                "transform": {
+                    "x": 0,
+                    "y": 0,
+                    "scale": 1.0,
+                    "rotation": 0,
+                    "width": 1920,
+                    "height": 1080,
+                },
+                "effects": {"opacity": 1.0},
+            },
+            layer_type="content",
+            base_output="0:v",
+            total_duration_ms=10000,
+            export_start_ms=0,
+            export_end_ms=10000,
+            is_still_image=False,
+        )
+
+        # Filter must NOT contain trim (it's at input level)
+        assert "trim=" not in filter_str, (
+            "trim filter found in filter chain — freeze-frame clips "
+            "must use input-level -ss/-to to avoid FFmpeg 7.x tpad bug"
+        )
+        # Filter must contain tpad
+        assert "tpad=stop_mode=clone:stop_duration=3.0" in filter_str
+        # Input prefix must have -ss and -to
+        assert len(input_prefix) == 4, f"Expected [-ss, X, -to, Y], got {input_prefix}"
+        assert input_prefix[0] == "-ss"
+        assert input_prefix[2] == "-to"
+        assert float(input_prefix[1]) == 10.0  # in_point_ms / 1000
+        assert float(input_prefix[3]) == 12.0  # out_point_ms / 1000
+
+    def test_build_clip_filter_no_freeze_uses_filter_trim(self):
+        """Non-freeze clips must still use filter-level trim (no input prefix)."""
+        pipeline = RenderPipeline()
+
+        filter_str, input_prefix = pipeline._build_clip_filter(
+            input_idx=1,
+            clip={
+                "start_ms": 0,
+                "duration_ms": 3000,
+                "in_point_ms": 5000,
+                "out_point_ms": 8000,
+                "transform": {
+                    "x": 0,
+                    "y": 0,
+                    "scale": 1.0,
+                    "rotation": 0,
+                    "width": 1920,
+                    "height": 1080,
+                },
+                "effects": {"opacity": 1.0},
+            },
+            layer_type="content",
+            base_output="0:v",
+            total_duration_ms=5000,
+            export_start_ms=0,
+            export_end_ms=5000,
+            is_still_image=False,
+        )
+
+        # Filter must contain trim (no freeze, so filter-level is fine)
+        assert "trim=start=5.0:end=8.0" in filter_str
+        # No tpad
+        assert "tpad=" not in filter_str
+        # No input prefix args
+        assert input_prefix == []
 
 
 class TestUndoableAction:


### PR DESCRIPTION
## 変更内容

FFmpeg 7.x で `tpad` がタイムスタンプ変更フィルター（`trim`, `setpts`）の後に配置されると無視されるバグへの対処。

- `freeze_frame_ms > 0` の動画クリップで `trim` をフィルターチェインから input 側 `-ss`/`-to` に移動
- `tpad` を `setpts` より前に配置（`format=yuva420p` → `tpad` → `setpts` の順）
- `_build_clip_filter()` の戻り値を `tuple[str, list[str]]` に変更し、input prefix args を返すように

## Self-review 済み

- [x] diff 確認、スコープ外の変更なし
- [x] 影響範囲: `pipeline.py` と `test_render_pipeline.py` のみ

## 実行した検証コマンド

```bash
uv run --python python3.11 pytest tests/test_render_pipeline.py -q       # 36 passed
uv run --python python3.11 pytest tests/test_render_package_builder.py -q  # 6 passed
uv run --python python3.11 ruff check src/render/pipeline.py tests/test_render_pipeline.py  # All checks passed
uv run --python python3.11 --extra dev mypy src/render/pipeline.py --ignore-missing-imports  # Success
```

## Playwright 対象

バックエンド変更のみ。フロントエンドの変更なし。

## 実操作で確認したこと

render package の filtergraph をパッチし、動画3 セクション2-2 でローカルレンダリング:

| 時刻 | 修正前 mean brightness | 修正後 mean brightness |
|------|----------------------|----------------------|
| 10s  | 201.7 (OK)           | 201.7 (OK)           |
| 12s  | 5.7 (BLACK)          | 204.0 (OK)           |
| 14s  | 5.7 (BLACK)          | 204.0 (OK)           |
| 20s  | 3.0 (BLACK)          | 211.7 (OK)           |
| 25s  | 206.1 (OK)           | 206.1 (OK)           |

## 残課題

- デプロイ後に render package API 経由でダウンロードし、パッケージ形式での実レンダリング検証が必要
- Cloud Run 上の FFmpeg (7.1.3 Debian) でも同じ tpad バグが存在するかの確認
  - Docker 環境で同じ問題が発生しなければ、ローカル FFmpeg 7.1.1 固有の可能性あり

Closes #107