### PR TITLE
fix(#213): ダウンロード版レンダパッケージで Scale 調整を適用

### DIFF
--- a/backend/src/render/pipeline.py
+++ b/backend/src/render/pipeline.py
@@ -1708,9 +1708,17 @@ class RenderPipeline:
                     f"h='max(2,trunc(ih*({scale_expr})))':eval=frame"
                 )
         elif image_with_explicit_size:
-            clip_filters.append(
-                f"scale=w='max(2,trunc({int(width)}))':h='max(2,trunc({int(height)}))':eval=init"
-            )
+            if has_keyframes or not math.isclose(scale, 1.0):
+                # scale != 1.0 or animated: multiply explicit size by scale expression
+                clip_filters.append(
+                    f"scale=w='max(2,trunc({int(width)}*({scale_expr})))':"
+                    f"h='max(2,trunc({int(height)}*({scale_expr})))':eval=frame"
+                )
+            else:
+                # scale == 1.0 and no keyframes: use fixed size (fast path)
+                clip_filters.append(
+                    f"scale=w='max(2,trunc({int(width)}))':h='max(2,trunc({int(height)}))':eval=init"
+                )
         elif width and height:
             clip_filters.append(
                 f"scale=w='max(2,trunc({int(width)}*({scale_expr})))':"

--- a/backend/tests/test_render_package_builder.py
+++ b/backend/tests/test_render_package_builder.py
@@ -1347,3 +1347,300 @@ async def test_render_package_matches_server_export_for_multitrack_audio_dynamic
         assert _framemd5(server_output) == _framemd5(package_output)
     finally:
         builder.cleanup()
+
+
+def _ffprobe_video_size(path):
+    """Return (width, height) of the first video stream."""
+    import subprocess
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v", "error",
+            "-select_streams", "v:0",
+            "-show_entries", "stream=width,height",
+            "-of", "csv=s=x:p=0",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    w, h = result.stdout.strip().split("x")
+    return int(w), int(h)
+
+
+@pytest.mark.asyncio
+async def test_render_package_transform_scale_applied_for_image_clip(
+    temp_output_dir: Path,
+) -> None:
+    """Regression test for #213: transform.scale must be reflected in the
+    download render package filtergraph (image clip with explicit width/height).
+
+    `image_with_explicit_size` clips (still-image + asset_id + explicit width/height)
+    previously entered a branch in _build_clip_filter that emitted a hard-coded
+    ``scale=w='max(2,trunc(W))':h='max(2,trunc(H))'`` ignoring the scale parameter
+    entirely.  The fix must multiply W/H by the scale_expr.
+
+    This test verifies the filtergraph written into the package contains the
+    scale multiplier — no FFmpeg execution required (unit-level, fast).
+    """
+    bg_path = temp_output_dir / "bg_scale.png"
+    Image.new("RGBA", (320, 180), (10, 20, 40, 255)).save(bg_path)
+
+    sprite_path = temp_output_dir / "sprite_scale.png"
+    Image.new("RGBA", (160, 90), (255, 0, 128, 255)).save(sprite_path)
+
+    timeline_data = {
+        "version": "1.0",
+        "duration_ms": 1000,
+        "layers": [
+            {
+                "id": "layer-bg",
+                "name": "Background",
+                "type": "background",
+                "visible": True,
+                "clips": [
+                    {
+                        "id": "clip-bg",
+                        "asset_id": "asset-bg",
+                        "start_ms": 0,
+                        "duration_ms": 1000,
+                        "in_point_ms": 0,
+                        "out_point_ms": 1000,
+                        "transform": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 320,
+                            "height": 180,
+                            "scale": 1.0,
+                            "rotation": 0,
+                        },
+                        "effects": {"opacity": 1.0},
+                    }
+                ],
+            },
+            {
+                "id": "layer-sprite",
+                "name": "Sprite",
+                "type": "content",
+                "visible": True,
+                "clips": [
+                    {
+                        "id": "clip-sprite",
+                        "asset_id": "asset-sprite",
+                        "start_ms": 0,
+                        "duration_ms": 1000,
+                        "in_point_ms": 0,
+                        "out_point_ms": 1000,
+                        # explicit width/height + scale=0.5 — the condition that
+                        # previously hit `image_with_explicit_size` and ignored scale.
+                        "transform": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 160,
+                            "height": 90,
+                            "scale": 0.5,
+                            "rotation": 0,
+                        },
+                        "effects": {"opacity": 1.0},
+                    }
+                ],
+            },
+        ],
+        "audio_tracks": [],
+        "groups": [],
+        "markers": [],
+    }
+
+    assets = {
+        "asset-bg": str(bg_path),
+        "asset-sprite": str(sprite_path),
+    }
+
+    builder = RenderPackageBuilder(
+        project_id="project-scale",
+        project_name="Scale Test",
+        width=320,
+        height=180,
+        fps=30,
+    )
+    try:
+        zip_path = await builder.build(
+            copy.deepcopy(timeline_data),
+            assets,
+            {
+                "asset-bg": "bg_scale.png",
+                "asset-sprite": "sprite_scale.png",
+            },
+        )
+        extract_dir = temp_output_dir / "scale-package"
+        extract_dir.mkdir()
+        with zipfile.ZipFile(zip_path) as archive:
+            archive.extractall(extract_dir)
+
+        package_root = next(extract_dir.glob("render_package_*"))
+
+        # Find the composite filtergraph file
+        filtergraph_files = list((package_root / "scripts").glob("*.filtergraph"))
+        assert filtergraph_files, "No .filtergraph file found in package scripts/"
+        filtergraph_content = filtergraph_files[0].read_text()
+
+        # The scale filter for the sprite clip must multiply width/height by
+        # the scale expression (0.5 in this case).  A plain ``trunc(160)`` or
+        # ``trunc(90)`` without multiplication means scale is being ignored.
+        # We check that "160*" or "*(0.5)" appears, which rules out the bare
+        # ``scale=w='max(2,trunc(160))':h='max(2,trunc(90))'`` bug pattern.
+        assert "160*(" in filtergraph_content or "*(0.5)" in filtergraph_content, (
+            "Filtergraph does not contain scale multiplication for the sprite clip.\n"
+            "Expected something like scale=w='max(2,trunc(160*(0.5)))' but got:\n"
+            + filtergraph_content
+        )
+        # The bare (un-scaled) pattern must NOT appear for the sprite input.
+        # trunc(160)) without a following '*' means scale is hard-coded.
+        assert "trunc(160))" not in filtergraph_content, (
+            "Filtergraph still contains hard-coded 'trunc(160))' without scale multiplier.\n"
+            "This means transform.scale=0.5 is being ignored for image_with_explicit_size clips.\n"
+            + filtergraph_content
+        )
+    finally:
+        builder.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+async def test_render_package_transform_scale_image_clip_output_matches_server(
+    temp_output_dir: Path,
+) -> None:
+    """End-to-end parity test for #213: package render.sh output must match
+    the server-side RenderPipeline output when transform.scale != 1.0 for an
+    image clip with explicit width/height (image_with_explicit_size path).
+    """
+    bg_path = temp_output_dir / "bg_scale_e2e.png"
+    Image.new("RGBA", (320, 180), (10, 20, 40, 255)).save(bg_path)
+
+    sprite_path = temp_output_dir / "sprite_scale_e2e.png"
+    Image.new("RGBA", (160, 90), (255, 0, 128, 255)).save(sprite_path)
+
+    timeline_data = {
+        "version": "1.0",
+        "duration_ms": 1000,
+        "layers": [
+            {
+                "id": "layer-bg",
+                "name": "Background",
+                "type": "background",
+                "visible": True,
+                "clips": [
+                    {
+                        "id": "clip-bg",
+                        "asset_id": "asset-bg",
+                        "start_ms": 0,
+                        "duration_ms": 1000,
+                        "in_point_ms": 0,
+                        "out_point_ms": 1000,
+                        "transform": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 320,
+                            "height": 180,
+                            "scale": 1.0,
+                            "rotation": 0,
+                        },
+                        "effects": {"opacity": 1.0},
+                    }
+                ],
+            },
+            {
+                "id": "layer-sprite",
+                "name": "Sprite",
+                "type": "content",
+                "visible": True,
+                "clips": [
+                    {
+                        "id": "clip-sprite",
+                        "asset_id": "asset-sprite",
+                        "start_ms": 0,
+                        "duration_ms": 1000,
+                        "in_point_ms": 0,
+                        "out_point_ms": 1000,
+                        "transform": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 160,
+                            "height": 90,
+                            "scale": 0.5,
+                            "rotation": 0,
+                        },
+                        "effects": {"opacity": 1.0},
+                    }
+                ],
+            },
+        ],
+        "audio_tracks": [],
+        "groups": [],
+        "markers": [],
+    }
+
+    assets = {
+        "asset-bg": str(bg_path),
+        "asset-sprite": str(sprite_path),
+    }
+
+    # ---- Server-side render ----
+    server_output = temp_output_dir / "server_scale_e2e.mp4"
+    pipeline = RenderPipeline(
+        job_id="scale-server-e2e",
+        project_id="project-scale-e2e",
+        width=320,
+        height=180,
+        fps=30,
+    )
+    await pipeline.render(copy.deepcopy(timeline_data), assets, str(server_output))
+    assert server_output.exists()
+
+    # ---- Package render ----
+    builder = RenderPackageBuilder(
+        project_id="project-scale-e2e",
+        project_name="Scale E2E Test",
+        width=320,
+        height=180,
+        fps=30,
+    )
+    try:
+        zip_path = await builder.build(
+            copy.deepcopy(timeline_data),
+            assets,
+            {
+                "asset-bg": "bg_scale_e2e.png",
+                "asset-sprite": "sprite_scale_e2e.png",
+            },
+        )
+        extract_dir = temp_output_dir / "scale-e2e-package"
+        extract_dir.mkdir()
+        with zipfile.ZipFile(zip_path) as archive:
+            archive.extractall(extract_dir)
+
+        package_root = next(extract_dir.glob("render_package_*"))
+        render_result = subprocess.run(
+            ["bash", "render.sh"],
+            cwd=package_root,
+            capture_output=True,
+            text=True,
+        )
+        assert render_result.returncode == 0, (
+            f"render.sh failed.\nstdout: {render_result.stdout}\nstderr: {render_result.stderr}"
+        )
+
+        package_output = package_root / "output" / "final.mp4"
+        assert package_output.exists()
+
+        # Server and package outputs must be pixel-identical (framemd5 parity)
+        server_md5 = _framemd5(server_output)
+        package_md5 = _framemd5(package_output)
+        assert server_md5 == package_md5, (
+            "Package output does not match server output — transform.scale may be ignored.\n"
+            f"server framemd5 (first line): {server_md5.splitlines()[0]}\n"
+            f"package framemd5 (first line): {package_md5.splitlines()[0]}"
+        )
+    finally:
+        builder.cleanup()

