### PR TITLE
fix: guarantee minimum 2 source-frame tpad for slow-speed clips

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1580,7 +1580,15 @@ class RenderPipeline:
         # tpad stop_duration by speed so that the effective freeze duration
         # equals the user-specified freeze_frame_ms.
         # Example: speed=2, freeze=3000ms → tpad=6.0s → setpts /2 → effective 3.0s
-        tpad_duration_ms = pad_duration_ms * speed
+        #
+        # Ensure minimum source-time padding of 2 frames.
+        # tpad operates in source time (before setpts speed adjustment).
+        # For speed < 1, pad_duration_ms * speed yields less than 1 source
+        # frame, which cannot absorb -ss/-to decode variance (up to 1 source
+        # frame).  Guarantee at least 2 source frames so the cloned padding
+        # always covers the decode gap regardless of speed.
+        min_source_pad_ms = 2 * (1000 / self.fps)
+        tpad_duration_ms = max(pad_duration_ms * speed, min_source_pad_ms)
 
         # FFmpeg 7.x bug: tpad is silently ignored when ANY timestamp-
         # altering filter (trim, setpts) precedes it in the same chain.

--- a/backend/tests/test_render_pipeline.py
+++ b/backend/tests/test_render_pipeline.py
@@ -1373,6 +1373,69 @@ class TestRenderPipeline:
         assert "tpad=" not in filter_str
         assert input_prefix == []
 
+    def test_build_clip_filter_slow_speed_tpad_has_source_floor(self):
+        """speed < 1 clips must have tpad stop_duration >= 2 source frames.
+
+        For speed=0.2 and pad_duration_ms=200ms (boundary guard):
+          Old implementation: tpad = 200 * 0.2 = 40ms = 0.04s
+          2 source frames at 30fps: 2/30 = 0.0667s
+
+        The old result (0.04s) is less than 1 source frame, so it cannot
+        absorb decode variance.  The fixed implementation uses max() to
+        guarantee at least 2 source frames.  Regression guard for #160.
+        """
+        pipeline = RenderPipeline()
+
+        filter_str, input_prefix = pipeline._build_clip_filter(
+            input_idx=1,
+            clip={
+                "start_ms": 0,
+                "duration_ms": 5000,
+                "in_point_ms": 0,
+                "out_point_ms": 5000,
+                "speed": 0.2,
+                "transform": {
+                    "x": 0,
+                    "y": 0,
+                    "scale": 1.0,
+                    "rotation": 0,
+                    "width": 1920,
+                    "height": 1080,
+                },
+                "effects": {"opacity": 1.0},
+            },
+            layer_type="content",
+            base_output="0:v",
+            total_duration_ms=8000,
+            export_start_ms=0,
+            export_end_ms=8000,
+            is_still_image=False,
+        )
+
+        # tpad must be present (boundary guard is always needed for video clips)
+        assert "tpad=" in filter_str, "tpad should be present for video clips"
+
+        # Extract stop_duration value from tpad filter
+        import re
+
+        m = re.search(r"tpad=stop_mode=clone:stop_duration=([0-9.]+)", filter_str)
+        assert m is not None, f"tpad stop_duration not found in: {filter_str}"
+        stop_duration_s = float(m.group(1))
+
+        # Minimum source-time floor: 2 frames at pipeline FPS
+        min_source_frames_s = 2 / pipeline.fps  # e.g., 2/30 ≈ 0.0667s
+        old_value_s = (200 * 0.2) / 1000  # 0.04s — would fail without the fix
+
+        assert stop_duration_s >= min_source_frames_s, (
+            f"tpad stop_duration={stop_duration_s:.4f}s is below 2-frame floor "
+            f"({min_source_frames_s:.4f}s at {pipeline.fps}fps). "
+            f"Old implementation would yield {old_value_s:.4f}s."
+        )
+        # Confirm old value would indeed be less than the floor (test is meaningful)
+        assert old_value_s < min_source_frames_s, (
+            "Old value is already above the floor — test logic is wrong"
+        )
+
 
 class TestUndoableAction:
     """Tests for UndoableAction dataclass."""


### PR DESCRIPTION
## Summary
- speed < 1 のクリップで tpad ソース時間パディングが1フレーム未満になり、クリップ接合部で暗転する問題を修正
- `tpad_duration_ms = max(pad_duration_ms * speed, 2 * (1000 / fps))` でソース時間2フレームの下限を保証
- speed >= 1: 変化なし、speed < 1: ソース2フレーム保証（再生時間は 2/speed フレーム、enableで制御）

## Verification
- セクション3-1 clip7 (speed=0.2) の filtergraph を手動修正し再レンダリング → 61秒付近の暗転解消を確認済み
- frame_0021 (61.167s) YAVG: 33.3 → 175.7

## Test plan
- [x] `ruff check src/` clean
- [x] `ruff format --check src/` clean
- [x] `pytest tests/test_render_pipeline.py` 55 tests passed
- [x] 新規テスト `test_build_clip_filter_slow_speed_tpad_has_source_floor` 追加
- [ ] デプロイ後セクション3-1を再レンダリングし61秒付近を確認

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>