### PR TITLE
fix(editor): commit numeric inputs only on Enter/blur (#221)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,8 @@
       "devDependencies": {
         "@eslint/js": "^9.16.0",
         "@playwright/test": "^1.57.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -38,6 +40,7 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.13.0",
+        "jsdom": "^26.1.0",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "~5.6.2",
@@ -58,6 +61,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -348,6 +372,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -2147,6 +2286,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2693,6 +2903,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2768,6 +2988,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3164,12 +3395,40 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/date-fns": {
       "version": "3.6.0",
@@ -3199,6 +3458,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3215,6 +3481,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -3228,6 +3505,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3255,6 +3540,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3987,6 +4285,19 @@
       "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -4014,6 +4325,34 @@
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/i18next": {
       "version": "25.8.10",
@@ -4053,6 +4392,19 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -4169,6 +4521,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4203,6 +4562,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4351,6 +4750,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -4502,6 +4912,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4594,6 +5011,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4890,6 +5320,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -5002,6 +5462,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5161,6 +5629,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5204,6 +5679,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -5366,6 +5861,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
@@ -5511,6 +6013,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5522,6 +6044,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5913,11 +6461,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wavesurfer.js": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.1.tgz",
       "integrity": "sha512-NswPjVHxk0Q1F/VMRemCPUzSojjuHHisQrBqQiRXg7MVbe3f5vQ6r0rTTXA/a/neC/4hnOEC4YpXca4LpH0SUg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -5940,6 +6511,44 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6001,6 +6610,45 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,8 @@
   "devDependencies": {
     "@eslint/js": "^9.16.0",
     "@playwright/test": "^1.57.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
@@ -46,6 +48,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.13.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.6.2",

--- a/frontend/src/components/common/NumericInput.test.tsx
+++ b/frontend/src/components/common/NumericInput.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import NumericInput from './NumericInput'
+
+describe('NumericInput', () => {
+  let onCommit: (value: number) => void
+
+  beforeEach(() => {
+    onCommit = vi.fn<(value: number) => void>()
+  })
+
+  it('Enter で commit が 1 回だけ呼ばれる（二重発火防止）', async () => {
+    const user = userEvent.setup()
+    render(<NumericInput value={10} onCommit={onCommit} data-testid="input" />)
+    const input = screen.getByTestId('input') as HTMLInputElement
+
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, '42')
+    await user.keyboard('{Enter}')
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith(42)
+  })
+
+  it('Tab (blur) で commit が 1 回呼ばれる', async () => {
+    const user = userEvent.setup()
+    render(<NumericInput value={10} onCommit={onCommit} data-testid="input" />)
+    const input = screen.getByTestId('input') as HTMLInputElement
+
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, '99')
+    await user.tab()
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith(99)
+  })
+
+  it('Escape で commit が呼ばれず、表示が元の value に戻る', async () => {
+    const user = userEvent.setup()
+    render(<NumericInput value={10} onCommit={onCommit} data-testid="input" />)
+    const input = screen.getByTestId('input') as HTMLInputElement
+
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, '55')
+    await user.keyboard('{Escape}')
+
+    expect(onCommit).toHaveBeenCalledTimes(0)
+    expect(input.value).toBe('10')
+  })
+
+  it('フォーカス中は外部 value 変更で表示が上書きされない', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <NumericInput value={10} onCommit={onCommit} data-testid="input" />,
+    )
+    const input = screen.getByTestId('input') as HTMLInputElement
+
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, '77')
+
+    // フォーカス中に親コンポーネントが value を変更
+    rerender(<NumericInput value={999} onCommit={onCommit} data-testid="input" />)
+
+    // 編集中の文字列が上書きされないこと
+    expect(input.value).toBe('77')
+  })
+
+  it('空欄で確定（blur）すると onCommit が呼ばれず、入力が元の value に戻る', async () => {
+    const user = userEvent.setup()
+    render(<NumericInput value={10} onCommit={onCommit} data-testid="input" />)
+    const input = screen.getByTestId('input') as HTMLInputElement
+
+    await user.click(input)
+    await user.clear(input)
+    await user.tab()
+
+    expect(onCommit).toHaveBeenCalledTimes(0)
+    expect(input.value).toBe('10')
+  })
+})

