### PR TITLE
fix: Editorのプロパティ変更をUndoできるようにする

### DIFF
--- a/frontend/e2e/undo-property-change.spec.ts
+++ b/frontend/e2e/undo-property-change.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test'
+import { bootstrapMockEditorPage } from './helpers/editorMockServer'
+import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
+
+/**
+ * Regression for #184: property changes driven by slider drag
+ * (onChange → updateTimelineLocal + onMouseUp → commit) must be undoable.
+ *
+ * Pre-fix, updateTimelineLocal mutated the store to the in-progress value,
+ * so by the time the commit ran, the "before" snapshot pushed to the undo
+ * history was equal to the "after" — making Ctrl/Cmd+Z a no-op.
+ */
+test.describe('Undo property change (issue #184)', () => {
+  test('slider-driven opacity change is reverted by undo', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Seed a video clip so the property panel is available.
+    await dragAssetToVideoLayer(page, {
+      assetId: mock.primaryAssetId,
+      layerId: 'layer-1',
+      offsetX: 220,
+    })
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const clip = page.locator('[data-testid^="timeline-video-clip-"]').first()
+    await clip.click()
+
+    const opacityInput = page.getByTestId('video-opacity-input')
+    await expect(opacityInput).toHaveValue('100')
+
+    // Simulate a slider drag: input events drive onChange (→ updateTimelineLocal),
+    // then a mouseup drives the commit (→ saveSequence). React listens to the
+    // native 'input' event for range inputs, so we dispatch it directly.
+    const slider = page.getByTestId('video-opacity-slider')
+    await slider.evaluate((el: HTMLInputElement) => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(el, '0.8')
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      setter.call(el, '0.5')
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await slider.dispatchEvent('mouseup')
+
+    // Commit reached the server: new sequence update recorded.
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(2)
+    const committedClip = mock.calls.sequenceUpdates[1].timelineData.layers[0].clips[0]
+    expect(committedClip.effects.opacity).toBeCloseTo(0.5, 2)
+
+    // Move focus off the slider so the keyboard handler accepts Ctrl/Cmd+Z.
+    await page.getByTestId('timeline-area').click()
+
+    // Undo the opacity change.
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+    await page.keyboard.press(`${modifier}+z`)
+
+    // Re-select to refresh the property panel.
+    await clip.click()
+    await expect(page.getByTestId('video-opacity-input')).toHaveValue('100')
+
+    // The undo produced a new sequence update returning opacity to 1.0.
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBeGreaterThanOrEqual(3)
+    const restoredUpdate = mock.calls.sequenceUpdates[mock.calls.sequenceUpdates.length - 1]
+    const restoredClip = restoredUpdate.timelineData.layers[0].clips[0]
+    expect(restoredClip.effects.opacity).toBeCloseTo(1.0, 2)
+  })
+})

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -215,6 +215,11 @@ interface ProjectState {
   timelineFuture: HistoryEntry[]
   maxHistorySize: number
   historyVersion: number
+  // Snapshot captured at the start of an interactive edit (e.g. slider drag).
+  // During drag, updateTimelineLocal mutates the store to the in-progress value,
+  // so at commit time we must use this snapshot instead of the current timeline
+  // as the "previous" state pushed to the undo history.
+  pendingInteractionBaseline: TimelineData | null
   // Sequence support
   currentSequence: SequenceDetail | null
   sequenceLoading: boolean
@@ -228,6 +233,8 @@ interface ProjectState {
   deleteProject: (id: string) => Promise<void>
   updateTimeline: (id: string, timeline: TimelineData, labelOrOptions?: string | { label?: string; skipHistory?: boolean }) => Promise<void>
   updateTimelineLocal: (id: string, timeline: TimelineData) => void  // Local only, no API call
+  beginInteraction: () => void  // Snapshot current timeline as undo baseline for subsequent commit
+  endInteraction: () => void    // Discard pending baseline (abort without commit)
   applyRemoteOps: (projectId: string, newVersion: number, operations: Operation[]) => void
   resolveConflict: (action: 'reload' | 'force') => Promise<void>
   undo: (id: string) => Promise<void>
@@ -344,6 +351,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   timelineFuture: [],
   maxHistorySize: 50,
   historyVersion: 0,
+  pendingInteractionBaseline: null,
   currentSequence: null,
   sequenceLoading: false,
   editToken: null,
@@ -444,9 +452,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       ? { label: labelOrOptions, skipHistory: false }
       : { label: labelOrOptions?.label, skipHistory: labelOrOptions?.skipHistory ?? false }
 
-    // Save current state to history before update (deep copy to prevent reference issues)
-    if (!options.skipHistory && currentTimeline && state.currentProject?.id === id) {
-      const timelineCopy = JSON.parse(JSON.stringify(currentTimeline)) as TimelineData
+    // Save current state to history before update (deep copy to prevent reference issues).
+    // Prefer pendingInteractionBaseline when it was captured by beginInteraction(): during
+    // slider drag, updateTimelineLocal has already overwritten currentTimeline with the
+    // in-progress value, so using currentTimeline as the "before" would make undo a no-op.
+    const baselineTimeline = state.pendingInteractionBaseline ?? currentTimeline
+    if (!options.skipHistory && baselineTimeline && state.currentProject?.id === id) {
+      const timelineCopy = JSON.parse(JSON.stringify(baselineTimeline)) as TimelineData
       const entry: HistoryEntry = {
         timeline: timelineCopy,
         label: options.label ?? 'タイムライン更新',
@@ -457,7 +469,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       if (newHistory.length > state.maxHistorySize) {
         newHistory.shift()
       }
-      set({ timelineHistory: newHistory, timelineFuture: [] })
+      set({ timelineHistory: newHistory, timelineFuture: [], pendingInteractionBaseline: null })
+    } else if (state.pendingInteractionBaseline) {
+      set({ pendingInteractionBaseline: null })
     }
 
     // Normalize layers with default values for visible/locked, then round numeric fields
@@ -523,8 +537,40 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }
   },
 
+  // Capture a baseline snapshot of the current timeline so that the next
+  // updateTimeline/saveSequence call pushes that snapshot (not the
+  // already-mutated current state) onto the undo history. Safe to call
+  // repeatedly during a drag — only the first call takes effect.
+  beginInteraction: () => {
+    const state = get()
+    if (state.pendingInteractionBaseline) return
+    const currentTimeline =
+      state.currentSequence?.timeline_data ?? state.currentProject?.timeline_data
+    if (!currentTimeline) return
+    const snapshot = JSON.parse(JSON.stringify(currentTimeline)) as TimelineData
+    set({ pendingInteractionBaseline: snapshot })
+  },
+
+  // Discard any pending interaction baseline without committing.
+  endInteraction: () => {
+    if (get().pendingInteractionBaseline) set({ pendingInteractionBaseline: null })
+  },
+
   // Local-only update (no API call) - for use during drag operations
   updateTimelineLocal: (id: string, timeline: TimelineData) => {
+    // Auto-capture interaction baseline on the first local update of a drag burst,
+    // BEFORE mutating the store. This preserves the pre-drag timeline so the
+    // eventual commit (updateTimeline/saveSequence) can push a real "before"
+    // entry to the undo history.
+    const prevState = get()
+    if (!prevState.pendingInteractionBaseline) {
+      const baseline =
+        prevState.currentSequence?.timeline_data ?? prevState.currentProject?.timeline_data
+      if (baseline) {
+        set({ pendingInteractionBaseline: JSON.parse(JSON.stringify(baseline)) as TimelineData })
+      }
+    }
+
     // Normalize layers with default values for visible/locked
     const normalizedLayers = timeline.layers.map((layer, index) => ({
       ...layer,
@@ -790,7 +836,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     return future.length > 0 ? future[0].label : null
   },
 
-  clearHistory: () => set({ timelineHistory: [], timelineFuture: [] }),
+  clearHistory: () => set({ timelineHistory: [], timelineFuture: [], pendingInteractionBaseline: null }),
 
   fetchSequence: async (projectId: string, sequenceId: string) => {
     const fetchId = ++_fetchSequenceCounter
@@ -865,9 +911,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       ? { label: labelOrOptions, skipHistory: false }
       : { label: labelOrOptions?.label, skipHistory: labelOrOptions?.skipHistory ?? false }
 
-    // Save current state to history before update
-    if (!options.skipHistory && currentTimeline && state.currentSequence?.id === sequenceId) {
-      const timelineCopy = JSON.parse(JSON.stringify(currentTimeline)) as TimelineData
+    // Save current state to history before update.
+    // Prefer pendingInteractionBaseline captured by beginInteraction() — during drag,
+    // updateTimelineLocal has already overwritten currentTimeline with the in-progress
+    // value, so using currentTimeline as the "before" would make undo a no-op.
+    const baselineTimeline = state.pendingInteractionBaseline ?? currentTimeline
+    if (!options.skipHistory && baselineTimeline && state.currentSequence?.id === sequenceId) {
+      const timelineCopy = JSON.parse(JSON.stringify(baselineTimeline)) as TimelineData
       const entry: HistoryEntry = {
         timeline: timelineCopy,
         label: options.label ?? 'タイムライン更新',
@@ -875,7 +925,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       }
       const newHistory = [...state.timelineHistory, entry]
       if (newHistory.length > state.maxHistorySize) newHistory.shift()
-      set({ timelineHistory: newHistory, timelineFuture: [] })
+      set({ timelineHistory: newHistory, timelineFuture: [], pendingInteractionBaseline: null })
+    } else if (state.pendingInteractionBaseline) {
+      set({ pendingInteractionBaseline: null })
     }
 
     // Normalize layers and round numeric fields to eliminate floating-point drift


### PR DESCRIPTION
## Summary
- スライダー drag 等の「onChange → `updateTimelineLocal` + onMouseUp → commit」パターンで、commit 時点の store には既に変更後の timeline が入っており、history に push される「変更前」が実質「変更後」と同一になるため Undo が no-op になっていた。
- `projectStore` に `pendingInteractionBaseline` を追加し、`updateTimelineLocal` の初回呼び出しで pre-drag の timeline を snapshot。`updateTimeline` / `saveSequence` は baseline が存在すればそれを優先して history に積む。
- 明示的な drag 境界制御用に `beginInteraction` / `endInteraction` も公開 API として追加。

## Verification
- `npx tsc -p tsconfig.json --noEmit` — pass
- `npm run lint` — pass
- `npm run build` — pass
- `npx playwright test` — 54 passed / 26 skipped（既存テストに回帰なし）
- `e2e/undo-property-change.spec.ts` を旧実装にリバートして実行すると opacity が 50% のまま戻らず fail することを確認。修正後は 100% に戻ることを検証。

## Test plan
- [x] Focused regression test `e2e/undo-property-change.spec.ts` を追加（旧実装で fail / 修正後 pass）
- [x] 既存の Playwright スモーク / critical-path が全てパス
- [x] TypeScript / ESLint / build 通過

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>