--- a/backend/tests/test_render_pipeline.py
+++ b/backend/tests/test_render_pipeline.py
@@ -829,8 +829,14 @@ class TestRenderPipeline:
         )
         assert output_path is not None
 
-    def test_build_clip_filter_image_with_explicit_size_ignores_scale_like_browser_preview(self):
-        """Image clips with explicit width/height should not apply transform.scale again."""
+    def test_build_clip_filter_image_with_explicit_size_applies_scale(self):
+        """Image clips with explicit width/height must multiply width/height by
+        transform.scale (fix for #213).
+
+        Previously (bug) the scale was silently ignored for `image_with_explicit_size`
+        clips — only the bare width/height were used.  After the fix the scale
+        expression must appear in the filter so that scale=1.5 enlarges the clip.
+        """
         pipeline = RenderPipeline()
 
         filter_str, _ = pipeline._build_clip_filter(
@@ -855,9 +861,42 @@ class TestRenderPipeline:
             is_still_image=True,
         )
 
+        # scale=1.5 must be multiplied into the explicit width/height
+        assert "trunc(320*(1.500000))" in filter_str
+        assert "trunc(180*(1.500000))" in filter_str
+        # The bare (un-scaled) pattern must NOT appear
+        assert "scale=w='max(2,trunc(320))':h='max(2,trunc(180))':eval=init" not in filter_str
+
+    def test_build_clip_filter_image_with_explicit_size_scale_1_uses_fast_path(self):
+        """When transform.scale == 1.0 and no keyframes, the fast path (eval=init)
+        should still be used for performance — only the non-1.0 case needs eval=frame.
+        """
+        pipeline = RenderPipeline()
+
+        filter_str, _ = pipeline._build_clip_filter(
+            input_idx=1,
+            clip={
+                "asset_id": "image-1",
+                "start_ms": 0,
+                "duration_ms": 1000,
+                "transform": {
+                    "x": 0,
+                    "y": 0,
+                    "scale": 1.0,
+                    "rotation": 0,
+                    "width": 320,
+                    "height": 180,
+                },
+                "effects": {"opacity": 1.0},
+            },
+            layer_type="content",
+            base_output="0:v",
+            total_duration_ms=1000,
+            is_still_image=True,
+        )
+
+        # scale=1.0 with no keyframes → fast path, no multiplication needed
         assert "scale=w='max(2,trunc(320))':h='max(2,trunc(180))':eval=init" in filter_str
