### PR TITLE
feat: AIチャットからレイヤー操作（追加/更新/並べ替え/削除）を接続 (#188)

### DIFF
--- a/backend/src/services/ai_service.py
+++ b/backend/src/services/ai_service.py
@@ -4794,9 +4794,7 @@ class AIService:
         if failed_actions:
             failed_descs = [a.description for a in failed_actions]
             clean_message = (
-                clean_message.strip()
-                + "\n\n⚠️ 実行できなかった操作: "
-                + ", ".join(failed_descs)
+                clean_message.strip() + "\n\n⚠️ 実行できなかった操作: " + ", ".join(failed_descs)
             )
         else:
             clean_message = clean_message.strip()

--- a/backend/src/services/ai_service.py
+++ b/backend/src/services/ai_service.py
@@ -4789,11 +4789,23 @@ class AIService:
         # Check if any actions were successfully applied
         any_applied = any(action.applied for action in actions) if actions else False
 
-        logger.info(f"[AI Response] Clean message length: {len(clean_message.strip())}")
+        # Append failed action warnings to the message so the user knows what didn't execute
+        failed_actions = [a for a in actions if not a.applied]
+        if failed_actions:
+            failed_descs = [a.description for a in failed_actions]
+            clean_message = (
+                clean_message.strip()
+                + "\n\n⚠️ 実行できなかった操作: "
+                + ", ".join(failed_descs)
+            )
+        else:
+            clean_message = clean_message.strip()
+
+        logger.info(f"[AI Response] Clean message length: {len(clean_message)}")
         logger.info(f"[AI Response] Actions count: {len(actions)}, any_applied: {any_applied}")
 
         return ChatResponse(
-            message=clean_message.strip(),
+            message=clean_message,
             actions=actions,
             actions_applied=any_applied,
         )
@@ -5031,9 +5043,42 @@ class AIService:
         "data": {{"x": 0, "y": 0, "scale": 1.0, "rotation": 0}}
       }}
     ]
+  }},
+  {{
+    "type": "add_layer",
+    "data": {{
+      "name": "レイヤー名",
+      "layer_type": "content",
+      "insert_at": null
+    }}
+  }},
+  {{
+    "type": "update_layer",
+    "layer_id": "レイヤーID",
+    "data": {{
+      "name": "新しい名称（省略可）",
+      "visible": true,
+      "locked": false
+    }}
+  }},
+  {{
+    "type": "reorder_layers",
+    "data": {{
+      "layer_ids": ["レイヤーID1", "レイヤーID2"]
+    }}
+  }},
+  {{
+    "type": "delete_layer",
+    "layer_id": "レイヤーID"
   }}
 ]
 ```
+
+## レイヤー操作の注意
+- `layer_type` の許可値: `content`, `background`, `avatar`, `effects`, `text`
+- `add_layer` の `insert_at`: 0=先頭（最前面）、null=先頭（デフォルト）
+- `update_layer` の `data` は変更したいフィールドのみ指定可（name/visible/locked）
+- `reorder_layers` の `layer_ids`: 全レイヤーIDを新しい並び順で指定
 
 ## 重要: asset_id について
 - **asset_id は必ず UUID 形式で指定してください**（例: "6d591866-a838-46ff-a356-442b2bf2afeb"）
@@ -5148,6 +5193,81 @@ class AIService:
                                 applied=result.success,
                             )
                         )
+                elif op_type == "add_layer":
+                    data = op.get("data", {})
+                    name = data.get("name", "新しいレイヤー")
+                    layer_type = data.get("layer_type", "content")
+                    insert_at = data.get("insert_at")
+                    result = await self.add_layer(
+                        project,
+                        name=name,
+                        layer_type=layer_type,
+                        insert_at=insert_at,
+                    )
+                    actions.append(
+                        ChatAction(
+                            type="add_layer",
+                            description=f"レイヤー '{result.name}' を追加しました (id={result.id})",
+                            applied=True,
+                        )
+                    )
+                elif op_type == "update_layer":
+                    layer_id = op.get("layer_id")
+                    if not layer_id:
+                        raise ValueError("layer_id required for update_layer operation")
+                    data = op.get("data", {})
+                    result = await self.update_layer(
+                        project,
+                        layer_id=layer_id,
+                        name=data.get("name"),
+                        visible=data.get("visible"),
+                        locked=data.get("locked"),
+                    )
+                    if result is None:
+                        raise ValueError(f"Layer not found: {layer_id}")
+                    actions.append(
+                        ChatAction(
+                            type="update_layer",
+                            description=f"レイヤー '{result.name}' を更新しました (id={result.id})",
+                            applied=True,
+                        )
+                    )
+                elif op_type == "reorder_layers":
+                    data = op.get("data", {})
+                    layer_ids = data.get("layer_ids", [])
+                    if not layer_ids:
+                        raise ValueError("layer_ids required for reorder_layers operation")
+                    result = await self.reorder_layers(project, layer_ids=layer_ids)
+                    actions.append(
+                        ChatAction(
+                            type="reorder_layers",
+                            description=f"{len(result)} 個のレイヤーを並べ替えました",
+                            applied=True,
+                        )
+                    )
+                elif op_type == "delete_layer":
+                    layer_id = op.get("layer_id")
+                    if not layer_id:
+                        raise ValueError("layer_id required for delete_layer operation")
+                    timeline = project.timeline_data or {}
+                    layers = timeline.get("layers", [])
+                    layer_to_delete = next(
+                        (lay for lay in layers if lay.get("id") == layer_id), None
+                    )
+                    if layer_to_delete is None:
+                        raise ValueError(f"Layer not found: {layer_id}")
+                    layer_name = layer_to_delete.get("name", layer_id)
+                    timeline["layers"] = [lay for lay in layers if lay.get("id") != layer_id]
+                    project.timeline_data = timeline
+                    flag_modified(project, "timeline_data")
+                    await self.db.flush()
+                    actions.append(
+                        ChatAction(
+                            type="delete_layer",
+                            description=f"レイヤー '{layer_name}' を削除しました (id={layer_id})",
+                            applied=True,
+                        )
+                    )
                 else:
                     actions.append(
                         ChatAction(

--- a/backend/tests/test_ai_api.py
+++ b/backend/tests/test_ai_api.py
@@ -1326,6 +1326,18 @@ class TestChatSequenceContext:
         assert "left_text_content" in prompt
         assert "id=` の値は有効な clip_id prefix" in prompt
 
