### PR TITLE
security(#215): change dev_mode default from True to False

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -110,6 +110,7 @@ jobs:
           -q
         env:
           ENVIRONMENT: test
+          DEV_MODE: "true"
 
       # Temporary: run the broad backend suite while excluding tests that still
       # require local services, live API credentials, database fixtures, or local test data.
@@ -124,3 +125,4 @@ jobs:
           "not requires_db and not requires_test_data and not requires_e2e and not requires_live_api"
         env:
           ENVIRONMENT: test
+          DEV_MODE: "true"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,7 @@
 APP_NAME="Douga API"
 ENVIRONMENT=development
 DEBUG=true
+DEV_MODE=true   # ローカル開発時のみ。本番 (Cloud Run) は明示的に false を設定済み
 
 # Database (Cloud SQL)
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/douga

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -95,7 +95,7 @@ class Settings(BaseSettings):
     render_ffmpeg_max_muxing_queue: int = 1024
 
     # Development/Testing - DEV_USER bypasses Firebase auth
-    dev_mode: bool = True  # Set to False in production
+    dev_mode: bool = False  # Set DEV_MODE=true in local .env to bypass auth
     dev_user_email: str = "dev@example.com"
     dev_user_name: str = "開発ユーザー"
     dev_user_id: str = "dev-user-123"

--- a/backend/tests/test_auth_dev_mode.py
+++ b/backend/tests/test_auth_dev_mode.py
@@ -1,0 +1,61 @@
+"""
+Regression tests: dev_mode=False のとき認証バイパスが無効になることを確認。
+
+- settings.dev_mode=False に monkeypatch で上書きし、lru_cache を貫通させる。
+- init_db と get_db をモックして DB 接続なしで起動できるようにする。
+- これらのテストは requires_db マーカーを付けない (pure auth check)。
+"""
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api import deps as deps_module
+from src.main import app
+from src.models.database import get_db
+
+
+async def _fake_db():
+    """DB 依存性のダミー。dev_mode=False の場合、DB に到達する前に 401 が上がるため
+    実際には呼ばれないが、override しておかないと DB 接続が試みられる。"""
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=MagicMock())
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.close = AsyncMock()
+    yield session
+
+
+@pytest.fixture
+def client_no_dev_mode(monkeypatch):
+    """settings.dev_mode=False に上書きした TestClient を返す。
+
+    init_db をモックして DB 接続なしで lifespan startup を通過させる。
+    """
+    patched = deepcopy(deps_module.settings)
+    patched.dev_mode = False
+    monkeypatch.setattr(deps_module, "settings", patched)
+
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        with patch("src.main.init_db", new=AsyncMock()), \
+             TestClient(app, raise_server_exceptions=False) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_auth_required_when_dev_mode_false(client_no_dev_mode):
+    """`dev_mode=False` のとき、認証ヘッダなしで /api/auth/me を叩くと 401 が返る。"""
+    resp = client_no_dev_mode.get("/api/auth/me")
+    assert resp.status_code == 401
+
+
+def test_dev_token_rejected_when_dev_mode_false(client_no_dev_mode):
+    """`dev_mode=False` のとき、dev-token は無効で 401 が返る。"""
+    resp = client_no_dev_mode.get(
+        "/api/auth/me",
+        headers={"Authorization": "Bearer dev-token"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- `backend/src/config.py` の `dev_mode` デフォルトを `True` → `False` に変更（本番認証バイパスのリスク排除）
- `backend/.env.example` に `DEV_MODE=true` をローカル開発用として明記
- `.github/workflows/pr-check.yml` の Backend Checks 2 step (`Run render parity tests`, `Run pytest (broad backend CI suite)`) に `DEV_MODE: "true"` env を追加（既存テストが dev-token bypass に依存しているための互換措置）
- `backend/tests/test_auth_dev_mode.py` を新規追加（`dev_mode=False` のとき認証ヘッダなしで 401 を返す regression test）

## Migration Note (ローカル開発者向け)

本 PR マージ後、`backend/.env` に `DEV_MODE=true` の明記が必須になります。
既に書いている場合は無変更。書いていない場合、ローカルでバックエンドを動かすと認証エラーが返るので追記してください。
本番 (Cloud Run) は env var で `DEV_MODE=false` を hotfix 済み (revision `douga-api-00584-6mp`, 2026-05-03) のため動作影響なし。

## CI Note

`.github/workflows/pr-check.yml` に `DEV_MODE: "true"` env を追加。これは既存テストが
`Authorization: Bearer dev-token` 経由の dev_mode バイパスに依存しているための互換措置。
将来テスト基盤を API Key ベースに移行する別 issue を切ります。

## 挙動変化が想定される箇所

- `backend/src/api/deps.py:236` の `get_optional_user` も `settings.dev_mode` を参照しており、デフォルト `False` 化により、認証ヘッダなしの呼び出し時に dev user を返さず `None` を返すようになる。`OptionalUser` を依存性として使うエンドポイントは元々 `None` 許容のため挙動互換だが、ローカル開発時は `DEV_MODE=true` を必ず `.env` に設定すること。

## Verification

ローカル (worktree `_orchestration/worktrees/issue-215`):

```
ruff check src/                     → OK
ruff format --check src/            → OK (109 files)
mypy src/ --ignore-missing-imports  → OK (109 source files)
DEV_MODE=true pytest tests/ -v --tb=short \
  -m "not requires_db and not requires_test_data and not requires_e2e and not requires_live_api"
                                    → 393 passed, 55 skipped, 253 deselected
unset DEV_MODE && pytest tests/test_auth_dev_mode.py
                                    → 2 passed
```

## Test plan

- [x] `dev_mode=False` で認証ヘッダなし `/api/auth/me` → 401
- [x] `dev_mode=False` で `Authorization: Bearer dev-token` → 401
- [x] CI と同条件 (`DEV_MODE=true`) で既存テスト全 pass
- [ ] CI Backend Checks pass
- [ ] CI Frontend Checks pass

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>