### PR TITLE
feat(timeline): 空白部分クリックで選択を解除する

### DIFF
--- a/frontend/e2e/timeline-empty-click-clear-selection.spec.ts
+++ b/frontend/e2e/timeline-empty-click-clear-selection.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from '@playwright/test'
+import type { AudioTrack } from '../src/store/projectStore'
+import { bootstrapMockEditorPage } from './helpers/editorMockServer'
+import { dragAssetToVideoLayer, openSeededEditor } from './helpers/editorPage'
+
+/**
+ * Issue #211: Clicking the empty area of the timeline canvas clears all
+ * clip/layer/audio-track selections.
+ *
+ * Scenarios verified:
+ * 1. Video clip selected → click empty canvas → selection cleared (property panel hides scale input)
+ * 2. Layer header selected → click empty canvas → header loses selected class
+ * 3. Audio track header selected → click empty canvas → header loses selected class
+ * 4. Ruler click does NOT clear selection (e.target !== e.currentTarget guard)
+ * 5. Ruler double-click still adds a marker (existing behaviour not broken)
+ */
+
+const LAYER_ID = 'layer-1'
+const TRACK_ID = 'track-bgm-1'
+
+async function setupEditorWithVideoClip(page: Parameters<typeof bootstrapMockEditorPage>[0]) {
+  const mock = await bootstrapMockEditorPage(page)
+  await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+  // Drop the seeded image asset onto the video layer so there is a clip to select
+  await dragAssetToVideoLayer(page, {
+    assetId: mock.primaryAssetId,
+    layerId: LAYER_ID,
+    offsetX: 220,
+  })
+  await expect.poll(() => mock.calls.sequenceUpdates.length).toBe(1)
+
+  return mock
+}
+
+async function setupEditorWithAudioTrack(page: Parameters<typeof bootstrapMockEditorPage>[0]) {
+  const mock = await bootstrapMockEditorPage(page)
+
+  const bgmTrack: AudioTrack = {
+    id: TRACK_ID,
+    name: 'BGM 1',
+    type: 'bgm',
+    volume: 1,
+    muted: false,
+    visible: true,
+    clips: [],
+  }
+
+  mock.projectDetails[mock.projectId].timeline_data.audio_tracks = [bgmTrack]
+  mock.sequences[mock.sequenceId].timeline_data.audio_tracks = JSON.parse(JSON.stringify([bgmTrack]))
+
+  await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+  return mock
+}
+
+/**
+ * Click directly on the timeline-canvas element itself (not on any child).
+ * Dispatches mousedown then click so that onMouseDownCapture resets
+ * suppressNextCanvasClick before onClick fires.
+ */
+async function clickEmptyCanvas(page: Parameters<typeof bootstrapMockEditorPage>[0]) {
+  await page.evaluate(() => {
+    const canvas = document.querySelector('[data-testid="timeline-canvas"]') as HTMLElement
+    if (!canvas) throw new Error('timeline-canvas not found')
+    canvas.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+    canvas.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+  })
+}
+
+test.describe('Timeline empty click clears selection (issue #211)', () => {
+  test('video clip selected → clicking empty canvas clears selection', async ({ page }) => {
+    await setupEditorWithVideoClip(page)
+
+    // Select the clip
+    const clip = page.locator('[data-testid^="timeline-video-clip-"]').first()
+    await clip.click()
+
+    // After selection, the property panel should show the scale input
+    const scaleInput = page.getByTestId('video-scale-input')
+    await expect(scaleInput).toBeVisible()
+
+    // Click directly on the canvas element itself (not on any child)
+    await clickEmptyCanvas(page)
+
+    // Property panel should no longer show the video clip scale input
+    await expect(scaleInput).toBeHidden()
+  })
+
+  test('layer header selected → clicking empty canvas clears layer selection', async ({ page }) => {
+    await setupEditorWithVideoClip(page)
+
+    // Click the layer header to select it (uses data-testid added in #211).
+    // Click on the layer name area (past w-6 drag handle + w-4 color picker = ~50px from left).
+    const layerHeader = page.getByTestId(`timeline-layer-header-${LAYER_ID}`)
+    const headerBox = await layerHeader.boundingBox()
+    expect(headerBox).not.toBeNull()
+    await page.mouse.click(headerBox!.x + 60, headerBox!.y + headerBox!.height / 2)
+
+    // Verify layer is selected via its CSS class (bg-primary-900/50 applied when selected)
+    await expect(layerHeader).toHaveClass(/bg-primary-900/)
+
+    // Click directly on the canvas element itself
+    await clickEmptyCanvas(page)
+
+    // Layer header should no longer have the selected class
+    await expect(layerHeader).not.toHaveClass(/bg-primary-900/)
+  })
+
+  test('audio track header selected → clicking empty canvas clears track selection', async ({ page }) => {
+    await setupEditorWithAudioTrack(page)
+
+    // Click the audio track header to select it.
+    // Click on the left edge (drag handle area) to avoid the Duck / Mute buttons on the right.
+    const trackHeader = page.getByTestId(`timeline-audio-track-header-${TRACK_ID}`)
+    const trackBox = await trackHeader.boundingBox()
+    expect(trackBox).not.toBeNull()
+    await page.mouse.click(trackBox!.x + 4, trackBox!.y + trackBox!.height / 2)
+
+    // Verify the track is selected (bg-amber-900/40 applied when selected)
+    await expect(trackHeader).toHaveClass(/bg-amber-900/)
+
+    // Click directly on the canvas element itself
+    await clickEmptyCanvas(page)
+
+    // Track header should no longer have the selected class
+    await expect(trackHeader).not.toHaveClass(/bg-amber-900/)
+  })
+
+  test('clicking ruler does NOT clear existing clip selection', async ({ page }) => {
+    await setupEditorWithVideoClip(page)
+
+    // Select the clip
+    const clip = page.locator('[data-testid^="timeline-video-clip-"]').first()
+    await clip.click()
+
+    // Wait for the property panel to appear (confirms selection)
+    const scaleInput = page.getByTestId('video-scale-input')
+    await expect(scaleInput).toBeVisible()
+
+    // Click the time ruler (data-testid="timeline-ruler", a child of timeline-canvas).
+    // Since ruler is a child, e.target !== e.currentTarget → clearAllSelections must NOT fire.
+    const ruler = page.getByTestId('timeline-ruler')
+    await expect(ruler).toBeVisible()
+    const rulerBox = await ruler.boundingBox()
+    expect(rulerBox).not.toBeNull()
+    await page.mouse.click(
+      rulerBox!.x + 100,
+      rulerBox!.y + rulerBox!.height / 2,
+    )
+
+    // Selection must still be intact — scale input stays visible
+    await expect(scaleInput).toBeVisible()
+  })
+
+  test('ruler double-click opens add-marker dialog (existing behaviour unchanged)', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    await openSeededEditor(page, mock.projectId, mock.sequenceId)
+
+    // The ruler has data-testid="timeline-ruler"; dblclick on it to open the marker dialog.
+    const ruler = page.getByTestId('timeline-ruler')
+    await expect(ruler).toBeVisible()
+
+    const rulerBox = await ruler.boundingBox()
+    expect(rulerBox).not.toBeNull()
+
+    await page.mouse.dblclick(
+      rulerBox!.x + 100,
+      rulerBox!.y + rulerBox!.height / 2,
+    )
+
+    // The marker dialog should appear (it contains a name input and submit button).
+    // Check that the overlay background appeared (bg-black/50 absolute inset-0 z-50).
+    // The dialog has a heading with the marker add text.
+    await expect(page.locator('.bg-black\\/50')).toBeVisible({ timeout: 5000 })
+
+    // Confirm no sequence update has occurred yet (dialog not submitted)
+    expect(mock.calls.sequenceUpdates.length).toBe(0)
+
+    // Dismiss the dialog by pressing Escape
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.bg-black\\/50')).toBeHidden()
+  })
+})

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -315,6 +315,8 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
   const tracksScrollRef = useRef<HTMLDivElement>(null)
   const timelineContainerRef = useRef<HTMLDivElement>(null)
   const isScrollSyncing = useRef(false)
