### PR TITLE
feat: サウンドレイヤーの高さをドラッグでリサイズ可能にする

### DIFF
--- a/frontend/e2e/audio-track-resize.spec.ts
+++ b/frontend/e2e/audio-track-resize.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test'
+import type { AudioTrack } from '../src/store/projectStore'
+import { bootstrapMockEditorPage } from './helpers/editorMockServer'
+import { openSeededEditor } from './helpers/editorPage'
+
+const TRACK_ID = 'track-bgm-1'
+
+async function setupEditorWithAudioTrack(page: Parameters<typeof bootstrapMockEditorPage>[0]) {
+  const mock = await bootstrapMockEditorPage(page)
+
+  const bgmTrack: AudioTrack = {
+    id: TRACK_ID,
+    name: 'BGM 1',
+    type: 'bgm',
+    volume: 1,
+    muted: false,
+    visible: true,
+    clips: [],
+  }
+
+  mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [bgmTrack]
+  mock.sequences[mock.sequenceId].timeline_data.audio_tracks = JSON.parse(JSON.stringify([bgmTrack]))
+
+  await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+  return mock
+}
+
+test.describe('Audio track resize', () => {
+  test('audio track row has an initial height that can be measured', async ({ page }) => {
+    await setupEditorWithAudioTrack(page)
+
+    const trackRow = page.getByTestId(`timeline-audio-track-row-${TRACK_ID}`)
+    await expect(trackRow).toBeVisible()
+
+    const box = await trackRow.boundingBox()
+    expect(box).not.toBeNull()
+    // Default height should be 48px (DEFAULT_LAYER_HEIGHT)
+    expect(box!.height).toBeGreaterThanOrEqual(32)
+  })
+
+  test('resize handle is present on the audio track row', async ({ page }) => {
+    await setupEditorWithAudioTrack(page)
+
+    const handle = page.getByTestId(`timeline-audio-track-resize-handle-${TRACK_ID}`)
+    await expect(handle).toBeVisible()
+  })
+
+  test('dragging resize handle changes audio track row height', async ({ page }) => {
+    await setupEditorWithAudioTrack(page)
+
+    const trackRow = page.getByTestId(`timeline-audio-track-row-${TRACK_ID}`)
+    const handle = page.getByTestId(`timeline-audio-track-resize-handle-${TRACK_ID}`)
+
+    await expect(trackRow).toBeVisible()
+    await expect(handle).toBeVisible()
+
+    const initialBox = await trackRow.boundingBox()
+    expect(initialBox).not.toBeNull()
+    const initialHeight = initialBox!.height
+
+    // Drag the handle downward by 50px to increase height
+    const handleBox = await handle.boundingBox()
+    expect(handleBox).not.toBeNull()
+    // Use a viewport-safe X coordinate (handle may extend beyond viewport width due to scroll container)
+    const viewport = page.viewportSize()
+    const safeX = Math.min(handleBox!.x + 100, (viewport?.width ?? 1280) - 10)
+    const startY = handleBox!.y + handleBox!.height / 2
+
+    await page.mouse.move(safeX, startY)
+    await page.mouse.down()
+    await page.mouse.move(safeX, startY + 50, { steps: 10 })
+    await page.mouse.up()
+
+    const newBox = await trackRow.boundingBox()
+    expect(newBox).not.toBeNull()
+    const newHeight = newBox!.height
+
+    // The height should have increased and should differ from the initial (64px) height
+    expect(newHeight).toBeGreaterThan(initialHeight)
+    // Specifically, should not still be the default 64px
+    expect(newHeight).not.toBe(64)
+  })
+
+  test('resized audio track height is restored after reload via localStorage', async ({ page }) => {
+    const mock = await setupEditorWithAudioTrack(page)
+
+    const handle = page.getByTestId(`timeline-audio-track-resize-handle-${TRACK_ID}`)
+    await expect(handle).toBeVisible()
+
+    const handleBox = await handle.boundingBox()
+    expect(handleBox).not.toBeNull()
+    // Use a viewport-safe X coordinate (handle may extend beyond viewport width due to scroll container)
+    const viewport2 = page.viewportSize()
+    const safeX2 = Math.min(handleBox!.x + 100, (viewport2?.width ?? 1280) - 10)
+    const startY2 = handleBox!.y + handleBox!.height / 2
+
+    // Drag downward 60px
+    await page.mouse.move(safeX2, startY2)
+    await page.mouse.down()
+    await page.mouse.move(safeX2, startY2 + 60, { steps: 10 })
+    await page.mouse.up()
+
+    const trackRow = page.getByTestId(`timeline-audio-track-row-${TRACK_ID}`)
+    const afterResizeBox = await trackRow.boundingBox()
+    expect(afterResizeBox).not.toBeNull()
+    const heightAfterResize = afterResizeBox!.height
+
+    // The height should differ from the initial 64px (proves resize happened)
+    expect(heightAfterResize).not.toBe(64)
+
+    // Reload the page
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('editor-header').waitFor()
+
+    // Reopen the same editor page
+    await page.goto(`/project/${mock.projectId}/sequence/${mock.sequenceId}`)
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('editor-header').waitFor()
+    await page.getByTestId('timeline-area').waitFor()
+
+    const trackRowAfterReload = page.getByTestId(`timeline-audio-track-row-${TRACK_ID}`)
+    await expect(trackRowAfterReload).toBeVisible()
+
+    const reloadedBox = await trackRowAfterReload.boundingBox()
+    expect(reloadedBox).not.toBeNull()
+    // Should be restored to the resized height, not the default 64px
+    expect(reloadedBox!.height).not.toBe(64)
+    expect(reloadedBox!.height).toBeCloseTo(heightAfterResize, 1)
+  })
+})

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -255,6 +255,18 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
     }
   })
   const [resizingLayerId, setResizingLayerId] = useState<string | null>(null)
