### PR TITLE
fix: freeze_frame 末尾境界の 1 フレーム黒化を修正 (#185)

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1873,10 +1873,20 @@ class RenderPipeline:
         logger.info(
             f"[CLIP DEBUG] Overlay enable: {enable_expr} (original: {start_ms}-{clip_end_ms}ms, export_start={export_start_ms}ms)"
         )
+        # eof_action=repeat: when the secondary stream hits EOF (e.g. at
+        # the end of a tpad-cloned freeze region), keep the last frame
+        # available to overlay instead of falling through to the base.
+        # Because 30fps quantization of setpts leaves the final output
+        # frame slightly before the enable boundary, eof_action=pass
+        # produces a single black frame at the freeze-frame / next-clip
+        # join (most visible for speed<1 clips adjoined by another clip
+        # on the same layer — see issue #185).  Frames past the enable
+        # window are still suppressed by enable='between(...)', so
+        # repeat has no visible effect outside the clip's time range.
         filter_str += (
             f"[{base_output}][{clip_ref}]overlay="
             f"x='{overlay_x}':y='{overlay_y}':"
-            f"eof_action=pass:enable='{enable_expr}'[{output_label}]"
+            f"eof_action=repeat:enable='{enable_expr}'[{output_label}]"
         )
 
         return filter_str, input_prefix_args


### PR DESCRIPTION
## Summary

- Closes #185
- `overlay=eof_action=pass` → `eof_action=repeat` に変更し、tpad で clone された freeze 区間の最終 playback フレームが 1 フレーム黒化する不具合を修正。
- 視覚的な副作用なし: `enable='between(...)'` により表示窓は従来どおり制御され、enable 外のフレームは依然非表示。

## 原因

speed<1 かつ直後に別クリップが隣接するケース（例: freeze 区間の末尾でちょうど次クリップが開始）で、30fps 出力グリッドと `setpts` 量子化のずれにより、secondary stream の最終フレーム playback PTS が enable 境界より ~1 フレーム手前 (~33ms) で終端する。`eof_action=pass` は secondary EOF 後に main(黒背景)をそのまま通すため、境界直前の 1 フレームが黒化していた。

### 最小再現

対象シーケンス: 動画3_セクション2-1 `/sequence/d4408e3d-c3d6-43ae-bb81-cf649b9912a2` の操作動画レイヤー 02:12 付近。

- clip[10]: `start=128700, dur=1074, freeze_frame_ms=3000, speed=0.7` → playback end 132.774s
- clip[11]: `start=132774, dur=9365, speed=0.7` → playback start 132.774s

| t [s] | 修正前 YAVG | 修正後 YAVG |
|------:|------------:|------------:|
| 132.700 | 198.718 | 198.718 |
| 132.733 | 198.718 | 198.718 |
| **132.767** | **16** (黒) | **198.718** |
| 132.800 | 198.733 | 198.733 |

## Test plan

- [x] `pytest tests/test_render_pipeline.py` (59 passed)
- [x] `ruff check src/render/pipeline.py`
- [x] minimal repro (ffmpeg filter_complex with exact pipeline output) で黒フレーム消失を確認
- [ ] 該当シーケンスの再レンダリングで 02:12 付近に黒フレームが無いことを確認（デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)