### PR TITLE
fix: Undo/Redo 後もクリップ選択を維持する

### DIFF
--- a/frontend/e2e/undo-preserves-selection.spec.ts
+++ b/frontend/e2e/undo-preserves-selection.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+import { bootstrapMockEditorPage } from './helpers/editorMockServer'
+import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
+
+/**
+ * Regression for #189: Undo / Redo must preserve the current clip selection
+ * when the clip still exists in the new timeline, and must refresh the
+ * property panel so the reverted value is immediately visible. Pre-fix,
+ * the `historyVersion` watcher unconditionally cleared selection, forcing
+ * the user to re-select the clip to confirm what the undo reverted.
+ */
+test.describe('Undo preserves clip selection (issue #189)', () => {
+  test('selection and property panel refresh across undo/redo', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await dragAssetToVideoLayer(page, {
+      assetId: mock.primaryAssetId,
+      layerId: 'layer-1',
+      offsetX: 220,
+    })
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const clip = page.locator('[data-testid^="timeline-video-clip-"]').first()
+    await clip.click()
+
+    // Change scale via the number input (commits directly).
+    const scaleInput = page.getByTestId('video-scale-input')
+    await expect(scaleInput).toHaveValue('100')
+    await scaleInput.fill('150')
+    await scaleInput.press('Tab')
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(2)
+    await expect(scaleInput).toHaveValue('150')
+
+    // Move focus off the input so Ctrl/Cmd+Z is not swallowed.
+    await page.getByTestId('timeline-area').click()
+
+    // Undo — without this fix the property panel empties because selection is cleared.
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+    await page.keyboard.press(`${modifier}+z`)
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(3)
+
+    // Without clicking the clip again, the property panel should reflect the
+    // reverted value because the selection is preserved and refreshed.
+    await expect(page.getByTestId('video-scale-input')).toHaveValue('100')
+  })
+})

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -383,12 +383,60 @@ export default function Editor() {
     setChromaRenderOverlayDims(null)
   }, [selectedVideoClip?.clipId])
 
-  // Clear selection on undo/redo (historyVersion increments on each undo/redo)
+  // After undo/redo, refresh the selected clip's cached data from the new
+  // timeline so users can immediately verify property changes. Only clear the
+  // selection if the clip was actually removed by the history mutation.
+  // (Issue #189 — previously this unconditionally cleared the selection,
+  //  making it hard to confirm what the Undo reverted.)
   useEffect(() => {
-    if (historyVersion > 0) {
+    if (historyVersion === 0) return
+    const state = useProjectStore.getState()
+    const timeline = state.currentSequence?.timeline_data ?? state.currentProject?.timeline_data
+    if (!timeline) {
       setSelectedVideoClip(null)
       setSelectedClip(null)
+      return
     }
+
+    setSelectedVideoClip(prev => {
+      if (!prev) return prev
+      const layer = timeline.layers.find(l => l.id === prev.layerId)
+      const clip = layer?.clips.find(c => c.id === prev.clipId)
+      if (!clip) return null
+      return {
+        ...prev,
+        transform: clip.transform,
+        effects: clip.effects,
+        keyframes: clip.keyframes,
+        speed: clip.speed ?? 1,
+        freezeFrameMs: clip.freeze_frame_ms ?? 0,
+        startMs: clip.start_ms,
+        durationMs: clip.duration_ms,
+        inPointMs: clip.in_point_ms,
+        outPointMs: clip.out_point_ms ?? (clip.in_point_ms + clip.duration_ms * (clip.speed || 1)),
+        fadeInMs: clip.effects.fade_in_ms ?? 0,
+        fadeOutMs: clip.effects.fade_out_ms ?? 0,
+        textContent: clip.text_content,
+        textStyle: clip.text_style as typeof prev.textStyle,
+        crop: clip.crop,
+        shape: clip.shape,
+      }
+    })
+
+    setSelectedClip(prev => {
+      if (!prev) return prev
+      const track = timeline.audio_tracks.find(t => t.id === prev.trackId)
+      const clip = track?.clips.find(c => c.id === prev.clipId)
+      if (!clip) return null
+      return {
+        ...prev,
+        volume: clip.volume,
+        fadeInMs: clip.fade_in_ms,
+        fadeOutMs: clip.fade_out_ms,
+        startMs: clip.start_ms,
+        durationMs: clip.duration_ms,
+      }
+    })
   }, [historyVersion])
 
   // Dismiss chroma render overlay when playhead moves more than 50ms from captured time


### PR DESCRIPTION
## Summary
- `Editor.tsx` の `historyVersion` watcher が Undo/Redo のたびに無条件で選択をクリアしていたため、Undo 直後にプロパティパネルが空になり、戻った値をその場で確認できなかった。
- 最新 timeline を store から読み、`layerId + clipId` / `trackId + clipId` で選択中クリップを再検索。存在すれば cached プロパティ（transform / effects / keyframes / speed / fades / text / shape / crop 等）を refresh、存在しない場合のみ null にする。
- `useProjectStore.getState()` + functional setter を使い、useEffect の依存は `historyVersion` のみに保つ。

## Verification
- `npx tsc -p tsconfig.json --noEmit` — pass
- `npm run lint` — pass
- `npm run build` — pass
- `npx playwright test` — 55 passed / 26 skipped（既存テストに回帰なし）
- `e2e/undo-preserves-selection.spec.ts`: scale を 100→150 に変更 → Undo → 再クリックなしで scale input が 100 に戻ることを検証。Editor.tsx を旧実装にリバートして実行すると input が空になり fail することを確認。

## Test plan
- [x] Focused regression test 追加（旧実装で fail / 修正後 pass）
- [x] Playwright 全体パス
- [x] TypeScript / ESLint / build 通過

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>