+  // Track heights state (persisted to localStorage)
+  const [trackHeights, setTrackHeights] = useState<Record<string, number>>(() => {
+    try {
+      const saved = localStorage.getItem(`timeline-track-heights-${projectId}`)
+      return saved ? JSON.parse(saved) : {}
+    } catch {
+      return {}
+    }
+  })
+  const [resizingTrackId, setResizingTrackId] = useState<string | null>(null)
+  const trackResizeStartY = useRef<number>(0)
+  const trackResizeStartHeight = useRef<number>(0)
   // Dropdown menu state (for click-triggered submenus)
   const [openMenuId, setOpenMenuId] = useState<'add' | null>(null)
   const [openSubmenu, setOpenSubmenu] = useState<'audio' | 'shapes' | null>(null)
@@ -813,6 +825,50 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
       }
     }
   }, [resizingLayerId, handleLayerResizeMove, handleLayerResizeEnd])
+
+  // Get track height (from state or default)
+  const getTrackHeight = useCallback((trackId: string): number => {
+    return trackHeights[trackId] ?? DEFAULT_LAYER_HEIGHT
+  }, [trackHeights, DEFAULT_LAYER_HEIGHT])
+
+  // Handle track resize start
+  const handleTrackResizeStart = useCallback((e: React.MouseEvent, trackId: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setResizingTrackId(trackId)
+    trackResizeStartY.current = e.clientY
+    trackResizeStartHeight.current = getTrackHeight(trackId)
+  }, [getTrackHeight])
+
+  // Handle track resize move
+  const handleTrackResizeMove = useCallback((e: MouseEvent) => {
+    if (!resizingTrackId) return
+    const deltaY = e.clientY - trackResizeStartY.current
+    const newHeight = Math.min(MAX_LAYER_HEIGHT, Math.max(MIN_LAYER_HEIGHT, trackResizeStartHeight.current + deltaY))
+    setTrackHeights(prev => ({ ...prev, [resizingTrackId]: newHeight }))
+  }, [resizingTrackId, MIN_LAYER_HEIGHT, MAX_LAYER_HEIGHT])
+
+  // Handle track resize end
+  const handleTrackResizeEnd = useCallback(() => {
+    if (resizingTrackId) {
+      // Save to localStorage
+      const newHeights = { ...trackHeights }
+      localStorage.setItem(`timeline-track-heights-${projectId}`, JSON.stringify(newHeights))
+    }
+    setResizingTrackId(null)
+  }, [resizingTrackId, trackHeights, projectId])
+
+  // Add track resize listeners
+  useEffect(() => {
+    if (resizingTrackId) {
+      window.addEventListener('mousemove', handleTrackResizeMove)
+      window.addEventListener('mouseup', handleTrackResizeEnd)
+      return () => {
+        window.removeEventListener('mousemove', handleTrackResizeMove)
+        window.removeEventListener('mouseup', handleTrackResizeEnd)
+      }
+    }
+  }, [resizingTrackId, handleTrackResizeMove, handleTrackResizeEnd])
 
   // Handle header resize start
   const handleHeaderResizeStart = useCallback((e: React.MouseEvent) => {
@@ -6101,6 +6157,8 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
               registerTrackRef={(trackId, el) => { trackRefs.current[trackId] = el }}
               crossTrackDragTargetId={dragState?.type === 'move' ? dragState.targetTrackId : null}
               crossTrackDropPreview={crossTrackDropPreview}
+              getTrackHeight={getTrackHeight}
+              handleTrackResizeStart={handleTrackResizeStart}
               onTrackClick={(trackId) => {
                 setSelectedClip(null)
                 setSelectedVideoClip(null)

--- a/frontend/src/components/editor/timeline/AudioTracks.tsx
+++ b/frontend/src/components/editor/timeline/AudioTracks.tsx
@@ -51,6 +51,8 @@ interface AudioTracksProps {
   onTrackClick?: (trackId: string) => void
   crossTrackDragTargetId?: string | null
   crossTrackDropPreview?: CrossTrackDropPreview | null
+  getTrackHeight?: (trackId: string) => number
+  handleTrackResizeStart?: (e: React.MouseEvent, trackId: string) => void
 }
 
 function AudioTracks({
@@ -83,6 +85,8 @@ function AudioTracks({
   onTrackClick,
   crossTrackDragTargetId,
   crossTrackDropPreview,
+  getTrackHeight,
+  handleTrackResizeStart,
 }: AudioTracksProps) {
   const { t } = useTranslation('editor')
   return (
@@ -92,7 +96,7 @@ function AudioTracks({
           key={track.id}
           ref={(el) => registerTrackRef?.(track.id, el)}
           data-testid={`timeline-audio-track-row-${track.id}`}
-          className={`h-16 border-b border-gray-700 relative z-[1] transition-colors cursor-pointer ${
+          className={`border-b border-gray-700 relative z-[1] transition-colors cursor-pointer ${
             dragOverTrack === track.id
               ? 'bg-green-900/30 border-green-500'
               : crossTrackDragTargetId === track.id
@@ -101,6 +105,7 @@ function AudioTracks({
                   ? 'bg-amber-900/30 border-amber-500'
                 : 'bg-gray-800/50'
           }`}
+          style={{ height: getTrackHeight ? getTrackHeight(track.id) : 64 }}
           onClick={() => onTrackClick?.(track.id)}
           onDragOver={(e) => handleDragOver(e, track.id)}
           onDragLeave={handleDragLeave}
@@ -327,6 +332,12 @@ function AudioTracks({
               <span className="text-green-400 text-sm">{t('timeline.dropHere')}</span>
             </div>
           )}
+          {/* Track height resize handle */}
+          <div
+            data-testid={`timeline-audio-track-resize-handle-${track.id}`}
+            className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize hover:bg-primary-500/50 transition-colors z-10"
+            onMouseDown={(e) => handleTrackResizeStart?.(e, track.id)}
+          />
         </div>
       ))}
     </>


### PR DESCRIPTION
## Summary
- タイムラインのサウンドトラック（SE / SE 2 / BGM 等）に高さリサイズハンドルを追加。映像レイヤーと同じ操作感でドラッグ可能に。
- 高さは `timeline-track-heights-${projectId}` キーで localStorage に永続化。リロード後も復元。
- min/max は映像レイヤーと共通（32px / 200px、デフォルト 48px → AudioTracks 側は従来 64px だったので、初期値の扱いは Timeline 側ハンドラの DEFAULT を踏襲）。

## Changes
- `frontend/src/components/editor/Timeline.tsx` (+58) — `trackHeights` state、`getTrackHeight` / `handleTrackResize{Start,Move,End}`、AudioTracks への props 渡し
- `frontend/src/components/editor/timeline/AudioTracks.tsx` (+13) — props 受け取り、固定 `h-16` を動的 `style` に置換、リサイズハンドル div 追加
- `frontend/e2e/audio-track-resize.spec.ts` (+132) — focused regression test

## Verification
worktree (`_orchestration/worktrees/issue-203`) で実行:

- ✅ `npm run lint` — 0 errors
- ✅ `npx tsc -p tsconfig.json --noEmit` — 0 errors
- ✅ `npm run build` — built in 1.73s
- ✅ `npx playwright test` — 67 passed / 26 skipped / 0 failed

## Test plan
- [x] サウンドトラック行に下端ハンドルが表示される
- [x] ハンドルをドラッグするとトラック高さが変わる（旧実装は固定 64px なので fail する条件をアサート）
- [x] localStorage に保存され、リロード後に復元される
- [x] 既存の映像レイヤーリサイズ・クリップ表示・trim/fade/group が壊れていない（既存 E2E すべて pass）

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>