--- a/frontend/src/components/common/NumericInput.tsx
+++ b/frontend/src/components/common/NumericInput.tsx
@@ -13,6 +13,8 @@ export interface NumericInputProps {
   className?: string
   'data-testid'?: string
   placeholder?: string
+  'aria-label'?: string
+  id?: string
 }
 
 /**
@@ -34,11 +36,15 @@ export default function NumericInput({
   className,
   'data-testid': testId,
   placeholder,
+  'aria-label': ariaLabel,
+  id,
 }: NumericInputProps) {
   const format = (v: number): string => (formatDisplay ? formatDisplay(v) : String(v))
 
   const [displayValue, setDisplayValue] = useState<string>(format(value))
   const focusedRef = useRef(false)
+  // Enter / Escape で処理済みの場合、onBlur 内での commit を skip するフラグ
+  const justHandledRef = useRef(false)
 
   // フォーカス中でなければ外部値の変化を同期
   useEffect(() => {
@@ -72,6 +78,8 @@ export default function NumericInput({
   return (
     <input
       type="number"
+      id={id}
+      aria-label={ariaLabel}
       data-testid={testId}
       min={min}
       max={max}
@@ -84,15 +92,23 @@ export default function NumericInput({
         focusedRef.current = true
       }}
       onBlur={() => {
+        // Enter / Escape で既に処理済みの場合は commit をスキップ
+        if (justHandledRef.current) {
+          justHandledRef.current = false
+          focusedRef.current = false
+          return
+        }
         focusedRef.current = false
         commit()
       }}
       onKeyDown={(e) => {
         e.stopPropagation()
         if (e.key === 'Enter') {
+          justHandledRef.current = true
           commit()
           e.currentTarget.blur()
         } else if (e.key === 'Escape') {
+          justHandledRef.current = true
           cancel()
           e.currentTarget.blur()
         }

--- a/frontend/src/components/common/NumericInput.tsx
+++ b/frontend/src/components/common/NumericInput.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface NumericInputProps {
+  value: number
+  onCommit: (value: number) => void
+  min?: number
+  max?: number
+  step?: number
+  /** 入力値 → store値の変換 (例: % → 比率 val/100) */
+  transform?: (raw: number) => number
+  /** 表示用フォーマット (例: Math.round, toFixed(2)) */
+  formatDisplay?: (value: number) => string
+  className?: string
+  'data-testid'?: string
+  placeholder?: string
+}
+
+/**
+ * 数値入力コンポーネント。
+ * - フォーカス中は外部 value の変更を無視する（編集中の値を上書きしない）
+ * - Enter または blur で onCommit を呼ぶ
+ * - 空文字 / NaN の場合は commit せず、直前の value に戻す
+ * - Esc でキャンセル（直前の value に戻す）
+ * - onKeyDown で stopPropagation（Editor ショートカット干渉防止）
+ */
+export default function NumericInput({
+  value,
+  onCommit,
+  min,
+  max,
+  step,
+  transform,
+  formatDisplay,
+  className,
+  'data-testid': testId,
+  placeholder,
+}: NumericInputProps) {
+  const format = (v: number): string => (formatDisplay ? formatDisplay(v) : String(v))
+
+  const [displayValue, setDisplayValue] = useState<string>(format(value))
+  const focusedRef = useRef(false)
+
+  // フォーカス中でなければ外部値の変化を同期
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setDisplayValue(format(value))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  const commit = () => {
+    const raw = parseFloat(displayValue)
+    if (displayValue.trim() === '' || Number.isNaN(raw)) {
+      // 不正値は元に戻す
+      setDisplayValue(format(value))
+      return
+    }
+
+    let clamped = raw
+    if (min !== undefined) clamped = Math.max(min, clamped)
+    if (max !== undefined) clamped = Math.min(max, clamped)
+
+    const committed = transform ? transform(clamped) : clamped
+    setDisplayValue(format(clamped))
+    onCommit(committed)
+  }
+
+  const cancel = () => {
+    setDisplayValue(format(value))
+  }
+
+  return (
+    <input
+      type="number"
+      data-testid={testId}
+      min={min}
+      max={max}
+      step={step}
+      placeholder={placeholder}
+      value={displayValue}
+      className={className}
+      onChange={(e) => setDisplayValue(e.target.value)}
+      onFocus={() => {
+        focusedRef.current = true
+      }}
+      onBlur={() => {
+        focusedRef.current = false
+        commit()
+      }}
+      onKeyDown={(e) => {
+        e.stopPropagation()
+        if (e.key === 'Enter') {
+          commit()
+          e.currentTarget.blur()
+        } else if (e.key === 'Escape') {
+          cancel()
+          e.currentTarget.blur()
+        }
+      }}
+    />
+  )
+}

--- a/frontend/src/components/editor/EditorAudioClipInspector.tsx
+++ b/frontend/src/components/editor/EditorAudioClipInspector.tsx
@@ -2,14 +2,7 @@ import { type Dispatch, type SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SelectedClipInfo } from '@/components/editor/Timeline'
 import type { TimelineData } from '@/store/projectStore'
