### PR TITLE
feat: +Add メニューの AUDIO / SHAPES をサブメニュー化

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -1927,6 +1927,7 @@ test.describe('Editor Critical Path', () => {
     await openSeededEditor(page, mock.projectId, mock.sequenceId)
 
     await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
     await page.getByTestId('timeline-add-shape-arrow').click()
 
     await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
@@ -1953,6 +1954,7 @@ test.describe('Editor Critical Path', () => {
     await openSeededEditor(page, mock.projectId, mock.sequenceId)
 
     await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
     await page.getByTestId('timeline-add-shape-arrow').click()
     await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
 
@@ -2005,6 +2007,7 @@ test.describe('Editor Critical Path', () => {
     await openSeededEditor(page, mock.projectId, mock.sequenceId)
 
     await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
     await page.getByTestId('timeline-add-shape-arrow').click()
     await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
 
@@ -2115,6 +2118,7 @@ test.describe('Editor Critical Path', () => {
     await openSeededEditor(page, mock.projectId, mock.sequenceId)
 
     await page.locator('[data-menu-id="add"] button').first().click()
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
     await page.getByTestId('timeline-add-shape-rectangle').click()
     await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
     const shapeClipId = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips[0]?.id

--- a/frontend/e2e/page-objects/EditorPage.ts
+++ b/frontend/e2e/page-objects/EditorPage.ts
@@ -64,7 +64,10 @@ export class EditorPage {
 
   async addRectangleShape() {
     if (!(await this.openAddDropdown())) return false
-    const rectButton = this.addDropdown.locator('button:has-text("Rectangle"), button:has-text("矩形"), button:has-text("四角")')
+    const shapesSubmenu = this.page.getByTestId('timeline-add-shapes-submenu')
+    if (!(await shapesSubmenu.isVisible({ timeout: 3000 }).catch(() => false))) return false
+    await shapesSubmenu.hover()
+    const rectButton = this.page.getByTestId('timeline-add-shape-rectangle')
     if (await rectButton.isVisible({ timeout: 3000 }).catch(() => false)) {
       await rectButton.click()
       await this.page.waitForTimeout(500)
@@ -75,6 +78,9 @@ export class EditorPage {
 
   async addArrowShape() {
     if (!(await this.openAddDropdown())) return false
+    const shapesSubmenu = this.page.getByTestId('timeline-add-shapes-submenu')
+    if (!(await shapesSubmenu.isVisible({ timeout: 3000 }).catch(() => false))) return false
+    await shapesSubmenu.hover()
     const arrowButton = this.page.getByTestId('timeline-add-shape-arrow')
     if (await arrowButton.isVisible({ timeout: 3000 }).catch(() => false)) {
       await arrowButton.click()

--- a/frontend/e2e/timeline-add-menu.spec.ts
+++ b/frontend/e2e/timeline-add-menu.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test'
+import { bootstrapMockEditorPage } from './helpers/editorMockServer'
+import { openSeededEditor } from './helpers/editorPage'
+
+test.describe('timeline +Add menu submenu structure (#192)', () => {
+  test('Shapes submenu is hidden until parent item is hovered', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Open the +Add dropdown
+    await page.locator('[data-menu-id="add"] button').first().click()
+
+    // Shapes submenu parent should be visible
+    await expect(page.getByTestId('timeline-add-shapes-submenu')).toBeVisible()
+
+    // Submenu panel and rectangle button should NOT yet be visible (requires hover)
+    await expect(page.getByTestId('timeline-add-shapes-submenu-panel')).toHaveCount(0)
+    await expect(page.getByTestId('timeline-add-shape-rectangle')).toHaveCount(0)
+  })
+
+  test('Shapes submenu opens on hover and shows shape buttons', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Open the +Add dropdown
+    await page.locator('[data-menu-id="add"] button').first().click()
+
+    // Hover over Shapes parent item
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
+
+    // Submenu panel should now be visible
+    await expect(page.getByTestId('timeline-add-shapes-submenu-panel')).toBeVisible()
+
+    // All shape buttons should be visible
+    await expect(page.getByTestId('timeline-add-shape-rectangle')).toBeVisible()
+    await expect(page.getByTestId('timeline-add-shape-circle')).toBeVisible()
+    await expect(page.getByTestId('timeline-add-shape-line')).toBeVisible()
+    await expect(page.getByTestId('timeline-add-shape-arrow')).toBeVisible()
+  })
+
+  test('Audio submenu is hidden until parent item is hovered', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Open the +Add dropdown
+    await page.locator('[data-menu-id="add"] button').first().click()
+
+    // Audio submenu parent should be visible
+    await expect(page.getByTestId('timeline-add-audio-submenu')).toBeVisible()
+
+    // Submenu panel should NOT yet be visible (requires hover)
+    await expect(page.getByTestId('timeline-add-audio-submenu-panel')).toHaveCount(0)
+  })
+
+  test('Audio submenu opens on hover and shows Narration / BGM / SE', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Open the +Add dropdown
+    await page.locator('[data-menu-id="add"] button').first().click()
+
+    // Hover over Audio parent item
+    await page.getByTestId('timeline-add-audio-submenu').hover()
+
+    // Audio submenu panel should be visible
+    await expect(page.getByTestId('timeline-add-audio-submenu-panel')).toBeVisible()
+
+    // Narration, BGM, SE buttons should be visible
+    const panel = page.getByTestId('timeline-add-audio-submenu-panel')
+    await expect(panel.locator('button').filter({ hasText: /Narration|ナレーション/ })).toBeVisible()
+    await expect(panel.locator('button').filter({ hasText: /BGM/ })).toBeVisible()
+    await expect(panel.locator('button').filter({ hasText: /SE/ })).toBeVisible()
+  })
+
+  test('clicking Rectangle from Shapes submenu adds a rectangle shape', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Open the +Add dropdown
+    await page.locator('[data-menu-id="add"] button').first().click()
+
+    // Hover over Shapes submenu and click Rectangle
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
+    await page.getByTestId('timeline-add-shape-rectangle').click()
+
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    const addedShape = mock.calls.sequenceUpdates[0].timelineData.layers[0].clips[0]?.shape
+    expect(addedShape?.type).toBe('rectangle')
+  })
+
+  test('only one submenu is open at a time', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Open the +Add dropdown
+    await page.locator('[data-menu-id="add"] button').first().click()
+
+    // Hover Audio submenu
+    await page.getByTestId('timeline-add-audio-submenu').hover()
+    await expect(page.getByTestId('timeline-add-audio-submenu-panel')).toBeVisible()
+    await expect(page.getByTestId('timeline-add-shapes-submenu-panel')).toHaveCount(0)
+
+    // Now hover Shapes submenu - Audio should close, Shapes should open
+    await page.getByTestId('timeline-add-shapes-submenu').hover()
+    await expect(page.getByTestId('timeline-add-shapes-submenu-panel')).toBeVisible()
+    await expect(page.getByTestId('timeline-add-audio-submenu-panel')).toHaveCount(0)
+  })
+})

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -257,6 +257,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
   const [resizingLayerId, setResizingLayerId] = useState<string | null>(null)
   // Dropdown menu state (for click-triggered submenus)
   const [openMenuId, setOpenMenuId] = useState<'add' | null>(null)
+  const [openSubmenu, setOpenSubmenu] = useState<'audio' | 'shapes' | null>(null)
   const resizeStartY = useRef<number>(0)
   const resizeStartHeight = useRef<number>(0)
   const DEFAULT_LAYER_HEIGHT = 48 // Default height for video layers (h-12 = 48px)
@@ -335,6 +336,13 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     }
     document.addEventListener('click', handleClickOutside)
     return () => document.removeEventListener('click', handleClickOutside)
+  }, [openMenuId])
+
+  // Reset submenu when main menu closes
+  useEffect(() => {
+    if (!openMenuId) {
+      setOpenSubmenu(null)
+    }
   }, [openMenuId])
 
   // Save zoom level to localStorage when it changes
@@ -5149,52 +5157,105 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
                   {t('timeline.addLayer')}
                 </button>
                 <div className="h-px bg-gray-600 my-1 mx-2" />
-                <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">{t('timeline.audioSection')}</div>
-                <button onClick={() => { handleAddAudioTrack('narration'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                  </svg>
-                  {t('timeline.narration')}
-                </button>
-                <button onClick={() => { handleAddAudioTrack('bgm'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
-                  </svg>
-                  BGM
-                </button>
-                <button onClick={() => { handleAddAudioTrack('se'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072M18.364 5.636a9 9 0 010 12.728" />
-                  </svg>
-                  SE
-                </button>
-                <div className="h-px bg-gray-600 my-1 mx-2" />
-                <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">{t('timeline.shapeSection')}</div>
-                <button data-testid="timeline-add-shape-rectangle" onClick={() => { handleAddShape('rectangle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth={2} />
-                  </svg>
-                  {t('timeline.rectangle')}
-                </button>
-                <button data-testid="timeline-add-shape-circle" onClick={() => { handleAddShape('circle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <circle cx="12" cy="12" r="9" strokeWidth={2} />
-                  </svg>
-                  {t('timeline.circle')}
-                </button>
-                <button data-testid="timeline-add-shape-line" onClick={() => { handleAddShape('line'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <line x1="4" y1="20" x2="20" y2="4" strokeWidth={2} />
-                  </svg>
-                  {t('timeline.line')}
-                </button>
-                <button data-testid="timeline-add-shape-arrow" onClick={() => { handleAddShape('arrow'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
-                  <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path d="M4 12h10" strokeWidth={2.4} strokeLinecap="round" />
-                    <path d="m12 6 8 6-8 6" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                  {t('timeline.arrow')}
-                </button>
+                {/* Audio submenu */}
+                <div
+                  className="relative"
+                  data-testid="timeline-add-audio-submenu"
+                  onMouseEnter={() => setOpenSubmenu('audio')}
+                  onMouseLeave={() => setOpenSubmenu(null)}
+                >
+                  <button className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
+                      </svg>
+                      {t('timeline.audioSection')}
+                    </span>
+                    <svg className="w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                  {openSubmenu === 'audio' && (
+                    <div
+                      data-testid="timeline-add-audio-submenu-panel"
+                      className="absolute top-0 left-full ml-0.5 bg-gray-700 rounded shadow-lg z-50 min-w-[160px] py-1"
+                      onMouseEnter={() => setOpenSubmenu('audio')}
+                      onMouseLeave={() => setOpenSubmenu(null)}
+                    >
+                      <button onClick={() => { handleAddAudioTrack('narration'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+                        </svg>
+                        {t('timeline.narration')}
+                      </button>
+                      <button onClick={() => { handleAddAudioTrack('bgm'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
+                        </svg>
+                        BGM
+                      </button>
+                      <button onClick={() => { handleAddAudioTrack('se'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072M18.364 5.636a9 9 0 010 12.728" />
+                        </svg>
+                        SE
+                      </button>
+                    </div>
+                  )}
+                </div>
+                {/* Shapes submenu */}
+                <div
+                  className="relative"
+                  data-testid="timeline-add-shapes-submenu"
+                  onMouseEnter={() => setOpenSubmenu('shapes')}
+                  onMouseLeave={() => setOpenSubmenu(null)}
+                >
+                  <button className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth={2} />
+                      </svg>
+                      {t('timeline.shapeSection')}
+                    </span>
+                    <svg className="w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                  {openSubmenu === 'shapes' && (
+                    <div
+                      data-testid="timeline-add-shapes-submenu-panel"
+                      className="absolute top-0 left-full ml-0.5 bg-gray-700 rounded shadow-lg z-50 min-w-[160px] py-1"
+                      onMouseEnter={() => setOpenSubmenu('shapes')}
+                      onMouseLeave={() => setOpenSubmenu(null)}
+                    >
+                      <button data-testid="timeline-add-shape-rectangle" onClick={() => { handleAddShape('rectangle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth={2} />
+                        </svg>
+                        {t('timeline.rectangle')}
+                      </button>
+                      <button data-testid="timeline-add-shape-circle" onClick={() => { handleAddShape('circle'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <circle cx="12" cy="12" r="9" strokeWidth={2} />
+                        </svg>
+                        {t('timeline.circle')}
+                      </button>
+                      <button data-testid="timeline-add-shape-line" onClick={() => { handleAddShape('line'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <line x1="4" y1="20" x2="20" y2="4" strokeWidth={2} />
+                        </svg>
+                        {t('timeline.line')}
+                      </button>
+                      <button data-testid="timeline-add-shape-arrow" onClick={() => { handleAddShape('arrow'); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
+                        <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path d="M4 12h10" strokeWidth={2.4} strokeLinecap="round" />
+                          <path d="m12 6 8 6-8 6" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                        {t('timeline.arrow')}
+                      </button>
+                    </div>
+                  )}
+                </div>
                 <div className="h-px bg-gray-600 my-1 mx-2" />
                 <button onClick={() => { handleAddText(); setOpenMenuId(null) }} className="w-full px-3 py-1.5 text-xs text-left text-white hover:bg-gray-600 flex items-center gap-2">
                   <svg className="w-4 h-4 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/i18n/locales/ja/editor.json
+++ b/frontend/src/i18n/locales/ja/editor.json
@@ -78,6 +78,8 @@
     "telopSourceLayer": "テロップ生成元: レイヤー {{name}}",
     "telopSelectedTrackHasNoSource": "選択した音声トラックにテロップ生成に使える音声/動画クリップがありません",
     "telopSelectedLayerHasNoSource": "選択したレイヤーにテロップ生成に使える音声/動画クリップがありません",
+    "audioSection": "オーディオ",
+    "narration": "ナレーション",
     "shapeSection": "図形",
     "rectangle": "四角形",
     "circle": "円",


### PR DESCRIPTION
## Summary

- タイムラインの `+ Add` ドロップダウンが縦に長くなりビューポートで見切れていた問題を修正
- AUDIO（Narration / BGM / SE）と SHAPES（Rectangle / Circle / Line / Arrow）を、親項目 hover で右方向に展開するサブメニューに再構成
- 既存 `data-testid`（`timeline-add-shape-*` 等）は維持。新規に `timeline-add-audio-submenu` / `timeline-add-shapes-submenu` を追加

## Verification

- `npm run lint` ✅ no errors
- `npx tsc -p tsconfig.json --noEmit` ✅ no errors
- `npm run build` ✅ built in 2.31s
- `npx playwright test` ✅ 61 passed, 26 skipped

## Test plan

- [x] focused regression test 追加: `frontend/e2e/timeline-add-menu.spec.ts`（6 ケース: サブメニュー非表示 / hover 展開 / 排他制御 / クリック動作）
- [x] 既存 E2E テスト `editor-critical-path.spec.ts` をサブメニュー hover 経由に更新
- [x] EditorPage page-object のヘルパー更新
- [x] 旧実装（フラット構造）で fail し、新実装で pass する regression として機能することを確認

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>