### PR TITLE
Clarify render package FFmpeg thread policy

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
     render_memory_safety_ratio: float = 0.80
     # Chunk duration (in seconds) for chunked rendering when memory is tight
     render_chunk_duration_s: int = 120
-    # Maximum threads for FFmpeg (limits per-thread buffer memory)
+    # Maximum threads for server-side FFmpeg compositing (limits per-thread buffer memory)
     render_ffmpeg_threads: int = 2
     # Maximum muxing queue size (limits FFmpeg muxer memory)
     render_ffmpeg_max_muxing_queue: int = 1024

--- a/backend/src/render/package_builder.py
+++ b/backend/src/render/package_builder.py
@@ -289,7 +289,9 @@ class RenderPackageBuilder:
         self._write_script("01_mix_audio.sh", audio_script_cmd, "Audio mixing", audio_output)
 
         if composite_result:
-            composite_script_cmd = self._rewrite_command(composite_result[0], pipeline.output_dir)
+            composite_script_cmd = self._drop_server_only_composite_limits(
+                self._rewrite_command(composite_result[0], pipeline.output_dir)
+            )
         else:
             duration_s = render_duration_ms / 1000
             composite_script_cmd = [
@@ -376,8 +378,8 @@ class RenderPackageBuilder:
             if composite_result:
                 _cmd, generated_files = composite_result
                 self._copy_generated_files(generated_files, prefix=f"{chunk_prefix}_")
-                composite_script_cmd = self._rewrite_command(
-                    composite_result[0], pipeline.output_dir
+                composite_script_cmd = self._drop_server_only_composite_limits(
+                    self._rewrite_command(composite_result[0], pipeline.output_dir)
                 )
             else:
                 duration_s = chunk_duration_ms / 1000
@@ -498,6 +500,25 @@ echo "[OK] Chunk concatenation complete: ./output/final.mp4"
                 new_arg = new_arg.replace(pipeline_output_dir, "./output")
 
             rewritten.append(new_arg)
+
+        return rewritten
+
+    def _drop_server_only_composite_limits(self, cmd: list[str]) -> list[str]:
+        """Remove server-only FFmpeg resource caps from package composite scripts.
+
+        The render package targets output parity with Export, but it runs on a
+        client machine. Cloud Run-specific caps such as `-threads 2` should not
+        be baked into the downloaded scripts.
+        """
+        rewritten: list[str] = []
+        idx = 0
+        while idx < len(cmd):
+            if cmd[idx] == "-threads" and idx + 1 < len(cmd):
+                idx += 2
+                continue
+
+            rewritten.append(cmd[idx])
+            idx += 1
 
         return rewritten
 
@@ -668,6 +689,15 @@ docker run --rm \
                 "shell": "bash",
                 "docker_image": "jrottenberg/ffmpeg:6.1-ubuntu2204",
             },
+            "execution_policy": {
+                "output_parity_target": "Matches Export output for the same timeline/assets",
+                "server_ffmpeg_threads": settings.render_ffmpeg_threads,
+                "package_ffmpeg_threads": "auto",
+                "notes": [
+                    "Package composite scripts omit the server-side FFmpeg thread cap.",
+                    "render-docker.sh pins the FFmpeg runtime but does not emulate Cloud Run resource limits.",
+                ],
+            },
         }
 
         path = os.path.join(self.package_dir, "manifest.json")
@@ -723,6 +753,12 @@ NOTES:
   - All file paths in scripts are relative to the package root
   - FFmpeg must be in your PATH
   - render.sh prints the server FFmpeg version used to build this package