-
-interface AudioPropertyFormState {
-  durationMs: string
-  startMs: string
-  volume: string
-  fadeInMs: string
-  fadeOutMs: string
-}
+import NumericInput from '@/components/common/NumericInput'
 
 interface NewVolumeKeyframeInput {
   timeMs: string
@@ -24,10 +17,8 @@ interface EditorAudioClipInspectorProps {
   handleRemoveVolumeKeyframe: (index: number) => void
   handleUpdateAudioClip: (updates: Record<string, unknown>) => void
   handleUpdateVolumeKeyframe: (index: number, timeMs: number, value: number) => void
-  localAudioProps: AudioPropertyFormState
   newKeyframeInput: NewVolumeKeyframeInput
   selectedClip: SelectedClipInfo
-  setLocalAudioProps: Dispatch<SetStateAction<AudioPropertyFormState>>
   setNewKeyframeInput: Dispatch<SetStateAction<NewVolumeKeyframeInput>>
   timelineData?: TimelineData
 }
@@ -40,10 +31,8 @@ export default function EditorAudioClipInspector({
   handleRemoveVolumeKeyframe,
   handleUpdateAudioClip,
   handleUpdateVolumeKeyframe,
-  localAudioProps,
   newKeyframeInput,
   selectedClip,
-  setLocalAudioProps,
   setNewKeyframeInput,
   timelineData,
 }: EditorAudioClipInspectorProps) {
@@ -81,100 +70,64 @@ export default function EditorAudioClipInspector({
 
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.startPosition')}</label>
-        <input
-          type="number"
-          min="0"
-          step="100"
-          value={localAudioProps.startMs}
-          onChange={(e) => setLocalAudioProps(prev => ({ ...prev, startMs: e.target.value }))}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              const val = Math.max(0, parseInt(localAudioProps.startMs) || 0)
-              setLocalAudioProps(prev => ({ ...prev, startMs: String(val) }))
-              handleUpdateAudioClip({ start_ms: val })
-            }
+        <NumericInput
+          value={selectedClip.startMs}
+          onCommit={(val) => {
+            const clamped = Math.max(0, val)
+            handleUpdateAudioClip({ start_ms: clamped })
           }}
-          onBlur={() => {
-            const val = Math.max(0, parseInt(localAudioProps.startMs) || 0)
-            setLocalAudioProps(prev => ({ ...prev, startMs: String(val) }))
-            handleUpdateAudioClip({ start_ms: val })
-          }}
+          min={0}
+          step={100}
+          formatDisplay={(v) => String(Math.round(v))}
           className="w-full px-2 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-primary-500"
         />
       </div>
 
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.volumePercent')}</label>
-        <input
+        <NumericInput
           data-testid="audio-clip-volume-input"
-          type="number"
-          min="0"
-          max="100"
-          step="1"
-          value={localAudioProps.volume}
-          onChange={(e) => setLocalAudioProps(prev => ({ ...prev, volume: e.target.value }))}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              const val = Math.max(0, Math.min(100, parseInt(localAudioProps.volume) || 0))
-              setLocalAudioProps(prev => ({ ...prev, volume: String(val) }))
-              handleUpdateAudioClip({ volume: val / 100 })
-            }
+          value={Math.round(selectedClip.volume * 100)}
+          onCommit={(val) => {
+            const clamped = Math.max(0, Math.min(100, val))
+            handleUpdateAudioClip({ volume: clamped / 100 })
           }}
-          onBlur={() => {
-            const val = Math.max(0, Math.min(100, parseInt(localAudioProps.volume) || 0))
-            setLocalAudioProps(prev => ({ ...prev, volume: String(val) }))
-            handleUpdateAudioClip({ volume: val / 100 })
-          }}
+          min={0}
+          max={100}
+          step={1}
+          formatDisplay={(v) => String(Math.round(v))}
           className="w-full px-2 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-primary-500"
         />
       </div>
 
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.fadeInMs')}</label>
-        <input
-          type="number"
-          min="0"
-          max="10000"
-          step="100"
-          value={localAudioProps.fadeInMs}
-          onChange={(e) => setLocalAudioProps(prev => ({ ...prev, fadeInMs: e.target.value }))}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              const val = Math.max(0, parseInt(localAudioProps.fadeInMs) || 0)
-              setLocalAudioProps(prev => ({ ...prev, fadeInMs: String(val) }))
-              handleUpdateAudioClip({ fade_in_ms: val })
-            }
+        <NumericInput
+          value={selectedClip.fadeInMs}
+          onCommit={(val) => {
+            const clamped = Math.max(0, val)
+            handleUpdateAudioClip({ fade_in_ms: clamped })
           }}
-          onBlur={() => {
-            const val = Math.max(0, parseInt(localAudioProps.fadeInMs) || 0)
-            setLocalAudioProps(prev => ({ ...prev, fadeInMs: String(val) }))
-            handleUpdateAudioClip({ fade_in_ms: val })
-          }}
+          min={0}
+          max={10000}
+          step={100}
+          formatDisplay={(v) => String(Math.round(v))}
           className="w-full px-2 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-primary-500"
         />
       </div>
 
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.fadeOutMs')}</label>
-        <input
-          type="number"
-          min="0"
-          max="10000"
-          step="100"
-          value={localAudioProps.fadeOutMs}
-          onChange={(e) => setLocalAudioProps(prev => ({ ...prev, fadeOutMs: e.target.value }))}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              const val = Math.max(0, parseInt(localAudioProps.fadeOutMs) || 0)
-              setLocalAudioProps(prev => ({ ...prev, fadeOutMs: String(val) }))
-              handleUpdateAudioClip({ fade_out_ms: val })
-            }
+        <NumericInput
+          value={selectedClip.fadeOutMs}
+          onCommit={(val) => {
+            const clamped = Math.max(0, val)
+            handleUpdateAudioClip({ fade_out_ms: clamped })
           }}