+    def test_build_chat_system_prompt_includes_layer_operations(self, ai_service):
+        """Prompt should include layer operation schemas."""
+        prompt = ai_service._build_chat_system_prompt("context")
+
+        assert '"type": "add_layer"' in prompt
+        assert '"type": "update_layer"' in prompt
+        assert '"type": "reorder_layers"' in prompt
+        assert '"type": "delete_layer"' in prompt
+        assert "content" in prompt
+        assert "background" in prompt
+        assert "avatar" in prompt
+
     def test_build_context_clip_summary_includes_background_state(self, ai_service):
         """Prompt context should expose background color and opacity for text clips."""
         clip = {
@@ -1965,3 +1977,273 @@ class TestPacingAnalysis:
 
         assert result.overall_avg_clip_duration_ms == 0
         assert len(result.segments) == 0
+
+
+# =============================================================================
+# Layer Operation Dispatch Tests (Issue #188)
+# =============================================================================
+
+
+class TestExecuteChatOperationsLayerDispatch:
+    """Tests for layer operation dispatch in _execute_chat_operations_on_project."""
+
+    @pytest.fixture
+    def project_with_layers(self):
+        """Project fixture with a minimal layer setup."""
+        project = MagicMock()
+        project.id = uuid.uuid4()
+        project.name = "Layer Test Project"
+        project.duration_ms = 60000
+        project.width = 1920
+        project.height = 1080
+        project.fps = 30
+        project.status = "draft"
+        project.updated_at = datetime.now(UTC)
+        project.timeline_data = {
+            "duration_ms": 60000,
+            "layers": [
+                {
+                    "id": "layer-bg-001",
+                    "name": "背景",
+                    "type": "background",
+                    "visible": True,
+                    "locked": False,
+                    "clips": [],
+                },
+                {
+                    "id": "layer-content-001",
+                    "name": "コンテンツ",
+                    "type": "content",
+                    "visible": True,
+                    "locked": False,
+                    "clips": [],
+                },
+            ],
+            "audio_tracks": [],
+        }
+        return project
+
+    @pytest.mark.asyncio
+    async def test_add_layer_dispatches_and_returns_action(
+        self, ai_service, project_with_layers
+    ):
+        """add_layer operation should create a new layer and return applied=True action."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "add_layer",
+                    "data": {
+                        "name": "テキストレイヤー",
+                        "layer_type": "text",
+                    },
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is True
+        assert actions[0].type == "add_layer"
+        assert "テキストレイヤー" in actions[0].description
+
+        # Layer should be added to the timeline
+        layers = project_with_layers.timeline_data["layers"]
+        assert any(lay["name"] == "テキストレイヤー" for lay in layers)
+
+    @pytest.mark.asyncio
+    async def test_add_layer_with_insert_at(self, ai_service, project_with_layers):
+        """add_layer with insert_at=0 should insert at the top of the list."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "add_layer",
+                    "data": {
+                        "name": "最前面レイヤー",
+                        "layer_type": "effects",
+                        "insert_at": 0,
+                    },
+                }
+            ],
+        )
+
+        assert actions[0].applied is True
+        layers = project_with_layers.timeline_data["layers"]
+        assert layers[0]["name"] == "最前面レイヤー"
+
+    @pytest.mark.asyncio
+    async def test_update_layer_dispatches_and_returns_action(
+        self, ai_service, project_with_layers
+    ):
+        """update_layer operation should modify layer properties and return applied=True."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "update_layer",
+                    "layer_id": "layer-content-001",
+                    "data": {
+                        "name": "メインコンテンツ",
+                        "visible": False,
+                    },
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is True
+        assert actions[0].type == "update_layer"
+
+        layers = project_with_layers.timeline_data["layers"]
+        updated = next(lay for lay in layers if lay["id"] == "layer-content-001")
+        assert updated["name"] == "メインコンテンツ"
+        assert updated["visible"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_layer_missing_layer_id_returns_error(
+        self, ai_service, project_with_layers
+    ):
+        """update_layer without layer_id should return applied=False with error message."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "update_layer",
+                    "data": {"name": "名前変更"},
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is False
+        assert "layer_id" in actions[0].description
+
+    @pytest.mark.asyncio
+    async def test_update_layer_nonexistent_layer_returns_error(
+        self, ai_service, project_with_layers
+    ):
+        """update_layer with unknown layer_id should return applied=False."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "update_layer",
+                    "layer_id": "no-such-layer",
+                    "data": {"name": "存在しない"},
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is False
+
+    @pytest.mark.asyncio
+    async def test_reorder_layers_dispatches_and_returns_action(
+        self, ai_service, project_with_layers
+    ):
+        """reorder_layers should change layer order and return applied=True."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "reorder_layers",
+                    "data": {
+                        "layer_ids": ["layer-content-001", "layer-bg-001"],
+                    },
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is True
+        assert actions[0].type == "reorder_layers"
+
+        layers = project_with_layers.timeline_data["layers"]
+        assert layers[0]["id"] == "layer-content-001"
+        assert layers[1]["id"] == "layer-bg-001"
+
+    @pytest.mark.asyncio
+    async def test_reorder_layers_missing_layer_ids_returns_error(
+        self, ai_service, project_with_layers
+    ):
+        """reorder_layers without layer_ids should return applied=False."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "reorder_layers",
+                    "data": {},
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is False
+
+    @pytest.mark.asyncio
+    async def test_delete_layer_dispatches_and_returns_action(
+        self, ai_service, project_with_layers
+    ):
+        """delete_layer should remove the layer and return applied=True."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "delete_layer",
+                    "layer_id": "layer-content-001",
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is True
+        assert actions[0].type == "delete_layer"
+        assert "コンテンツ" in actions[0].description
+
+        layers = project_with_layers.timeline_data["layers"]
+        assert all(lay["id"] != "layer-content-001" for lay in layers)
+
+    @pytest.mark.asyncio
+    async def test_delete_layer_nonexistent_layer_returns_error(
+        self, ai_service, project_with_layers
+    ):
+        """delete_layer with unknown layer_id should return applied=False."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [
+                {
+                    "type": "delete_layer",
+                    "layer_id": "no-such-layer",
+                }
+            ],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is False
+
+    @pytest.mark.asyncio
+    async def test_delete_layer_missing_layer_id_returns_error(
+        self, ai_service, project_with_layers
+    ):
+        """delete_layer without layer_id should return applied=False."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [{"type": "delete_layer"}],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_op_type_returns_applied_false(
+        self, ai_service, project_with_layers
+    ):
+        """Unknown operation type should return applied=False with informative description."""
+        actions = await ai_service._execute_chat_operations_on_project(
+            project_with_layers,
+            [{"type": "future_unsupported_op"}],
+        )
+
+        assert len(actions) == 1
+        assert actions[0].applied is False
+        assert "future_unsupported_op" in actions[0].description


