### PR TITLE
fix: 明示的サイズあり画像にも Scale プロパティを反映させる

### DIFF
--- a/frontend/e2e/scale-applies-to-resized-image.spec.ts
+++ b/frontend/e2e/scale-applies-to-resized-image.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test'
+import { bootstrapMockEditorPage } from './helpers/editorMockServer'
+import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
+
+/**
+ * Regression for #194: scale slider / number-input must affect the image
+ * preview wrapper transform even when the image clip has an explicit
+ * transform.width / transform.height (i.e. hasExplicitSize === true).
+ *
+ * Pre-fix, the hasExplicitSize branch in EditorPreviewMediaClip.tsx omitted
+ * scale() from the wrapper's CSS transform, so changing the Scale property
+ * had no visual effect.
+ */
+test.describe('Scale applies to image preview wrapper (issue #194)', () => {
+  // Helper: get the CSS transform string of the wrapper div that contains the
+  // image element with a given data-clip-id attribute.
+  async function getImageWrapperTransform(page: import('@playwright/test').Page, clipId: string): Promise<string> {
+    return page.evaluate((id) => {
+      const img = document.querySelector(`img[data-clip-id="${id}"]`)
+      if (!img) throw new Error(`img[data-clip-id="${id}"] not found`)
+      // The wrapper is the grandparent: img → div.relative → div.absolute
+      const wrapper = img.parentElement?.parentElement
+      if (!wrapper) throw new Error('wrapper div not found')
+      return (wrapper as HTMLElement).style.transform
+    }, clipId)
+  }
+
+  test('scale change is reflected in wrapper transform (no explicit size)', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Drop the image asset onto layer-1.
+    await dragAssetToVideoLayer(page, {
+      assetId: mock.primaryAssetId,
+      layerId: 'layer-1',
+      offsetX: 220,
+    })
+    await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+    // Select the clip.
+    const clip = page.locator('[data-testid^="timeline-video-clip-"]').first()
+    await clip.click()
+
+    // Retrieve the clip id from the timeline element's data-testid.
+    const clipTestId = await clip.getAttribute('data-testid') ?? ''
+    const clipId = clipTestId.replace('timeline-video-clip-', '')
+
+    // Verify initial scale=1 is present in the transform.
+    const initialTransform = await getImageWrapperTransform(page, clipId)
+    expect(initialTransform).toContain('scale(1)')
+
+    // Change scale to 50% via the number input.
+    const scaleInput = page.getByTestId('video-scale-input')
+    await expect(scaleInput).toHaveValue('100')
+    await scaleInput.fill('50')
+    await scaleInput.press('Tab')
+
+    // The wrapper transform must now include scale(0.5).
+    const updatedTransform = await getImageWrapperTransform(page, clipId)
+    expect(updatedTransform).toContain('scale(0.5)')
+  })
+
+  test('scale change is reflected in wrapper transform when explicit size is set (hasExplicitSize)', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+
+    // Seed the timeline with a clip that already has transform.width / transform.height
+    // so that hasExplicitSize === true from the very first render.
+    const clipId = 'clip-explicit-size'
+    const seededClip = {
+      id: clipId,
+      asset_id: mock.primaryAssetId,
+      start_ms: 0,
+      duration_ms: 5000,
+      in_point_ms: 0,
+      out_point_ms: null,
+      transform: {
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 300,
+        scale: 1,
+        rotation: 0,
+      },
+      effects: {
+        opacity: 1,
+      },
+    }
+    // Inject the clip into the seeded sequence so GET /sequences/:id returns it.
+    const seq = mock.sequences[mock.sequenceId]
+    seq.timeline_data.layers[0].clips.push(seededClip as never)
+    seq.timeline_data.duration_ms = 5000
+    seq.duration_ms = 5000
+    // Keep project detail in sync.
+    mock.projectDetails[mock.projectId].timeline_data = JSON.parse(JSON.stringify(seq.timeline_data))
+    mock.projectDetails[mock.projectId].duration_ms = 5000
+
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // Select the seeded clip from the timeline.
+    const timelineClip = page.getByTestId(`timeline-video-clip-${clipId}`)
+    await timelineClip.click()
+
+    // Confirm scale input starts at 100.
+    const scaleInput = page.getByTestId('video-scale-input')
+    await expect(scaleInput).toHaveValue('100')
+
+    // Confirm wrapper initially has scale(1).
+    const initialTransform = await getImageWrapperTransform(page, clipId)
+    expect(initialTransform).toContain('scale(1)')
+
+    // Change scale to 50% via the number input.
+    await scaleInput.fill('50')
+    await scaleInput.press('Tab')
+
+    // Pre-fix: the hasExplicitSize branch omitted scale() entirely, so this
+    // assertion would FAIL on old code. Post-fix, scale(0.5) must appear.
+    const updatedTransform = await getImageWrapperTransform(page, clipId)
+    expect(updatedTransform).toContain('scale(0.5)')
+  })
+})

--- a/frontend/src/components/editor/EditorPreviewMediaClip.tsx
+++ b/frontend/src/components/editor/EditorPreviewMediaClip.tsx
@@ -211,9 +211,7 @@ export default function EditorPreviewMediaClip({
       ? {
           top: '50%',
           left: '50%',
-          transform: hasExplicitSize
-            ? `translate(-50%, -50%) translate(${activeClip.transform.x}px, ${activeClip.transform.y}px) rotate(${activeClip.transform.rotation}deg)`
-            : `translate(-50%, -50%) translate(${activeClip.transform.x}px, ${activeClip.transform.y}px) scale(${activeClip.transform.scale}) rotate(${activeClip.transform.rotation}deg)`,
+          transform: `translate(-50%, -50%) translate(${activeClip.transform.x}px, ${activeClip.transform.y}px) scale(${activeClip.transform.scale}) rotate(${activeClip.transform.rotation}deg)`,
           opacity: activeClip.transform.opacity,
           zIndex,
           transformOrigin: 'center center',


### PR DESCRIPTION
## Summary
- 画像クリップを preview のドラッグハンドルでリサイズすると `transform.width`/`transform.height` がセットされ、`hasExplicitSize === true` になる。この分岐で wrapper の CSS transform から `scale()` が外れていたため、Properties パネルの Scale を変更しても画像が見た目上反応しなかった。
- 両分岐を統一して常に `translate(...) scale(${scale}) rotate(...)` を適用。明示的サイズ設定時も Scale が複合的に効くようになる。Video 側 (293 行) は元から常に scale 適用なので変更なし。

## Verification
- `npx tsc -p tsconfig.json --noEmit` — pass
- `npm run lint` — pass
- `npm run build` — pass
- `npx playwright test` — 57 passed / 26 skipped
- 新規 focused test `e2e/scale-applies-to-resized-image.spec.ts`:
  - **明示的サイズなし**で scale 50% 設定 → wrapper transform に `scale(0.5)` が含まれる
  - **明示的サイズあり** clip を seed → scale 50% 設定 → wrapper transform に `scale(0.5)` が含まれる（旧実装は scale が transform 文字列に出ず fail）

## Related design feedback
ユーザーから「スケールは縦横（X/Y）別指定の方が正しい」というフィードバックあり。これは separate issue として大きめのリファクタで扱う想定。本 PR は Scale プロパティが効かない不具合の修正に focus。

## Test plan
- [x] Focused regression test 追加（旧実装で fail / 修正後 pass）
- [x] Playwright 全体パス
- [x] TypeScript / ESLint / build 通過

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>