-        assert "trunc(320*(1.500000))" not in filter_str
-        assert "trunc(180*(1.500000))" not in filter_str
 
     def test_build_clip_filter_adds_slide_transition_offsets(self):
         """Slide transitions should become overlay position offsets."""


### PR DESCRIPTION
## Summary
- `RenderPipeline._build_clip_filter` の `image_with_explicit_size` 分岐で `transform.scale` を `scale_expr` で乗算しておらず、明示サイズを持つ画像クリップで Scale が完全に無視されていた問題を修正
- `scale != 1.0` または keyframes ありの場合は乗算式を含む `eval=frame` 形式を使用、`scale == 1.0` かつ keyframes なしの場合のみ従来の `eval=init` 高速パスを維持
- 既存の `..._ignores_scale_like_browser_preview` テストはバグ動作を仕様として固定していたため、正しい動作の regression test に置き換え

## 影響範囲
- `backend/src/render/pipeline.py` (+8/-2 行)
- これは**サーバー側エクスポートとパッケージ生成の両方**で同じフィルター生成を使うため、サーバー側出力も同じく Scale を反映する形に変わる
- 旧実装で意図的に「ブラウザプレビューと合わせて Scale を無視」していた場合、このPRはその挙動を破壊する。Frontend のプレビュー側で同種のクリップ（画像 + 明示 width/height）の `transform.scale` がどう扱われているか、レビュー時に確認してほしい

## Verification
- 旧実装で fail することを確認した focused regression test を追加:
  - `test_render_package_transform_scale_applied_for_image_clip` — `.filtergraph` に `160*(0.5)` が含まれることを検証（FFmpeg 不要）
  - `test_render_package_transform_scale_image_clip_output_matches_server` — `bash render.sh` 実行後にサーバー出力と framemd5 一致を検証（E2E）
  - `test_build_clip_filter_image_with_explicit_size_applies_scale` — `scale=1.5` で `trunc(320*(1.500000))` が含まれること
  - `test_build_clip_filter_image_with_explicit_size_scale_1_uses_fast_path` — `scale=1.0` では従来の高速パスが維持されること

## Test plan
- [x] `ruff check src/`
- [x] `ruff format --check src/`
- [x] `mypy src/ --ignore-missing-imports`
- [x] `python -m pytest tests/` → 391 passed, 57 skipped (DB/E2E依存テスト除く)
- [ ] CI 全項目 pass
- [ ] レビュアーによる Frontend プレビュー挙動の確認（上記 影響範囲 参照）

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>