-          onBlur={() => {
-            const val = Math.max(0, parseInt(localAudioProps.fadeOutMs) || 0)
-            setLocalAudioProps(prev => ({ ...prev, fadeOutMs: String(val) }))
-            handleUpdateAudioClip({ fade_out_ms: val })
-          }}
+          min={0}
+          max={10000}
+          step={100}
+          formatDisplay={(v) => String(Math.round(v))}
           className="w-full px-2 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-primary-500"
         />
       </div>
@@ -191,6 +144,7 @@ export default function EditorAudioClipInspector({
                 step="100"
                 value={newKeyframeInput.timeMs}
                 onChange={(e) => setNewKeyframeInput(prev => ({ ...prev, timeMs: e.target.value }))}
+                onKeyDown={(e) => e.stopPropagation()}
                 placeholder="0"
                 className="w-full px-1.5 py-1 bg-gray-700 border border-gray-600 rounded text-white text-xs focus:outline-none focus:border-orange-500"
               />
@@ -204,6 +158,7 @@ export default function EditorAudioClipInspector({
                 step="10"
                 value={newKeyframeInput.volume}
                 onChange={(e) => setNewKeyframeInput(prev => ({ ...prev, volume: e.target.value }))}
+                onKeyDown={(e) => e.stopPropagation()}
                 className="w-full px-1.5 py-1 bg-gray-700 border border-gray-600 rounded text-white text-xs focus:outline-none focus:border-orange-500"
               />
             </div>
@@ -270,6 +225,7 @@ export default function EditorAudioClipInspector({
                         step="100"
                         value={keyframe.time_ms}
                         onChange={(e) => handleUpdateVolumeKeyframe(index, parseInt(e.target.value) || 0, keyframe.value)}
+                        onKeyDown={(e) => e.stopPropagation()}
                         className="w-16 px-1 py-0.5 bg-gray-600 border border-gray-500 rounded text-white text-xs"
                         title={t('editor.timeMs')}
                       />
@@ -281,6 +237,7 @@ export default function EditorAudioClipInspector({
                         step="10"
                         value={Math.round(keyframe.value * 100)}
                         onChange={(e) => handleUpdateVolumeKeyframe(index, keyframe.time_ms, (parseInt(e.target.value) || 0) / 100)}
+                        onKeyDown={(e) => e.stopPropagation()}
                         className="w-12 px-1 py-0.5 bg-gray-600 border border-gray-500 rounded text-orange-400 text-xs"
                         title={t('editor.volumePercent')}
                       />

--- a/frontend/src/components/editor/EditorPropertyPanel.tsx
+++ b/frontend/src/components/editor/EditorPropertyPanel.tsx
@@ -7,14 +7,6 @@ import EditorVideoClipInspector from '@/components/editor/EditorVideoClipInspect
 import type { SelectedClipInfo, SelectedVideoClipInfo } from '@/components/editor/Timeline'
 import type { TimelineData } from '@/store/projectStore'
 
-interface AudioPropertyFormState {
-  durationMs: string
-  startMs: string
-  volume: string
-  fadeInMs: string
-  fadeOutMs: string
-}
-
 interface NewVolumeKeyframeInput {
   timeMs: string
   volume: string
@@ -59,7 +51,6 @@ interface EditorPropertyPanelProps {
   handleUpdateVolumeKeyframe: (index: number, timeMs: number, value: number) => void
   isPropertyPanelOpen: boolean
   isComposing: boolean
-  localAudioProps: AudioPropertyFormState
   localTextContent: string
   newKeyframeInput: NewVolumeKeyframeInput
   projectId: string | null | undefined
@@ -78,7 +69,6 @@ interface EditorPropertyPanelProps {
   setChromaRenderOverlayTimeMs: Dispatch<SetStateAction<number | null>>
   setIsComposing: Dispatch<SetStateAction<boolean>>
   setIsPropertyPanelOpen: Dispatch<SetStateAction<boolean>>
-  setLocalAudioProps: Dispatch<SetStateAction<AudioPropertyFormState>>
   setLocalTextContent: Dispatch<SetStateAction<string>>
   setNewKeyframeInput: Dispatch<SetStateAction<NewVolumeKeyframeInput>>
   setSelectedKeyframeIndex: Dispatch<SetStateAction<number | null>>
@@ -126,7 +116,6 @@ export default function EditorPropertyPanel({
   handleUpdateVolumeKeyframe,
   isPropertyPanelOpen,
   isComposing,
-  localAudioProps,
   localTextContent,
   newKeyframeInput,
   projectId,
@@ -145,7 +134,6 @@ export default function EditorPropertyPanel({
   setChromaRenderOverlayTimeMs,
   setIsComposing,
   setIsPropertyPanelOpen,
-  setLocalAudioProps,
   setLocalTextContent,
   setNewKeyframeInput,
   setSelectedKeyframeIndex,
@@ -246,10 +234,8 @@ export default function EditorPropertyPanel({
                 handleRemoveVolumeKeyframe={handleRemoveVolumeKeyframe}
                 handleUpdateAudioClip={handleUpdateAudioClip}
                 handleUpdateVolumeKeyframe={handleUpdateVolumeKeyframe}
-                localAudioProps={localAudioProps}
                 newKeyframeInput={newKeyframeInput}
                 selectedClip={selectedClip}
-                setLocalAudioProps={setLocalAudioProps}
                 setNewKeyframeInput={setNewKeyframeInput}
                 timelineData={timelineData}
               />

--- a/frontend/src/components/editor/EditorVideoClipDetailsSection.tsx
+++ b/frontend/src/components/editor/EditorVideoClipDetailsSection.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { Asset } from '@/api/assets'
 import type { SelectedVideoClipInfo } from '@/components/editor/Timeline'
+import NumericInput from '@/components/common/NumericInput'
 
 type UpdateHandler = (updates: Record<string, unknown>) => void
 
@@ -46,48 +47,33 @@ export default function EditorVideoClipDetailsSection({
 
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.startPosition')}</label>
-        <input
-          type="text"
-          inputMode="decimal"
-          defaultValue={(selectedVideoClip.startMs / 1000).toFixed(2)}
-          key={`start-${selectedVideoClip.clipId}-${selectedVideoClip.startMs}`}
-          onBlur={(e) => {
-            const val = parseFloat(e.target.value)
-            if (!Number.isNaN(val) && val >= 0) {
+        {/* startMs は秒単位で表示 (.toFixed(2))、commit 時に ms に戻す */}
+        <NumericInput
+          value={selectedVideoClip.startMs / 1000}
+          onCommit={(val) => {
+            if (val >= 0) {
               handleUpdateVideoClipTiming({ startMs: Math.round(val * 1000) })
-            } else {
-              e.target.value = (selectedVideoClip.startMs / 1000).toFixed(2)
             }
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.currentTarget.blur()
-            }
-          }}
+          min={0}
+          step={0.01}
+          formatDisplay={(v) => v.toFixed(2)}
           className="w-full bg-gray-700 text-white text-sm px-2 py-1 rounded"
         />
       </div>
 
       <div>
         <label className="block text-xs text-gray-500 mb-1">{t('editor.duration')}</label>
-        <input
-          type="text"
-          inputMode="decimal"
-          defaultValue={(selectedVideoClip.durationMs / 1000).toFixed(2)}
-          key={`duration-${selectedVideoClip.clipId}-${selectedVideoClip.durationMs}`}
-          onBlur={(e) => {
-            const val = parseFloat(e.target.value)
-            if (!Number.isNaN(val) && val >= 0.1) {
+        <NumericInput
+          value={selectedVideoClip.durationMs / 1000}
+          onCommit={(val) => {
+            if (val >= 0.1) {
               handleUpdateVideoClipTiming({ durationMs: Math.round(val * 1000) })
-            } else {
-              e.target.value = (selectedVideoClip.durationMs / 1000).toFixed(2)
             }
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.currentTarget.blur()
-            }
-          }}
+          min={0.1}
+          step={0.01}
+          formatDisplay={(v) => v.toFixed(2)}
           className="w-full bg-gray-700 text-white text-sm px-2 py-1 rounded"
         />
       </div>
@@ -118,27 +104,18 @@ export default function EditorVideoClipDetailsSection({
           <div className="flex items-center justify-between mb-1">
             <label className="text-xs text-gray-500">{t('editor.speed')}</label>
             <div className="flex items-center">
-              <input
-                type="number"
-                min="20"
-                max="500"
-                step="10"
-                key={`speed-${selectedVideoClip.speed ?? 1}`}
-                defaultValue={Math.round((selectedVideoClip.speed ?? 1) * 100)}
-                onKeyDown={(e) => {
-                  e.stopPropagation()
-                  if (e.key === 'Enter') {
-                    const val = Math.max(20, Math.min(500, parseInt(e.currentTarget.value) || 100)) / 100
-                    handleUpdateVideoClipDebounced({ speed: val })
-                    e.currentTarget.blur()
+              <NumericInput
+                value={Math.round((selectedVideoClip.speed ?? 1) * 100)}
+                onCommit={(val) => {
+                  const clamped = Math.max(20, Math.min(500, val)) / 100
+                  if (clamped !== (selectedVideoClip.speed ?? 1)) {
+                    handleUpdateVideoClipDebounced({ speed: clamped })
                   }
                 }}
-                onBlur={(e) => {
-                  const val = Math.max(20, Math.min(500, parseInt(e.target.value) || 100)) / 100
-                  if (val !== (selectedVideoClip.speed ?? 1)) {
-                    handleUpdateVideoClipDebounced({ speed: val })
-                  }
-                }}
+                min={20}
+                max={500}
+                step={10}
+                formatDisplay={(v) => String(Math.round(v))}
                 className="w-14 px-1 py-0.5 text-xs text-white bg-gray-700 border border-gray-600 rounded text-right"
               />
               <span className="text-xs text-gray-500 ml-1">%</span>

--- a/frontend/src/components/editor/EditorVideoClipTransformSection.tsx
+++ b/frontend/src/components/editor/EditorVideoClipTransformSection.tsx
@@ -1,6 +1,7 @@
 import { type Dispatch, type SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SelectedVideoClipInfo } from '@/components/editor/Timeline'
+import NumericInput from '@/components/common/NumericInput'
 
 type UpdateHandler = (updates: Record<string, unknown>) => void
 
@@ -125,19 +126,21 @@ export default function EditorVideoClipTransformSection({
         <div className="grid grid-cols-2 gap-2">
           <div>
             <label className="block text-xs text-gray-600">X</label>
-            <input
-              type="number"
+            <NumericInput
               value={displayX}
-              onChange={(e) => handleUpdateVideoClip({ transform: { x: parseInt(e.target.value) || 0 } })}
+              onCommit={(val) => handleUpdateVideoClip({ transform: { x: val } })}
+              step={1}
+              formatDisplay={(v) => String(Math.round(v))}
               className="w-full bg-gray-700 text-white text-sm px-2 py-1 rounded"
             />
           </div>
           <div>
             <label className="block text-xs text-gray-600">Y</label>
-            <input
-              type="number"
+            <NumericInput
               value={displayY}
-              onChange={(e) => handleUpdateVideoClip({ transform: { y: parseInt(e.target.value) || 0 } })}
+              onCommit={(val) => handleUpdateVideoClip({ transform: { y: val } })}
+              step={1}
+              formatDisplay={(v) => String(Math.round(v))}
               className="w-full bg-gray-700 text-white text-sm px-2 py-1 rounded"
             />
           </div>
@@ -153,26 +156,19 @@ export default function EditorVideoClipTransformSection({
                   {t('editor.scaleLabel', { kf: hasKeyframes ? ' (KF)' : '' })}
                 </label>
                 <div className="flex items-center">
-                  <input
+                  <NumericInput
                     data-testid="video-scale-input"
-                    type="number"
-                    min="10"
-                    max="300"
-                    step="10"
-                    key={`scale-${displayScale}`}
-                    defaultValue={Math.round(displayScale * 100)}
-                    onKeyDown={(e) => {
-                      e.stopPropagation()
-                      if (e.key === 'Enter') {
-                        e.currentTarget.blur()
+                    value={Math.round(displayScale * 100)}
+                    onCommit={(val) => {
+                      const clamped = Math.max(10, Math.min(300, val)) / 100
+                      if (clamped !== displayScale) {
+                        handleUpdateVideoClip({ transform: { scale: clamped } })
                       }
                     }}
-                    onBlur={(e) => {
-                      const val = Math.max(10, Math.min(300, parseInt(e.target.value) || 100)) / 100
-                      if (val !== displayScale) {
-                        handleUpdateVideoClip({ transform: { scale: val } })
-                      }
-                    }}
+                    min={10}
+                    max={300}
+                    step={10}
+                    formatDisplay={(v) => String(Math.round(v))}
                     className="w-14 px-1 py-0.5 text-xs text-white bg-gray-700 border border-gray-600 rounded text-right"
                   />
                   <span className="text-xs text-gray-500 ml-1">%</span>
@@ -198,25 +194,18 @@ export default function EditorVideoClipTransformSection({
                 {t('editor.rotationLabel', { kf: hasKeyframes ? ' (KF)' : '' })}
               </label>
               <div className="flex items-center">
-                <input
-                  type="number"
-                  min="-180"
-                  max="180"
-                  step="1"
-                  key={`rot-${displayRotation}`}
-                  defaultValue={Math.round(displayRotation)}
-                  onKeyDown={(e) => {
-                    e.stopPropagation()
-                    if (e.key === 'Enter') {
-                      e.currentTarget.blur()
+                <NumericInput
+                  value={Math.round(displayRotation)}
+                  onCommit={(val) => {
+                    const clamped = Math.max(-180, Math.min(180, val))
+                    if (clamped !== displayRotation) {
+                      handleUpdateVideoClip({ transform: { rotation: clamped } })
                     }
                   }}
-                  onBlur={(e) => {
-                    const val = Math.max(-180, Math.min(180, parseInt(e.target.value) || 0))
-                    if (val !== displayRotation) {
-                      handleUpdateVideoClip({ transform: { rotation: val } })
-                    }
-                  }}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  formatDisplay={(v) => String(Math.round(v))}
                   className="w-14 px-1 py-0.5 text-xs text-white bg-gray-700 border border-gray-600 rounded text-right"
                 />
                 <span className="text-xs text-gray-500 ml-1">°</span>
@@ -275,26 +264,19 @@ export default function EditorVideoClipTransformSection({
         <div className="flex items-center justify-between mb-1">
           <label className="text-xs text-gray-500">{t('editor.opacity')}</label>
           <div className="flex items-center">
-            <input
+            <NumericInput
               data-testid="video-opacity-input"
-              type="number"
-              min="0"
-              max="100"
-              step="1"
-              key={`op-${selectedVideoClip.effects.opacity ?? 1}`}
-              defaultValue={Math.round((selectedVideoClip.effects.opacity ?? 1) * 100)}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === 'Enter') {
-                  e.currentTarget.blur()
+              value={Math.round((selectedVideoClip.effects.opacity ?? 1) * 100)}
+              onCommit={(val) => {
+                const clamped = Math.max(0, Math.min(100, val)) / 100
+                if (clamped !== (selectedVideoClip.effects.opacity ?? 1)) {
+                  handleUpdateVideoClip({ effects: { opacity: clamped } })
                 }
               }}
-              onBlur={(e) => {
-                const val = Math.max(0, Math.min(100, parseInt(e.target.value) || 0)) / 100
-                if (val !== (selectedVideoClip.effects.opacity ?? 1)) {
-                  handleUpdateVideoClip({ effects: { opacity: val } })
-                }
-              }}
+              min={0}
+              max={100}
+              step={1}
+              formatDisplay={(v) => String(Math.round(v))}
               className="w-14 px-1 py-0.5 text-xs text-white bg-gray-700 border border-gray-600 rounded text-right"
             />
             <span className="text-xs text-gray-500 ml-1">%</span>
@@ -319,25 +301,18 @@ export default function EditorVideoClipTransformSection({
           <div className="flex items-center justify-between mb-1">
             <label className="text-xs text-gray-500">{t('editor.fadeIn')}</label>
             <div className="flex items-center">
-              <input
-                type="number"
-                min="0"
-                max="3000"
-                step="100"
-                key={`vfi-${selectedVideoClip.fadeInMs ?? 0}`}
-                defaultValue={selectedVideoClip.fadeInMs ?? 0}
-                onKeyDown={(e) => {
-                  e.stopPropagation()
-                  if (e.key === 'Enter') {
-                    e.currentTarget.blur()
+              <NumericInput
+                value={selectedVideoClip.fadeInMs ?? 0}
+                onCommit={(val) => {
+                  const clamped = Math.max(0, Math.min(3000, val))
+                  if (clamped !== (selectedVideoClip.fadeInMs ?? 0)) {
+                    handleUpdateVideoClip({ effects: { fade_in_ms: clamped } })
                   }
                 }}
-                onBlur={(e) => {
-                  const val = Math.max(0, Math.min(3000, parseInt(e.target.value) || 0))
-                  if (val !== (selectedVideoClip.fadeInMs ?? 0)) {
-                    handleUpdateVideoClip({ effects: { fade_in_ms: val } })
-                  }
-                }}
+                min={0}
+                max={3000}
+                step={100}
+                formatDisplay={(v) => String(Math.round(v))}
                 className="w-14 px-1 py-0.5 text-xs text-white bg-gray-700 border border-gray-600 rounded text-right"
               />
               <span className="text-xs text-gray-500 ml-1">ms</span>
@@ -359,25 +334,18 @@ export default function EditorVideoClipTransformSection({
           <div className="flex items-center justify-between mb-1">
             <label className="text-xs text-gray-500">{t('editor.fadeOut')}</label>
             <div className="flex items-center">
-              <input
-                type="number"
-                min="0"
-                max="3000"
-                step="100"
-                key={`vfo-${selectedVideoClip.fadeOutMs ?? 0}`}
-                defaultValue={selectedVideoClip.fadeOutMs ?? 0}
-                onKeyDown={(e) => {
-                  e.stopPropagation()
-                  if (e.key === 'Enter') {
-                    e.currentTarget.blur()
+              <NumericInput
+                value={selectedVideoClip.fadeOutMs ?? 0}
+                onCommit={(val) => {
+                  const clamped = Math.max(0, Math.min(3000, val))
+                  if (clamped !== (selectedVideoClip.fadeOutMs ?? 0)) {
+                    handleUpdateVideoClip({ effects: { fade_out_ms: clamped } })
                   }
                 }}
-                onBlur={(e) => {
-                  const val = Math.max(0, Math.min(3000, parseInt(e.target.value) || 0))
-                  if (val !== (selectedVideoClip.fadeOutMs ?? 0)) {
-                    handleUpdateVideoClip({ effects: { fade_out_ms: val } })
-                  }
-                }}
+                min={0}
+                max={3000}
+                step={100}
+                formatDisplay={(v) => String(Math.round(v))}
                 className="w-14 px-1 py-0.5 text-xs text-white bg-gray-700 border border-gray-600 rounded text-right"
               />
               <span className="text-xs text-gray-500 ml-1">ms</span>

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -271,14 +271,6 @@ export default function Editor() {
   // Local state for text editing with IME support
   const [localTextContent, setLocalTextContent] = useState('')
   const [isComposing, setIsComposing] = useState(false)
-  // Local state for audio property editing (to avoid re-render on every input change)
-  const [localAudioProps, setLocalAudioProps] = useState<{
-    durationMs: string
-    volume: string
-    fadeInMs: string
-    fadeOutMs: string
-    startMs: string
-  }>({ durationMs: '0', volume: '100', fadeInMs: '0', fadeOutMs: '0', startMs: '0' })
   // Local state for new volume keyframe input
   const [newKeyframeInput, setNewKeyframeInput] = useState({ timeMs: '', volume: '100' })
   const [isAIChatOpen, setIsAIChatOpen] = useState(savedLayout.isAIChatOpen)
@@ -607,20 +599,6 @@ export default function Editor() {
   // Computed timeline data: prefer sequence, fallback to project
   const timelineData = currentSequence?.timeline_data ?? currentProject?.timeline_data
   const timelineDataSignature = JSON.stringify(timelineData)
-
-  // Sync local audio properties when selected audio clip changes
-  // selectedClip is for audio tracks (narration, bgm, se), selectedVideoClip is for video/image layers
-  useEffect(() => {
-    if (selectedClip) {
-      setLocalAudioProps({
-        durationMs: String(selectedClip.durationMs),
-        volume: String(Math.round(selectedClip.volume * 100)),
-        fadeInMs: String(selectedClip.fadeInMs),
-        fadeOutMs: String(selectedClip.fadeOutMs),
-        startMs: String(selectedClip.startMs),
-      })
-    }
-  }, [selectedClip])
 
   // Clean up orphaned audio/video refs when timeline changes
   // Also stop playback to prevent ghost audio with stale timing
@@ -4082,7 +4060,6 @@ export default function Editor() {
                 handleUpdateVolumeKeyframe={handleUpdateVolumeKeyframe}
                 isPropertyPanelOpen={isPropertyPanelOpen}
                 isComposing={isComposing}
-                localAudioProps={localAudioProps}
                 localTextContent={localTextContent}
                 newKeyframeInput={newKeyframeInput}
                 projectId={projectId ?? null}
@@ -4101,7 +4078,6 @@ export default function Editor() {
                 setChromaRenderOverlayTimeMs={setChromaRenderOverlayTimeMs}
                 setIsComposing={setIsComposing}
                 setIsPropertyPanelOpen={setIsPropertyPanelOpen}
-                setLocalAudioProps={setLocalAudioProps}
                 setLocalTextContent={setLocalTextContent}
                 setNewKeyframeInput={setNewKeyframeInput}
                 setSelectedKeyframeIndex={setSelectedKeyframeIndex}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: 'node',
+    environment: 'jsdom',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     resolve: {
       alias: {


### PR DESCRIPTION
Closes #221

## Summary
- 共通コンポーネント `NumericInput` を `frontend/src/components/common/NumericInput.tsx` に新設
- 編集中はローカル state で保持し親 store への update を停止、**Enter または blur で確定**、**Esc でキャンセル**
- 空欄や NaN を確定しても**デフォルト値に戻らず**、編集前の値を維持
- フォーカス中は外部 value の変更で `displayValue` を上書きしない（編集中の値が消えない）
- TransformSection / DetailsSection / AudioClipInspector の数値inputを `NumericInput` に統一。それに伴い `Editor.tsx` の `localAudioProps` state を削除（`NumericInput` 内に責務を寄せた）

## Files changed
- `frontend/src/components/common/NumericInput.tsx` (new)
- `frontend/src/components/editor/EditorVideoClipTransformSection.tsx` (X / Y / scale / rotation / opacity / fadeIn / fadeOut)
- `frontend/src/components/editor/EditorVideoClipDetailsSection.tsx` (startMs / durationMs / speed)
- `frontend/src/components/editor/EditorAudioClipInspector.tsx` (startMs / volume / fadeInMs / fadeOutMs)
- `frontend/src/components/editor/EditorPropertyPanel.tsx`
- `frontend/src/pages/Editor.tsx`

既存の `data-testid`（`video-scale-input`, `video-opacity-input`, `video-scale-slider`, `video-opacity-slider` 等）は維持。スライダーの即時プレビュー＋onMouseUp 確定パターンも維持。

## Test plan
- [x] `npx tsc --noEmit` (frontend) — エラーなし
- [x] `npm run build` (frontend) — 成功
- [x] `npx playwright test` — 79 passed / 26 skipped / 0 failed
- [ ] 手動確認: プロパティパネルで X 値を全部消して Enter → 編集前の値に戻ることを確認
- [ ] 手動確認: 編集中はプレビュー/タイムラインが暴れないことを確認

## Out of scope
- ボリュームキーフレーム編集 (`EditorAudioClipInspector` L268付近) は今回対象外（onChange方式維持、stopPropagation のみ追加）。優先度低のため別Issueでフォロー可。