### PR TITLE
fix(timeline): サウンドトラック高さ変更の位置ズレ・リサイズ不能を修正

### DIFF
--- a/frontend/e2e/audio-track-resize.spec.ts
+++ b/frontend/e2e/audio-track-resize.spec.ts
@@ -129,4 +129,54 @@ test.describe('Audio track resize', () => {
     expect(reloadedBox!.height).not.toBe(64)
     expect(reloadedBox!.height).toBeCloseTo(heightAfterResize, 1)
   })
+
+  test('header height matches clip row height (no vertical misalignment)', async ({ page }) => {
+    await setupEditorWithAudioTrack(page)
+
+    const header = page.getByTestId(`timeline-audio-track-header-${TRACK_ID}`)
+    const row = page.getByTestId(`timeline-audio-track-row-${TRACK_ID}`)
+
+    await expect(header).toBeVisible()
+    await expect(row).toBeVisible()
+
+    const headerBox = await header.boundingBox()
+    const rowBox = await row.boundingBox()
+    expect(headerBox).not.toBeNull()
+    expect(rowBox).not.toBeNull()
+
+    // Header and clip row must share the same height (old h-16 fixed header would fail this)
+    expect(headerBox!.height).toBeCloseTo(rowBox!.height, 1)
+  })
+
+  test('header height matches clip row height after resize', async ({ page }) => {
+    await setupEditorWithAudioTrack(page)
+
+    const headerHandle = page.getByTestId(`timeline-audio-track-header-resize-handle-${TRACK_ID}`)
+    const header = page.getByTestId(`timeline-audio-track-header-${TRACK_ID}`)
+    const row = page.getByTestId(`timeline-audio-track-row-${TRACK_ID}`)
+
+    await expect(headerHandle).toBeVisible()
+
+    const handleBox = await headerHandle.boundingBox()
+    expect(handleBox).not.toBeNull()
+    const viewport = page.viewportSize()
+    const safeX = Math.min(handleBox!.x + 100, (viewport?.width ?? 1280) - 10)
+    const startY = handleBox!.y + handleBox!.height / 2
+
+    // Drag header resize handle downward by 50px
+    await page.mouse.move(safeX, startY)
+    await page.mouse.down()
+    await page.mouse.move(safeX, startY + 50, { steps: 10 })
+    await page.mouse.up()
+
+    const headerBox = await header.boundingBox()
+    const rowBox = await row.boundingBox()
+    expect(headerBox).not.toBeNull()
+    expect(rowBox).not.toBeNull()
+
+    // After resize via header handle, both must still be equal
+    expect(headerBox!.height).toBeCloseTo(rowBox!.height, 1)
+    // And the height must have changed from the default 64px
+    expect(headerBox!.height).toBeGreaterThan(64)
+  })
 })

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -273,6 +273,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
   const resizeStartY = useRef<number>(0)
   const resizeStartHeight = useRef<number>(0)
   const DEFAULT_LAYER_HEIGHT = 48 // Default height for video layers (h-12 = 48px)
+  const DEFAULT_AUDIO_TRACK_HEIGHT = 64 // Default height for audio tracks (h-16 = 64px)
   const MIN_LAYER_HEIGHT = 32
   const MAX_LAYER_HEIGHT = 200
   // Track header width state (resizable)
