### PR TITLE
fix(render): include strokeWidth in line shape PNG canvas (#135)

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1882,20 +1882,11 @@ class RenderPipeline:
         width = max(width, 1)
         height = max(height, 1)
 
-        # For lines, we need to handle differently
-        if shape_type == "line":
-            # Line: width is length, height is stroke width
-            # Create bounding box with padding for stroke
-            height = max(stroke_width * 2, 4)
-
-        # Canvas size: for shapes other than line, expand by strokeWidth on each axis
-        # so that the stroke is not clipped at the edges (matches browser SVG behaviour).
-        if shape_type == "line":
-            canvas_w = width
-            canvas_h = height
-        else:
-            canvas_w = width + stroke_width
-            canvas_h = height + stroke_width
+        # Canvas size: expand by strokeWidth on each axis so that the stroke is
+        # not clipped at the edges (matches browser SVG behaviour).
+        # Browser SVG: <svg width={shape.width + strokeWidth} height={shape.height + strokeWidth}>
+        canvas_w = width + stroke_width
+        canvas_h = height + stroke_width
 
         # Create transparent image
         img = Image.new("RGBA", (canvas_w, canvas_h), (0, 0, 0, 0))
@@ -1944,9 +1935,14 @@ class RenderPipeline:
                 )
 
             elif shape_type == "line":
-                # Draw horizontal line centered in the bounding box
-                y_center = height // 2
-                draw.line([(0, y_center), (width, y_center)], fill=stroke_rgba, width=stroke_width)
+                # Match browser SVG:
+                #   <line x1={sw/2} y1={(h+sw)/2} x2={w+sw/2} y2={(h+sw)/2}>
+                y_center = canvas_h / 2
+                draw.line(
+                    [(sw2, y_center), (width + sw2, y_center)],
+                    fill=stroke_rgba,
+                    width=stroke_width,
+                )
 
             elif shape_type == "arrow":
                 # Arrow geometry ported from frontend shapeGeometry.ts

--- a/backend/tests/test_render_pipeline.py
+++ b/backend/tests/test_render_pipeline.py
@@ -454,7 +454,7 @@ class TestRenderPipeline:
                     f"{shape_type}: expected (206, 106) but got {img.size}"
                 )
 
-        # line: canvas should NOT expand by strokeWidth (existing behaviour)
+        # line: canvas also expands by strokeWidth to match browser SVG
         output_path_line = pipeline._generate_shape_image(
             shape={
                 "type": "line",
@@ -472,8 +472,8 @@ class TestRenderPipeline:
         from PIL import Image
 
         with Image.open(output_path_line) as img:
-            # line height is overridden to max(stroke_width*2, 4) = 8, width stays 300
-            assert img.size[0] == 300
+            # line: width + strokeWidth = 304, height + strokeWidth = 14
+            assert img.size == (304, 14)
 
     def test_build_clip_filter_shape_uses_intrinsic_overlay_size(self):
         """Shape clips should scale their generated PNG, not reinterpret transform width/height."""


### PR DESCRIPTION
## Summary

Follow-up to #136 — extends the strokeWidth canvas fix to `line` shapes as well.

Codex review of #136 flagged that line clips were still using the old canvas size without strokeWidth expansion. Browser SVG renders lines in a `(width + strokeWidth) × (height + strokeWidth)` canvas with endpoints inset by `strokeWidth/2`, but the render pipeline was not doing the same.

## Changes

- Remove special-case that excluded line from canvas expansion
- Update line drawing coordinates to match browser SVG: `x1=sw/2, x2=width+sw/2, y=(canvas_h)/2`
- Update test expectations for line canvas size

## Pre-PR Gate

- [x] Self-review
- [x] Lint: `ruff check` pass
- [x] Tests: 46 passed
- [ ] E2E render verification pending deploy

## Test Plan

- `test_generate_shape_image_canvas_includes_stroke_width` verifies line canvas is `(width + strokeWidth, height + strokeWidth)`