### PR TITLE
fix(render): include strokeWidth in shape PNG canvas to match browser SVG (#135)

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1888,8 +1888,17 @@ class RenderPipeline:
             # Create bounding box with padding for stroke
             height = max(stroke_width * 2, 4)
 
+        # Canvas size: for shapes other than line, expand by strokeWidth on each axis
+        # so that the stroke is not clipped at the edges (matches browser SVG behaviour).
+        if shape_type == "line":
+            canvas_w = width
+            canvas_h = height
+        else:
+            canvas_w = width + stroke_width
+            canvas_h = height + stroke_width
+
         # Create transparent image
-        img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+        img = Image.new("RGBA", (canvas_w, canvas_h), (0, 0, 0, 0))
         draw = ImageDraw.Draw(img)
 
         # Parse hex color to RGBA tuple
@@ -1911,41 +1920,28 @@ class RenderPipeline:
         fill_rgba = hex_to_rgba(fill_color, alpha) if filled else None
         stroke_rgba = hex_to_rgba(stroke_color, alpha)
 
+        # Offset for stroke so that the stroke centre sits at strokeWidth/2 from the
+        # canvas edge, matching the browser SVG:
+        #   <rect x={strokeWidth/2} y={strokeWidth/2} width={shape.width} height={shape.height} …>
+        sw2 = stroke_width / 2
+
         try:
             if shape_type == "rectangle":
-                if filled:
-                    draw.rectangle(
-                        [(0, 0), (width - 1, height - 1)],
-                        fill=fill_rgba,
-                        outline=stroke_rgba,
-                        width=stroke_width,
-                    )
-                else:
-                    # For outline only, offset to keep stroke inside bounds
-                    offset = stroke_width // 2
-                    draw.rectangle(
-                        [(offset, offset), (width - 1 - offset, height - 1 - offset)],
-                        fill=None,
-                        outline=stroke_rgba,
-                        width=stroke_width,
-                    )
+                # Both filled and unfilled use the same coordinate offset (SVG does the same).
+                draw.rectangle(
+                    [(sw2, sw2), (sw2 + width - 1, sw2 + height - 1)],
+                    fill=fill_rgba,
+                    outline=stroke_rgba,
+                    width=stroke_width,
+                )
 
             elif shape_type == "circle":
-                if filled:
-                    draw.ellipse(
-                        [(0, 0), (width - 1, height - 1)],
-                        fill=fill_rgba,
-                        outline=stroke_rgba,
-                        width=stroke_width,
-                    )
-                else:
-                    offset = stroke_width // 2
-                    draw.ellipse(
-                        [(offset, offset), (width - 1 - offset, height - 1 - offset)],
-                        fill=None,
-                        outline=stroke_rgba,
-                        width=stroke_width,
-                    )
+                draw.ellipse(
+                    [(sw2, sw2), (sw2 + width - 1, sw2 + height - 1)],
+                    fill=fill_rgba,
+                    outline=stroke_rgba,
+                    width=stroke_width,
+                )
 
             elif shape_type == "line":
                 # Draw horizontal line centered in the bounding box

--- a/backend/tests/test_render_pipeline.py
+++ b/backend/tests/test_render_pipeline.py
@@ -418,8 +418,62 @@ class TestRenderPipeline:
         assert output_path is not None
         from PIL import Image
 
+        # Canvas should be shape.width + strokeWidth × shape.height + strokeWidth
+        # (strokeWidth=2 → 102 × 52) to match browser SVG canvas size.
         with Image.open(output_path) as image:
-            assert image.size == (100, 50)
+            assert image.size == (102, 52)
+
+    def test_generate_shape_image_canvas_includes_stroke_width(self, temp_output_dir):
+        """Shape PNG canvas size must be (shape.width + strokeWidth) × (shape.height + strokeWidth).
+
+        This matches the browser SVG which uses the expanded canvas so that the stroke
+        is not clipped at the edges.
+        """
+        pipeline = RenderPipeline()
+        pipeline.output_dir = str(temp_output_dir)
+
+        for shape_type in ("rectangle", "circle"):
+            output_path = pipeline._generate_shape_image(
+                shape={
+                    "type": shape_type,
+                    "width": 200,
+                    "height": 100,
+                    "fillColor": "#aabbcc",
+                    "strokeColor": "#112233",
+                    "strokeWidth": 6,
+                    "filled": True,
+                },
+                clip={"transform": {}},
+                shape_idx=0,
+            )
+            assert output_path is not None, f"{shape_type}: output_path is None"
+            from PIL import Image
+
+            with Image.open(output_path) as img:
+                assert img.size == (206, 106), (
+                    f"{shape_type}: expected (206, 106) but got {img.size}"
+                )
+
+        # line: canvas should NOT expand by strokeWidth (existing behaviour)
+        output_path_line = pipeline._generate_shape_image(
+            shape={
+                "type": "line",
+                "width": 300,
+                "height": 10,
+                "fillColor": "#000000",
+                "strokeColor": "#ffffff",
+                "strokeWidth": 4,
+                "filled": True,
+            },
+            clip={"transform": {}},
+            shape_idx=1,
+        )
+        assert output_path_line is not None
+        from PIL import Image
+
+        with Image.open(output_path_line) as img:
+            # line height is overridden to max(stroke_width*2, 4) = 8, width stays 300
+            assert img.size[0] == 300
 
     def test_build_clip_filter_shape_uses_intrinsic_overlay_size(self):
         """Shape clips should scale their generated PNG, not reinterpret transform width/height."""
@@ -521,7 +575,8 @@ class TestRenderPipeline:
         from PIL import Image
 
         with Image.open(output_path) as img:
-            assert img.size == (230, 80)
+            # strokeWidth=2 → canvas is (230+2, 80+2)
+            assert img.size == (232, 82)
             assert img.mode == "RGBA"
             # Verify the image contains non-transparent pixels (arrow was actually drawn)
             bbox = img.getbbox()
@@ -550,7 +605,8 @@ class TestRenderPipeline:
         from PIL import Image
 
         with Image.open(output_path) as img:
-            assert img.size == (230, 80)
+            # strokeWidth=3 → canvas is (230+3, 80+3)
+            assert img.size == (233, 83)
             bbox = img.getbbox()
             assert bbox is not None, "Outline-only arrow is completely transparent"
 
@@ -577,7 +633,8 @@ class TestRenderPipeline:
         from PIL import Image
 
         with Image.open(output_path) as img:
-            assert img.size == (400, 80)
+            # strokeWidth=2 → canvas is (400+2, 80+2)
+            assert img.size == (402, 82)
             bbox = img.getbbox()
             assert bbox is not None
 
@@ -609,9 +666,10 @@ class TestRenderPipeline:
         from PIL import Image
 
         with Image.open(output_path) as img:
-            # Image canvas uses the requested width, but the arrow polygon
+            # Image canvas uses the requested width + strokeWidth.  Arrow polygon
             # is drawn using the safe (clamped) geometry so it fits.
-            assert img.size == (50, 40)
+            # strokeWidth=2 → canvas is (50+2, 40+2)
+            assert img.size == (52, 42)
             bbox = img.getbbox()
             assert bbox is not None, "Small arrow should still be visible"
 


### PR DESCRIPTION
## Summary

Closes #135

- `_generate_shape_image` の PNG canvas サイズを `(shape.width + strokeWidth) × (shape.height + strokeWidth)` に拡張し、ブラウザ SVG と一致させた
- rectangle / circle の描画座標を SVG と同じ `(strokeWidth/2, strokeWidth/2)` オフセットに統一
- line の描画ロジックは既存のまま維持

## Root Cause

ブラウザ Preview: `<svg width={shape.width + strokeWidth}>` で strokeWidth を含む
FFmpeg PNG: `Image.new((shape.width, shape.height))` で strokeWidth を含まない

例: shape.width=586, strokeWidth=17 → ブラウザ: 603px, FFmpeg: 586px (17px差)

## Pre-PR Gate

- [x] Self-review: diff確認、不要な変更なし
- [x] Lint: `uv run --python 3.11 ruff check backend/src/render/pipeline.py backend/tests/test_render_pipeline.py` → pass
- [x] Tests: `uv run --python 3.11 pytest backend/tests/test_render_pipeline.py -x -v` → 46 passed
- [ ] E2E render verification: 実プロジェクトでの検証はデプロイ後に実施予定

## Test Coverage

- 既存テストのサイズ期待値を strokeWidth 加算分に更新
- 新規テスト `test_generate_shape_image_canvas_includes_stroke_width`: rectangle/circle/line の canvas サイズを検証

## Residual Risks

- render pipeline の shape 生成のみ変更、他クリップ種別に影響なし
- 実プロジェクトでの e2e 検証がデプロイ後に必要