### PR DESCRIPTION
## Summary

- `_build_chat_system_prompt` に `add_layer` / `update_layer` / `reorder_layers` / `delete_layer` の JSON スキーマを追加し、AI が操作ブロックでレイヤー操作を指示できるようにした
- `_execute_chat_operations_on_project` に4種のレイヤー操作ディスパッチャを追加。既存の `add_layer` / `update_layer` / `reorder_layers` メソッドを呼び出す実装とし、`delete_layer` はインライン実装
- 失敗操作がある場合に `_process_ai_response` 内で応答テキスト末尾へ `⚠️ 実行できなかった操作:` 警告を追記し、AIの言葉と実行結果の乖離をユーザーに通知

Closes #188

## Test plan

- [x] `ruff check src/` → All checks passed
- [x] `pytest tests/test_ai_api.py::TestExecuteChatOperationsLayerDispatch` → 11 passed
- [x] `pytest tests/test_ai_api.py` → 71 passed（既存テスト含む全件）
- [x] `pytest tests/ -m "not requires_db" --ignore=tests/e2e --ignore=tests/smoke --ignore=tests/contract --ignore=tests/test_v1_api_all_endpoints.py` → 351 passed, 5 failed（既存の `test_e2e_playwright.py` のみ、ローカルサーバー不要なテストはすべてグリーン）
- [x] フロントエンドは変更なし（既存の `[OK]` / `[NG]` 表示で失敗操作はすでにユーザーに見える）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)