### PR TITLE
feat(timeline): タイムラインに「最初に移動」ボタンを追加

### DIFF
--- a/frontend/e2e/editor-critical-path.spec.ts
+++ b/frontend/e2e/editor-critical-path.spec.ts
@@ -2951,4 +2951,23 @@ test.describe('Editor Critical Path', () => {
     expect(updatedB?.volume_keyframes?.[1].value).toBeGreaterThan(0.9)
     expect(updatedC?.volume).toBeCloseTo(0.7, 5)
   })
+
+  test('scroll-to-start button is visible and clickable', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    const scrollToStartBtn = page.getByTestId('timeline-scroll-to-start')
+    await expect(scrollToStartBtn).toBeVisible()
+    await scrollToStartBtn.click()
+    // After clicking scroll-to-start, the button should still be visible (no crash)
+    await expect(scrollToStartBtn).toBeVisible()
+  })
+
+  test('scroll-to-start and scroll-to-end buttons are both present in toolbar', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    await expect(page.getByTestId('timeline-scroll-to-start')).toBeVisible()
+    await expect(page.getByTestId('timeline-scroll-to-end')).toBeVisible()
+  })
 })

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -5460,9 +5460,22 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
             </svg>
           </button>
           <button
+            onClick={() => scrollToTime(0, 'left')}
+            className="p-1.5 bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white rounded transition-colors"
+            title={t('timeline.scrollToStart')}
+            aria-label={t('timeline.scrollToStart')}
+            data-testid="timeline-scroll-to-start"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 19l-7-7 7-7M19 12H5" />
+            </svg>
+          </button>
+          <button
             onClick={() => scrollToTime(timeline.duration_ms, 'left')}
             className="p-1.5 bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white rounded transition-colors"
             title={t('timeline.scrollToEnd')}
+            aria-label={t('timeline.scrollToEnd')}
+            data-testid="timeline-scroll-to-end"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 5l7 7-7 7M5 12h14" />

--- a/frontend/src/i18n/locales/en/editor.json
+++ b/frontend/src/i18n/locales/en/editor.json
@@ -87,6 +87,7 @@
     "snapOff": "Snap off (S)",
     "snapToPrev": "Snap to previous clip",
     "selectAfterPlayhead": "Select after playhead (A)",
+    "scrollToStart": "Scroll to start",
     "scrollToEnd": "Scroll to end (Shift+E)",
     "scrollToPlayhead": "Scroll to playhead (Shift+H)",
     "fitToWindow": "Fit timeline to window",

--- a/frontend/src/i18n/locales/ja/editor.json
+++ b/frontend/src/i18n/locales/ja/editor.json
@@ -86,6 +86,8 @@
     "line": "線",
     "arrow": "矢印",
     "text": "テキスト",
+    "scrollToStart": "最初に移動",
+    "scrollToEnd": "最後に移動",
     "trackLabel": "トラック"
   },
   "editor": {


### PR DESCRIPTION
## Summary
- タイムラインのツールバーに「最初に移動」ボタン（←）を追加。「最後に移動」ボタン（→）の直前に配置。
- クリックで `scrollToTime(0, 'left')` が走り、タイムラインが先頭にスクロール。
- i18n: `timeline.scrollToStart` を en/ja に追加。ja では合わせて `scrollToEnd` の翻訳も追加（ペアで意味を成すため）。
- 既存の「最後に移動」ボタンに `aria-label` と `data-testid="timeline-scroll-to-end"` を補完追加。

## Verification
- `npm run lint` PASS
- `npx tsc -p tsconfig.json --noEmit` PASS
- `npm run build` PASS (1.98s)
- `npx playwright test` PASS (69 passed, 26 skipped)

## Test plan
- [x] focused regression test 追加: `scroll-to-start button is visible and clickable`
- [x] focused regression test 追加: `scroll-to-start and scroll-to-end buttons are both present in toolbar`（旧実装では fail）
- [x] 全 e2e パス確認済み

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>