### PR TITLE
docs: clarify sequence-targeted render package flow (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Practical rule:
 
 - Use browser AI only for the currently open editor context.
 - Use the API workflow when operating on projects or sequences outside the currently open browser session.
+- For sequence-targeted render packages, call `POST /api/projects/{project_id}/render/package?sequence_id=<UUID>` or use `X-Edit-Session`.
+- Do not expect `GET /api/projects/{project_id}/render/download?sequence_id=...` to select a sequence. That endpoint only returns the latest completed render for the project.
 
 ---
 

--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -187,3 +187,42 @@ POST /api/ai/v1/projects/{project_id}/clips/{clip_id}/chroma-key/apply
   }
 }
 ```
+
+---
+
+## 6. Sequence を指定した render package の生成
+
+```bash
+curl -X POST \
+  "${API_BASE}/api/projects/${PROJECT_ID}/render/package?sequence_id=${SEQUENCE_ID}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+```json
+{
+  "download_url": "https://storage.googleapis.com/..."
+}
+```
+
+`X-Edit-Session` を使う場合:
+
+```bash
+curl -X POST \
+  "${API_BASE}/api/projects/${PROJECT_ID}/render/package" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Edit-Session: ${EDIT_SESSION_ID}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+よくある間違い:
+
+```bash
+curl -X GET \
+  "${API_BASE}/api/projects/${PROJECT_ID}/render/download?sequence_id=${SEQUENCE_ID}" \
+  -H "Authorization: Bearer ${TOKEN}"
+```
+
+これは sequence を選びません。`GET /render/download` は project に対する最新 completed render の signed URL を返すだけです。特定 sequence の package を得たい場合は `POST /render/package?sequence_id=...` を使います。

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -267,13 +267,18 @@ OpenAPI の各スキーマには `x-constraints` を付与する。
 
 - `GET /api/projects/{project_id}/render/download`
   - 最新の完了済み render の signed URL を取得
+  - `sequence_id` は解決しない。project に対する最新 completed render を返す
+  - 特定 sequence の render package を取得したい場合の入口ではない
 
 - `POST /api/projects/{project_id}/render/package`
   - client-side render package を生成
   - body: `{start_ms?: number, end_ms?: number}`
+  - `?sequence_id=<UUID>` で対象 sequence を明示指定できる
+  - `X-Edit-Session` があればそれを優先し、なければ `sequence_id`、最後に default sequence を使う
   - ZIP の中には asset、generated PNG、FFmpeg script、`render.sh` が含まれる
   - この package は簡易 export ではなく、同じ timeline / assets / export range に対して
     `Export` と同じ最終動画をローカル実行で再現する経路として扱う
+  - `GET /render/download?sequence_id=...` のような使い方では sequence targeting にならない
 
 ---
 

--- a/docs/E2E_VIDEO_WORKFLOW.md
+++ b/docs/E2E_VIDEO_WORKFLOW.md
@@ -473,6 +473,19 @@ curl -X GET \
 
 署名付き URL が返る（有効期限 24 時間）。
 
+注意:
+- `GET /render/download` は project に対する最新 completed render を返す
+- `?sequence_id=...` を付けても sequence targeting にはならない
+- 特定 sequence の render package を取得したい場合は、先に package を sequence 指定で生成する
+
+```bash
+curl -X POST \
+  "${API_BASE}/api/projects/${PROJECT_ID}/render/package?sequence_id=${SEQUENCE_ID}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 ### Step 7.4: レンダリング取り消し
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify in README and API docs that `GET /render/download` does not resolve `sequence_id`
- document the correct sequence-targeted flow via `POST /render/package?sequence_id=...` or `X-Edit-Session`
- add a concrete API example and E2E workflow note for the common mistake

## Self-review
- self-review completed; scope is docs-only and limited to README plus API docs/examples

## Verification
- `git diff --check`

## Playwright
- not applicable; docs-only change

## Manual check
- verified docs now consistently distinguish render package generation from render download retrieval

## Residual risks
- docs-only; no runtime behavior changes