### PR TITLE
fix(#217): Preview クリック時に Timeline の Clip 選択も同期

### DIFF
--- a/frontend/e2e/preview-click-select.spec.ts
+++ b/frontend/e2e/preview-click-select.spec.ts
@@ -140,20 +140,18 @@ test.describe('Preview click-to-select (issue #217)', () => {
     // The property panel should still be visible (shape inspector stays open).
     await expect(scaleInput).toBeVisible()
 
-    // Timeline clip A should lose selection ring, clip B should gain it.
+    // Wait for Timeline internal state to sync from the external prop (selectedVideoClipExternal).
+    // The useEffect in Timeline.tsx propagates Editor's selectedVideoClip down to the internal
+    // selectedVideoClip state, which is reflected as data-selected="true" on the clip wrapper
+    // (VideoLayers.tsx sets this attribute based on isSelected).
     const clipATimeline = page.getByTestId('timeline-video-clip-clip-a')
     const clipBTimeline = page.getByTestId('timeline-video-clip-clip-b')
 
-    const isClipAStillSelected = await clipATimeline.evaluate((el) => {
-      return el.innerHTML.includes('ring-')
-    })
-    const isClipBSelected = await clipBTimeline.evaluate((el) => {
-      return el.innerHTML.includes('ring-')
-    })
+    // Clip B must have data-selected="true" (Timeline highlight synced from Preview click)
+    await expect(clipBTimeline).toHaveAttribute('data-selected', 'true', { timeout: 3000 })
 
-    // With fix: B is selected and A is deselected.
-    // Assert at least one direction is correct (B selected OR A deselected).
-    expect(isClipBSelected || !isClipAStillSelected).toBe(true)
+    // Clip A must no longer be selected
+    await expect(clipATimeline).not.toHaveAttribute('data-selected', 'true')
   })
 
   test('clicking overlapping clip B (higher layer index) selects clip B, not clip A underneath', async ({ page }) => {
@@ -211,15 +209,12 @@ test.describe('Preview click-to-select (issue #217)', () => {
     const clipATimeline = page.getByTestId('timeline-video-clip-clip-aa')
     const clipBTimeline = page.getByTestId('timeline-video-clip-clip-bb')
 
-    const isClipAStillSelected = await clipATimeline.evaluate((el) => {
-      return el.innerHTML.includes('ring-')
-    })
-    const isClipBSelected = await clipBTimeline.evaluate((el) => {
-      return el.innerHTML.includes('ring-')
-    })
-
     // With fix: B is on top (zIndex 11 > 10) so clicking center selects B.
-    // A must be deselected OR B must be selected.
-    expect(isClipBSelected || !isClipAStillSelected).toBe(true)
+    // Additionally, Timeline internal state must sync from the external prop (selectedVideoClipExternal):
+    // clip B must have data-selected="true".
+    await expect(clipBTimeline).toHaveAttribute('data-selected', 'true', { timeout: 3000 })
+
+    // Clip A must no longer be selected
+    await expect(clipATimeline).not.toHaveAttribute('data-selected', 'true')
   })
 })

--- a/frontend/src/components/editor/Timeline.tsx
+++ b/frontend/src/components/editor/Timeline.tsx
@@ -171,6 +171,8 @@ interface TimelineProps {
   defaultImageDurationMs?: number
   onAssetsChange?: () => void  // Called after file upload to refresh assets list
   onFreezeFrame?: (clipId: string, layerId: string) => void
+  /** External (controlled) selection from Editor — e.g. driven by Preview clicks */
+  selectedVideoClipExternal?: { layerId: string; clipId: string } | null
 }
 
 type TelopSourceSelection = {
@@ -189,7 +191,7 @@ type TelopGenerationStatus =
     message: string
   }
 
-export default function Timeline({ timeline, projectId, assets, currentTimeMs = 0, isPlaying = false, onClipSelect, onVideoClipSelect, onSeek, selectedKeyframeIndex, onKeyframeSelect, unmappedAssetIds = new Set(), defaultImageDurationMs = 5000, onAssetsChange, onFreezeFrame }: TimelineProps) {
+export default function Timeline({ timeline, projectId, assets, currentTimeMs = 0, isPlaying = false, onClipSelect, onVideoClipSelect, onSeek, selectedKeyframeIndex, onKeyframeSelect, unmappedAssetIds = new Set(), defaultImageDurationMs = 5000, onAssetsChange, onFreezeFrame, selectedVideoClipExternal }: TimelineProps) {
   const { t } = useTranslation('editor')
   const [zoom, setZoom] = useState(() => loadTimelineZoom())
   const [selectedClip, setSelectedClip] = useState<{ trackId: string; clipId: string } | null>(null)
@@ -226,6 +228,30 @@ export default function Timeline({ timeline, projectId, assets, currentTimeMs = 
   // Multi-selection state
   const [selectedVideoClips, setSelectedVideoClips] = useState<Set<string>>(new Set())
   const [selectedAudioClips, setSelectedAudioClips] = useState<Set<string>>(new Set())
+
+  // Sync internal selectedVideoClip with externally controlled selection (e.g. from Preview clicks).
+  // Guard: skip setState when layerId/clipId already match to prevent feedback loops where
+  //   internal change → onVideoClipSelect → Editor state → prop → useEffect → setState (no-op here).
+  useEffect(() => {
+    if (selectedVideoClipExternal === undefined) return
+    if (selectedVideoClipExternal === null) {
+      if (selectedVideoClip !== null) {
+        setSelectedVideoClip(null)
+        setSelectedVideoClips(new Set())
+      }
+      return
+    }
+    const { layerId, clipId } = selectedVideoClipExternal
+    if (selectedVideoClip?.layerId === layerId && selectedVideoClip?.clipId === clipId) return
+    setSelectedVideoClip({ layerId, clipId })
+    setSelectedLayerId(layerId)
+    setSelectedVideoClips(new Set())
+    setSelectedAudioTrackId(null)
+    setSelectedClip(null)
+  // selectedVideoClip is intentionally omitted from deps: reading it for guard only, not driving the effect
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVideoClipExternal])
+
   // Stretch mode clips (clips with orange handles for time stretching)
   const [stretchModeClips, setStretchModeClips] = useState<Set<string>>(new Set())
   // Freeze-end mode clips (clips with blue right handles for freeze frame extension)

--- a/frontend/src/components/editor/timeline/VideoLayers.tsx
+++ b/frontend/src/components/editor/timeline/VideoLayers.tsx
@@ -273,6 +273,7 @@ function VideoLayers({
                   <div
                     key={clip.id}
                     data-testid={`timeline-video-clip-${clip.id}`}
+                    data-selected={isSelected ? 'true' : undefined}
                     className={`absolute top-1 bottom-1 rounded select-none group overflow-hidden ${
                       (isSelected || isMultiSelected) ? 'z-10' : ''
                     } ${isLinkedHighlight ? 'z-10' : ''} ${isDragging ? 'opacity-80' : ''} ${layer.locked ? 'cursor-not-allowed' : ''} ${hasOverlap ? 'z-10' : ''}`}

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -4011,6 +4011,7 @@ export default function Editor() {
                 defaultImageDurationMs={defaultImageDurationMs}
                 onAssetsChange={fetchAssets}
                 onFreezeFrame={handleFreezeFrame}
+                selectedVideoClipExternal={selectedVideoClip ? { layerId: selectedVideoClip.layerId, clipId: selectedVideoClip.clipId } : null}
               />
             </Suspense>
           </div>


### PR DESCRIPTION
## Summary
- PR #218 (z-index 修正) の follow-up。
- Preview 上でオブジェクトをクリックしても Timeline のクリップ選択が更新されない問題を修正。
- 原因: `Timeline` コンポーネント内部の `selectedVideoClip` state は Editor → Timeline 方向の同期がなく、Preview 経由で Editor の `selectedVideoClip` だけが更新されても Timeline 上のハイライトが追随しなかった。
- 対策: `Timeline` に `selectedVideoClipExternal` prop を追加し、Editor 側の選択を `useEffect` で内部 state に反映。フィードバックループ防止のため layerId/clipId 一致時は no-op ガード。

## Verification
- `npm run lint` — pass
- `npx tsc -p tsconfig.json --noEmit` — pass
- `npm run build` — pass
- `npx playwright test --project=chromium` — 79 passed / 10 skipped

## Focused Regression
`frontend/e2e/preview-click-select.spec.ts` を更新:
- Preview 上のクリップ B を直接クリックした後、Timeline 上のクリップ B 要素が `data-selected="true"` を持つことを検証。
- クリップ A は `data-selected` が外れていることも検証。

`VideoLayers.tsx` のクリップ要素に `data-selected` 属性を追加（既存の class ベース判定より安定したテスト用属性）。

## Test plan
- [x] lint
- [x] type check
- [x] build
- [x] Playwright E2E (chromium)

Refs #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>