### PR TITLE
feat: 同一トラック優先スナップで微小ギャップを防止

### DIFF
--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -570,34 +570,70 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
 
   // Snap threshold in milliseconds (equivalent to ~5 pixels at normal zoom)
   const SNAP_THRESHOLD_MS = 500
+  // Cross-track snap threshold (stricter, used when no same-track snap found)
+  const CROSS_TRACK_SNAP_THRESHOLD_MS = 200
 
   // Get all snap points (start and end of all clips) excluding specified clips
-  const getSnapPoints = useCallback((excludeClipIds: Set<string>): number[] => {
+  // When options.layerId is provided, only returns points from that video layer.
+  // When options.trackId is provided, only returns points from that audio track.
+  // Without options, returns all snap points (backward compatible).
+  const getSnapPoints = useCallback((excludeClipIds: Set<string>, options?: { layerId?: string; trackId?: string }): number[] => {
     const points = new Set<number>()
 
-    // Add video clip boundaries
-    for (const layer of timeline.layers) {
-      for (const clip of layer.clips) {
-        if (!excludeClipIds.has(clip.id)) {
-          points.add(clip.start_ms)
-          points.add(clip.start_ms + clip.duration_ms + (clip.freeze_frame_ms ?? 0))
+    if (options?.layerId) {
+      // Same-layer only: video clips in the specified layer
+      const layer = timeline.layers.find(l => l.id === options.layerId)
+      if (layer) {
+        for (const clip of layer.clips) {
+          if (!excludeClipIds.has(clip.id)) {
+            points.add(clip.start_ms)
+            points.add(clip.start_ms + clip.duration_ms + (clip.freeze_frame_ms ?? 0))
+          }
         }
       }
-    }
-
-    // Add audio clip boundaries
-    for (const track of timeline.audio_tracks) {
-      for (const clip of track.clips) {
-        if (!excludeClipIds.has(clip.id)) {
-          points.add(clip.start_ms)
-          points.add(clip.start_ms + clip.duration_ms)
+      // Add playhead position (0 and current time)
+      points.add(0)
+      points.add(currentTimeMs)
+    } else if (options?.trackId) {
+      // Same-track only: audio clips in the specified track
+      const track = timeline.audio_tracks.find(t => t.id === options.trackId)
+      if (track) {
+        for (const clip of track.clips) {
+          if (!excludeClipIds.has(clip.id)) {
+            points.add(clip.start_ms)
+            points.add(clip.start_ms + clip.duration_ms)
+          }
         }
       }
-    }
+      // Add playhead position (0 and current time)
+      points.add(0)
+      points.add(currentTimeMs)
+    } else {
+      // All snap points (original behavior, backward compatible)
+      // Add video clip boundaries
+      for (const layer of timeline.layers) {
+        for (const clip of layer.clips) {
+          if (!excludeClipIds.has(clip.id)) {
+            points.add(clip.start_ms)
+            points.add(clip.start_ms + clip.duration_ms + (clip.freeze_frame_ms ?? 0))
+          }
+        }
+      }
 
-    // Add playhead position (0 and current time)
-    points.add(0)
-    points.add(currentTimeMs)
+      // Add audio clip boundaries
+      for (const track of timeline.audio_tracks) {
+        for (const clip of track.clips) {
+          if (!excludeClipIds.has(clip.id)) {
+            points.add(clip.start_ms)
+            points.add(clip.start_ms + clip.duration_ms)
+          }
+        }
+      }
+
+      // Add playhead position (0 and current time)
+      points.add(0)
+      points.add(currentTimeMs)
+    }
 
     return Array.from(points).sort((a, b) => a - b)
   }, [timeline, currentTimeMs])
@@ -1538,6 +1574,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     pixelsPerSecond,
     isSnapEnabled,
     snapThresholdMs: SNAP_THRESHOLD_MS,
+    crossTrackSnapThresholdMs: CROSS_TRACK_SNAP_THRESHOLD_MS,
     getSnapPoints,
     findNearestSnapPoint,
     updateTimeline,

--- a/frontend/src/components/editor/timeline/types.ts
+++ b/frontend/src/components/editor/timeline/types.ts
@@ -51,11 +51,13 @@ export interface DragState {
   groupVideoClips?: GroupClipInitialPosition[]
   groupAudioClips?: GroupClipInitialPosition[]
   targetTrackId?: string | null  // Track to drop the clip onto (for cross-track drag)
+  layerId?: string  // Layer ID for same-track snap priority (audio clips don't have this, use trackId)
 }
 
 export interface VideoDragState {
   type: 'move' | 'trim-start' | 'trim-end' | 'stretch-start' | 'stretch-end' | 'freeze-end'
   layerId: string
+  dragLayerId?: string  // Layer ID at drag start (for same-layer snap priority)
   clipId: string
   startX: number
   startY: number  // Added for cross-layer drag detection

--- a/frontend/src/components/editor/timeline/useTimelineDrag.ts
+++ b/frontend/src/components/editor/timeline/useTimelineDrag.ts
@@ -14,7 +14,8 @@ interface UseTimelineDragParams {
   pixelsPerSecond: number
   isSnapEnabled: boolean
   snapThresholdMs: number
-  getSnapPoints: (excludeClipIds: Set<string>) => number[]
+  crossTrackSnapThresholdMs: number
+  getSnapPoints: (excludeClipIds: Set<string>, options?: { layerId?: string; trackId?: string }) => number[]
   findNearestSnapPoint: (timeMs: number, snapPoints: number[], threshold: number) => number | null
   updateTimeline: (projectId: string, data: TimelineData, label?: string) => Promise<void> | void
   projectId: string
@@ -40,6 +41,7 @@ export function useTimelineDrag({
   pixelsPerSecond,
   isSnapEnabled,
   snapThresholdMs,
+  crossTrackSnapThresholdMs,
   getSnapPoints,
   findNearestSnapPoint,
   updateTimeline,
@@ -220,12 +222,20 @@ export function useTimelineDrag({
 
     if (dragState.type === 'move') {
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newStartMs = dragState.initialStartMs + deltaMs
         const newEndMs = newStartMs + dragState.initialDurationMs
 
-        const snapStart = findNearestSnapPoint(newStartMs, snapPoints, snapThresholdMs)
-        const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
+        // Phase 1: Same-track snap (stricter threshold via trackId)
+        const sameTrackSnapPoints = getSnapPoints(draggingClipIds, { trackId: dragState.trackId })
+        let snapStart = findNearestSnapPoint(newStartMs, sameTrackSnapPoints, snapThresholdMs)
+        let snapEnd = findNearestSnapPoint(newEndMs, sameTrackSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-track snap with stricter threshold
+        if (snapStart === null && snapEnd === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapStart = findNearestSnapPoint(newStartMs, allSnapPoints, crossTrackSnapThresholdMs)
+          snapEnd = findNearestSnapPoint(newEndMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapStart !== null) {
           deltaMs = snapStart - dragState.initialStartMs
@@ -242,9 +252,17 @@ export function useTimelineDrag({
     } else if (dragState.type === 'trim-start') {
       // Snap the new start position when trimming from the left
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newStartMs = Math.max(0, dragState.initialStartMs + deltaMs)
-        const snapStart = findNearestSnapPoint(newStartMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-track snap
+        const sameTrackSnapPoints = getSnapPoints(draggingClipIds, { trackId: dragState.trackId })
+        let snapStart = findNearestSnapPoint(newStartMs, sameTrackSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-track snap with stricter threshold
+        if (snapStart === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapStart = findNearestSnapPoint(newStartMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapStart !== null) {
           deltaMs = snapStart - dragState.initialStartMs
@@ -258,9 +276,17 @@ export function useTimelineDrag({
     } else if (dragState.type === 'trim-end') {
       // Snap the new end position when trimming from the right
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newEndMs = dragState.initialStartMs + dragState.initialDurationMs + deltaMs
-        const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-track snap
+        const sameTrackSnapPoints = getSnapPoints(draggingClipIds, { trackId: dragState.trackId })
+        let snapEnd = findNearestSnapPoint(newEndMs, sameTrackSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-track snap with stricter threshold
+        if (snapEnd === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapEnd = findNearestSnapPoint(newEndMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapEnd !== null) {
           deltaMs = snapEnd - dragState.initialStartMs - dragState.initialDurationMs
@@ -320,7 +346,7 @@ export function useTimelineDrag({
         dragRafRef.current = null
       })
     }
-  }, [dragState, pixelsPerSecond, isSnapEnabled, getSnapPoints, findNearestSnapPoint, snapThresholdMs, setSnapLineMs, audioTracks, trackRefs])
+  }, [dragState, pixelsPerSecond, isSnapEnabled, getSnapPoints, findNearestSnapPoint, snapThresholdMs, crossTrackSnapThresholdMs, setSnapLineMs, audioTracks, trackRefs])
 
   const handleClipDragEnd = useCallback(() => {
     if (dragRafRef.current !== null) {
@@ -633,6 +659,7 @@ export function useTimelineDrag({
     setVideoDragState({
       type,
       layerId,
+      dragLayerId: layerId,  // Record the layer at drag start for same-layer snap priority
       clipId,
       startX: e.clientX,
       startY: e.clientY,
@@ -702,14 +729,25 @@ export function useTimelineDrag({
     }
     pendingTargetLayerIdRef.current = detectedTargetLayerId
 
+    // The layer the clip started dragging from (for same-layer snap priority)
+    const dragStartLayerId = videoDragState.dragLayerId ?? videoDragState.layerId
+
     if (videoDragState.type === 'move') {
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newStartMs = videoDragState.initialStartMs + deltaMs
         const newEndMs = newStartMs + videoDragState.initialVisibleDurationMs
 
-        const snapStart = findNearestSnapPoint(newStartMs, snapPoints, snapThresholdMs)
-        const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
+        // Phase 1: Same-layer snap
+        const sameLayerSnapPoints = getSnapPoints(draggingClipIds, { layerId: dragStartLayerId })
+        let snapStart = findNearestSnapPoint(newStartMs, sameLayerSnapPoints, snapThresholdMs)
+        let snapEnd = findNearestSnapPoint(newEndMs, sameLayerSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-layer snap with stricter threshold
+        if (snapStart === null && snapEnd === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapStart = findNearestSnapPoint(newStartMs, allSnapPoints, crossTrackSnapThresholdMs)
+          snapEnd = findNearestSnapPoint(newEndMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapStart !== null) {
           deltaMs = snapStart - videoDragState.initialStartMs
@@ -738,9 +776,17 @@ export function useTimelineDrag({
     } else if (videoDragState.type === 'trim-start') {
       // Snap the new start position when trimming from the left
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newStartMs = Math.max(0, videoDragState.initialStartMs + deltaMs)
-        const snapStart = findNearestSnapPoint(newStartMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-layer snap
+        const sameLayerSnapPoints = getSnapPoints(draggingClipIds, { layerId: dragStartLayerId })
+        let snapStart = findNearestSnapPoint(newStartMs, sameLayerSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-layer snap with stricter threshold
+        if (snapStart === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapStart = findNearestSnapPoint(newStartMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapStart !== null) {
           deltaMs = snapStart - videoDragState.initialStartMs
@@ -754,9 +800,17 @@ export function useTimelineDrag({
     } else if (videoDragState.type === 'trim-end') {
       // Snap the new end position when trimming from the right
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newEndMs = videoDragState.initialStartMs + videoDragState.initialDurationMs + deltaMs
-        const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-layer snap
+        const sameLayerSnapPoints = getSnapPoints(draggingClipIds, { layerId: dragStartLayerId })
+        let snapEnd = findNearestSnapPoint(newEndMs, sameLayerSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-layer snap with stricter threshold
+        if (snapEnd === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapEnd = findNearestSnapPoint(newEndMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapEnd !== null) {
           deltaMs = snapEnd - videoDragState.initialStartMs - videoDragState.initialDurationMs
@@ -770,9 +824,17 @@ export function useTimelineDrag({
     } else if (videoDragState.type === 'stretch-start') {
       // Snap the new start position when stretching from the left
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newStartMs = Math.max(0, videoDragState.initialStartMs + deltaMs)
-        const snapStart = findNearestSnapPoint(newStartMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-layer snap
+        const sameLayerSnapPoints = getSnapPoints(draggingClipIds, { layerId: dragStartLayerId })
+        let snapStart = findNearestSnapPoint(newStartMs, sameLayerSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-layer snap with stricter threshold
+        if (snapStart === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapStart = findNearestSnapPoint(newStartMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapStart !== null) {
           deltaMs = snapStart - videoDragState.initialStartMs
@@ -786,9 +848,17 @@ export function useTimelineDrag({
     } else if (videoDragState.type === 'stretch-end') {
       // Snap the new end position when stretching from the right
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const newEndMs = videoDragState.initialStartMs + videoDragState.initialDurationMs + deltaMs
-        const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-layer snap
+        const sameLayerSnapPoints = getSnapPoints(draggingClipIds, { layerId: dragStartLayerId })
+        let snapEnd = findNearestSnapPoint(newEndMs, sameLayerSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-layer snap with stricter threshold
+        if (snapEnd === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapEnd = findNearestSnapPoint(newEndMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapEnd !== null) {
           deltaMs = snapEnd - videoDragState.initialStartMs - videoDragState.initialDurationMs
@@ -802,11 +872,19 @@ export function useTimelineDrag({
     } else if (videoDragState.type === 'freeze-end') {
       // Snap the new end position when extending with freeze frame
       if (isSnapEnabled) {
-        const snapPoints = getSnapPoints(draggingClipIds)
         const initialFreezeMs = videoDragState.initialFreezeFrameMs ?? 0
         const newFreezeMs = Math.max(0, initialFreezeMs + deltaMs)
         const newEndMs = videoDragState.initialStartMs + videoDragState.initialDurationMs + newFreezeMs
-        const snapEnd = findNearestSnapPoint(newEndMs, snapPoints, snapThresholdMs)
+
+        // Phase 1: Same-layer snap
+        const sameLayerSnapPoints = getSnapPoints(draggingClipIds, { layerId: dragStartLayerId })
+        let snapEnd = findNearestSnapPoint(newEndMs, sameLayerSnapPoints, snapThresholdMs)
+
+        // Phase 2: Fall back to all-layer snap with stricter threshold
+        if (snapEnd === null) {
+          const allSnapPoints = getSnapPoints(draggingClipIds)
+          snapEnd = findNearestSnapPoint(newEndMs, allSnapPoints, crossTrackSnapThresholdMs)
+        }
 
         if (snapEnd !== null) {
           const snappedFreezeMs = snapEnd - videoDragState.initialStartMs - videoDragState.initialDurationMs
@@ -835,7 +913,7 @@ export function useTimelineDrag({
         videoDragRafRef.current = null
       })
     }
-  }, [videoDragState, pixelsPerSecond, isSnapEnabled, getSnapPoints, findNearestSnapPoint, snapThresholdMs, setSnapLineMs, sortedLayers, layerRefs])
+  }, [videoDragState, pixelsPerSecond, isSnapEnabled, getSnapPoints, findNearestSnapPoint, snapThresholdMs, crossTrackSnapThresholdMs, setSnapLineMs, sortedLayers, layerRefs])
 
   const handleVideoClipDragEnd = useCallback(() => {
     if (videoDragRafRef.current !== null) {


### PR DESCRIPTION
## Summary
- 同一トラック/レイヤー内のスナップポイントを優先（閾値 500ms）
- 同一トラックにスナップ先がない場合のみ、全体から探索（閾値 200ms）
- 複数選択時は掴んでいるクリップのトラック/レイヤーを基準に
- playhead スナップ・ドロップ処理は従来通り（全体スナップ）

## Verification
- `npm run lint` — パス
- `npx tsc --noEmit` — パス
- `npm run build` — パス

## Test plan
- [x] lint / tsc / build パス
- [ ] E2E: 同一トラック上で隣接クリップにスナップされること
- [ ] E2E: 別トラックのクリップにもスナップできること（200ms以内）

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>