+  // Suppress the next timeline-canvas click if it follows a clip drag/mousedown cycle
+  const suppressNextCanvasClick = useRef(false)
   // Viewport bar resize state
   const [viewportBarDrag, setViewportBarDrag] = useState<{
     type: 'left' | 'right' | 'move'
@@ -367,6 +369,18 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
   const sortedLayers = useMemo(() => {
     return [...timeline.layers].sort((a, b) => (b.order ?? 0) - (a.order ?? 0))
   }, [timeline.layers])
+
+  // Clear all clip/layer/audio selections at once
+  const clearAllSelections = useCallback(() => {
+    setSelectedClip(null)
+    setSelectedVideoClip(null)
+    setSelectedLayerId(null)
+    setSelectedAudioTrackId(null)
+    setSelectedVideoClips(new Set())
+    setSelectedAudioClips(new Set())
+    onClipSelect?.(null)
+    onVideoClipSelect?.(null)
+  }, [onClipSelect, onVideoClipSelect])
 
   // Sync vertical scroll between labels and tracks
   const handleLabelsScroll = useCallback(() => {
@@ -5568,6 +5582,7 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
             return (
             <React.Fragment key={layer.id}>
             <div
+              data-testid={`timeline-layer-header-${layer.id}`}
               className={`border-b border-gray-700 flex items-center group cursor-pointer transition-colors relative ${
                 dragOverLayer === layer.id
                   ? 'bg-purple-900/20'
@@ -5904,9 +5919,34 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
           onScroll={handleTracksScroll}
           className="flex-1 overflow-x-scroll overflow-y-scroll scrollbar-hide"
         >
-          <div ref={timelineContainerRef} className="relative" style={{ minWidth: Math.max(canvasWidth, 800) }}>
+          <div
+            ref={timelineContainerRef}
+            className="relative"
+            style={{ minWidth: Math.max(canvasWidth, 800) }}
+            data-testid="timeline-canvas"
+            onMouseDownCapture={(e) => {
+              // Capture phase: record whether mousedown originated on a clip element.
+              // Runs before any child stopPropagation, so we always capture the real target.
+              // Used to suppress clearAllSelections when a clip drag ends on the canvas
+              // (mousedown on clip, mouseup/click on canvas due to re-render mid-drag).
+              const target = e.target as HTMLElement
+              suppressNextCanvasClick.current = !!(target.closest(
+                '[data-testid^="timeline-video-clip-"], [data-testid^="timeline-audio-clip-"]'
+              ))
+            }}
+            onClick={(e) => {
+              if (e.target !== e.currentTarget) return
+              // Ignore clicks whose mousedown started on a clip (drag-end scenarios)
+              if (suppressNextCanvasClick.current) {
+                suppressNextCanvasClick.current = false
+                return
+              }
+              clearAllSelections()
+            }}
+          >
             {/* Time Ruler - click to seek, double-click/right-click to add marker - sticky so it stays visible when scrolling */}
             <div
+              data-testid="timeline-ruler"
               className="h-6 border-b border-gray-700 relative cursor-pointer hover:bg-gray-700/30 sticky top-0 bg-gray-800 z-10"
               onClick={(e) => {
                 if (!onSeek) return


### PR DESCRIPTION
## Summary
タイムラインの空白部分（クリップ・ヘッダーが無いエリア）をクリックすると、選択中のクリップ／レイヤー／オーディオトラックを一括解除する。DaVinci Resolve / Premiere Pro / FCPX 互換の挙動。

## Changes
- `Timeline.tsx` (+42):
  - `clearAllSelections` useCallback ヘルパーを新設（6 つの選択 state + 親コールバックを一括クリア）
  - `timelineContainerRef` の div に `data-testid="timeline-canvas"` と空白クリック解除ロジックを追加
  - クリップドラッグ起動時の意図しない解除を防ぐため、`onMouseDownCapture` + `suppressNextCanvasClick` ref で「ドラッグ操作後の click」を抑止
  - ルーラー / レイヤーヘッダー側に E2E 用 `data-testid` を追加
- `e2e/timeline-empty-click-clear-selection.spec.ts` (+184): 新規 5 ケース

## Implementation note
当初は `e.target === e.currentTarget` での単純ガードを試したが、クリップ `onMouseDown` で発生する再レンダリングにより mouseup が空白側に着地するケースがあり不十分だった。キャプチャフェーズでクリップの mousedown を捕まえて次の click を抑制する方式に変更し、安定した。

## Verification
worktree (`_orchestration/worktrees/issue-211`) で実行:

- ✅ `npm run lint` — clean
- ✅ `npx tsc -p tsconfig.json --noEmit` — clean
- ✅ `npm run build` — pass
- ✅ `npx playwright test` — 76 passed / 26 skipped / 0 failed

## Test plan
- [x] ビデオクリップ選択 → 空白クリック → 解除
- [x] レイヤーヘッダー選択 → 空白クリック → 解除
- [x] オーディオトラック選択 → 空白クリック → 解除
- [x] ルーラークリックでは選択が解除されない（再生ヘッド移動のみ）
- [x] ルーラーダブルクリックでマーカー追加（既存挙動維持）
- [x] クリップドラッグ操作で誤って選択解除されない

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>