@@ -828,8 +829,8 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
 
   // Get track height (from state or default)
   const getTrackHeight = useCallback((trackId: string): number => {
-    return trackHeights[trackId] ?? DEFAULT_LAYER_HEIGHT
-  }, [trackHeights, DEFAULT_LAYER_HEIGHT])
+    return trackHeights[trackId] ?? DEFAULT_AUDIO_TRACK_HEIGHT
+  }, [trackHeights, DEFAULT_AUDIO_TRACK_HEIGHT])
 
   // Handle track resize start
   const handleTrackResizeStart = useCallback((e: React.MouseEvent, trackId: string) => {
@@ -5743,9 +5744,10 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
             <div
               key={track.id}
               data-testid={`timeline-audio-track-header-${track.id}`}
-              className={`h-16 px-2 py-1 border-b border-gray-700 flex items-center group cursor-pointer transition-colors ${
+              className={`relative px-2 py-1 border-b border-gray-700 flex items-center group cursor-pointer transition-colors ${
                 dragOverTrack === track.id ? 'bg-green-900/20' : ''
               } ${isTrackSelected ? 'bg-amber-900/40 border-l-2 border-l-amber-400' : ''} ${isDraggingTrack ? 'opacity-50' : ''} ${isDropTargetTrack ? 'border-t-2 border-t-primary-500' : ''} ${track.visible === false ? 'opacity-50' : ''}`}
+              style={{ height: getTrackHeight(track.id) }}
               onClick={() => {
                 setSelectedAudioTrackId(track.id)
                 setSelectedLayerId(null)
@@ -5855,6 +5857,13 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
                 className="w-full h-1 mt-1"
               />
               </div>
+              {/* Resize handle */}
+              <div
+                data-testid={`timeline-audio-track-header-resize-handle-${track.id}`}
+                className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize hover:bg-primary-500/50 transition-colors"
+                onMouseDown={(e) => handleTrackResizeStart(e, track.id)}
+                title={t('timeline.handles.resizeHeight')}
+              />
             </div>
           )
           })}

--- a/frontend/src/components/editor/timeline/AudioTracks.tsx
+++ b/frontend/src/components/editor/timeline/AudioTracks.tsx
@@ -336,7 +336,10 @@ function AudioTracks({
           <div
             data-testid={`timeline-audio-track-resize-handle-${track.id}`}
             className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize hover:bg-primary-500/50 transition-colors z-10"
-            onMouseDown={(e) => handleTrackResizeStart?.(e, track.id)}
+            onMouseDown={(e) => {
+              e.stopPropagation()
+              handleTrackResizeStart?.(e, track.id)
+            }}
           />
         </div>
       ))}


### PR DESCRIPTION
## Summary
PR #204 でサウンドトラックの高さリサイズ機能を入れた際に発生した 3 件の不具合を修正。

- **位置ズレ**: 左ペイン（ヘッダー）と右ペイン（クリップ行）の高さが食い違う
- **リサイズ不能感**: 左ペイン側にハンドルがなく、ユーザーが掴めない
- **デフォルト高さの低下**: 64px → 48px に縮んでいた（DEFAULT_LAYER_HEIGHT を共有していたため）

## Changes
- `Timeline.tsx` (+13/-2):
  - 音声専用 `DEFAULT_AUDIO_TRACK_HEIGHT = 64` を新設（映像の `DEFAULT_LAYER_HEIGHT = 48` は据え置き）
  - `getTrackHeight` の fallback を 64px へ
  - 音声ヘッダー div から `h-16` 削除、`style={{ height: getTrackHeight(track.id) }}` を適用、`relative` を付与
  - 映像側と同等のリサイズハンドル div をヘッダー末尾に追加（`data-testid=timeline-audio-track-header-resize-handle-${id}`）
- `AudioTracks.tsx` (+4/-1):
  - クリップ下端ハンドルの `onMouseDown` で `e.stopPropagation()`（ドラッグ後の click 伝搬による意図しない選択を防ぐ）
- `audio-track-resize.spec.ts` (+50): regression 用 E2E 2 件追加
  - ヘッダー行とクリップ行の高さが一致する（旧実装の `h-16` 固定なら fail）
  - ヘッダー側ハンドルでドラッグするとヘッダー・クリップ両方が同じ新高さになる

## Verification
worktree (`_orchestration/worktrees/issue-208`) で実行:

- ✅ `npm run lint` — clean
- ✅ `npx tsc -p tsconfig.json --noEmit` — clean
- ✅ `npm run build` — built in 2.10s
- ✅ `npx playwright test` — 71 passed / 26 skipped / 0 failed（既存 + 新規含む）

## Test plan
- [x] サウンドトラックのヘッダー行とクリップ行の縦位置が揃う
- [x] ヘッダー側のリサイズハンドルでドラッグすると高さが変わる
- [x] クリップ側ハンドルからのドラッグでヘッダー側も同じ高さに追従する
- [x] localStorage に永続化、リロード後も復元（既存テスト）
- [x] 映像レイヤー側の挙動は不変（既存テスト全 pass）

## Notes
「空白部分クリックで選択解除されない」については、調査の結果タイムラインコンテナ自体に従来から全体クリックハンドラが無いことを確認。本 PR は、ハンドルからの click 伝搬を `stopPropagation` で抑止する範囲のみ修正。空白クリック解除そのものは PR #204 起因ではなく既存挙動と判断し、別 issue 候補とする。

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>