+  - scripts/02_composite_video.sh intentionally does not pin FFmpeg thread count;
+    local FFmpeg chooses threads automatically
+  - Server-side `-threads {settings.render_ffmpeg_threads}` is treated as a Cloud Run
+    resource cap, not as output-parity behavior
+  - render-docker.sh pins the FFmpeg image/version only; it does not recreate
+    server CPU or memory limits
 """
         path = os.path.join(self.package_dir, "README.txt")
         with open(path, "w") as f:

--- a/backend/tests/test_render_package_builder.py
+++ b/backend/tests/test_render_package_builder.py
@@ -76,6 +76,122 @@ def _framemd5(path: Path) -> str:
     return "\n".join(line for line in result.stdout.splitlines() if not line.startswith("#"))
 
 
+def _minimal_image_timeline(duration_ms: int = 1200) -> dict:
+    return {
+        "version": "1.0",
+        "duration_ms": duration_ms,
+        "layers": [
+            {
+                "id": "layer-background",
+                "name": "Background",
+                "type": "background",
+                "visible": True,
+                "clips": [
+                    {
+                        "id": "clip-background",
+                        "asset_id": "asset-image-1",
+                        "start_ms": 0,
+                        "duration_ms": duration_ms,
+                        "in_point_ms": 0,
+                        "out_point_ms": duration_ms,
+                        "transform": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 320,
+                            "height": 180,
+                            "scale": 1.0,
+                            "rotation": 0,
+                        },
+                    }
+                ],
+            }
+        ],
+        "audio_tracks": [],
+        "groups": [],
+        "markers": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_render_package_composite_script_omits_server_thread_cap(
+    temp_output_dir: Path,
+) -> None:
+    image_path = temp_output_dir / "background.png"
+    Image.new("RGBA", (320, 180), (24, 78, 164, 255)).save(image_path)
+
+    builder = RenderPackageBuilder(
+        project_id="proj-thread-policy",
+        project_name="Thread Policy",
+        width=320,
+        height=180,
+        fps=30,
+    )
+    try:
+        await builder.build(
+            _minimal_image_timeline(),
+            {"asset-image-1": str(image_path)},
+            {"asset-image-1": "background.png"},
+        )
+
+        composite_script = (
+            Path(builder.package_dir) / "scripts" / "02_composite_video.sh"
+        ).read_text()
+        manifest = json.loads((Path(builder.package_dir) / "manifest.json").read_text())
+        readme = (Path(builder.package_dir) / "README.txt").read_text()
+
+        assert "-threads" not in composite_script
+        assert manifest["execution_policy"]["server_ffmpeg_threads"] == (
+            package_builder_module.settings.render_ffmpeg_threads
+        )
+        assert manifest["execution_policy"]["package_ffmpeg_threads"] == "auto"
+        assert "omit the server-side FFmpeg thread cap" in "\n".join(
+            manifest["execution_policy"]["notes"]
+        )
+        assert "intentionally does not pin FFmpeg thread count" in readme
+    finally:
+        builder.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_chunked_render_package_composite_script_omits_server_thread_cap(
+    temp_output_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image_path = temp_output_dir / "background.png"
+    Image.new("RGBA", (320, 180), (24, 78, 164, 255)).save(image_path)
+
+    monkeypatch.setattr(
+        package_builder_module,
+        "analyze_timeline_for_memory",
+        lambda *_args, **_kwargs: {
+            "needs_chunking": True,
+            "recommended_chunks": 3,
+            "chunk_duration_s": 1,
+        },
+    )
+
+    builder = RenderPackageBuilder(
+        project_id="proj-thread-policy-chunked",
+        project_name="Thread Policy Chunked",
+        width=320,
+        height=180,
+        fps=30,
+    )
+    try:
+        await builder.build(
+            _minimal_image_timeline(duration_ms=2500),
+            {"asset-image-1": str(image_path)},
+            {"asset-image-1": "background.png"},
+        )
+
+        chunk_script = (
+            Path(builder.package_dir) / "scripts" / "01_render_chunk_000.sh"
+        ).read_text()
+        assert "-threads" not in chunk_script
+    finally:
+        builder.cleanup()
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
 async def test_render_package_output_matches_server_export(temp_output_dir: Path) -> None:

--- a/docs/RENDER_PACKAGE_PARITY_PLAN.md
+++ b/docs/RENDER_PACKAGE_PARITY_PLAN.md
@@ -134,6 +134,8 @@ Current state:
 - `render-docker.sh` を package に同梱済み
 - shell quoting drift を避けるため package scripts は `filter_complex_script` を使う
 - audio intermediate は lossy AAC ではなく WAV に固定し、final MP4 でのみ AAC 化する
+- package scripts は server-side `-threads 2` を引き継がず、local FFmpeg の
+  thread auto-selection に委ねる
 
 ### 6. parity を release gate にする
 
@@ -172,6 +174,14 @@ When modifying render behavior:
 2. If yes, add or update a parity fixture first or in the same PR
 3. Verify both server `Export` and package execution
 4. Do not ship package-only rendering behavior unless explicitly accepted as temporary debt
+
+Execution-policy boundary:
+
+- Output parity is the goal for the encoded result, not for Cloud Run resource caps
+- Server-only execution limits such as FFmpeg `-threads` may be omitted from package scripts
+  when they are documented in package README / manifest and covered by tests
+- `render-docker.sh` pins FFmpeg runtime/version, but it is not a guarantee of matching
+  server CPU or memory limits
 
 ## Exit Condition
 


### PR DESCRIPTION
## Summary
- treat `render_ffmpeg_threads` as a server-side Cloud Run resource cap, not package parity behavior
- strip `-threads <n>` from generated render package composite scripts while keeping server export commands unchanged
- document the package execution policy in the manifest, README, and parity plan, and add regression tests for standard/chunked packages

## Self-Review
- Self-reviewed the diff for scope and kept the server export path unchanged
- Confirmed only package script generation, docs, and tests changed

## Verification Commands
- `uv run --extra dev ruff check src tests/test_render_package_builder.py`
- `uv run --extra dev ruff format --check src tests/test_render_package_builder.py`
- `ENVIRONMENT=test uv run --extra dev mypy src/render/package_builder.py`
- `uv build`
- `uv run --python 3.11 pytest tests/test_audio_mixer.py tests/test_render_package_builder.py tests/test_render_pipeline.py tests/test_timeline_normalization.py -q`

## Issue-Specific Verification
- Verified the generated package composite script no longer contains `-threads` for both standard and chunked package flows via regression tests that inspect the emitted shell scripts and manifest/README policy text
- Verified server export parity coverage still passes in the render package/pipeline gate above

## Manual Verification
- No frontend or editor interaction was involved in this issue
- Behavior was verified at the generated package artifact level (script/manifest/README output)

## Residual Risks
- Local FFmpeg auto-thread selection may change runtime characteristics across machines, but the package now documents that this is outside the output-parity contract
