### PR TITLE
fix(#233): keep cache expiresAt on ETag 304 to avoid stale GCS signed URLs

### DIFF
--- a/frontend/src/lib/cache/etagCache.test.ts
+++ b/frontend/src/lib/cache/etagCache.test.ts
@@ -388,6 +388,86 @@ describe('clearAllUserData', () => {
 })
 
 // ---------------------------------------------------------------------------
+// fetchWithETag - 304 TTL non-extension (regression #233)
+// ---------------------------------------------------------------------------
+describe('fetchWithETag - 304 TTL non-extension (regression #233)', () => {
+  it('304 応答を繰り返しても最初の writeCache 時刻から ttlMs 経過後にキャッシュが破棄される', async () => {
+    const cacheKey = 'cache:v1:test:ttl-regression'
+    const ttlMs = 50 * 60 * 1000 // 50 minutes
+    const initialTime = 1_700_000_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(initialTime)
+
+    // T=0: 初回 200 応答
+    let fetcher = vi.fn().mockResolvedValue({
+      data: { url: 'signed-url-v1' },
+      etag: 'W/"abc"',
+      status: 200,
+    })
+    await fetchWithETag({ cacheKey, fetcher, ttlMs })
+    const firstEntry = readCache<{ url: string }>(cacheKey)
+    expect(firstEntry?.expiresAt).toBe(initialTime + ttlMs)
+
+    // T=40min: 304 応答 → expiresAt は変わらないはず
+    vi.setSystemTime(initialTime + 40 * 60 * 1000)
+    fetcher = vi.fn().mockResolvedValue({
+      data: null as unknown as { url: string },
+      etag: 'W/"abc"',
+      status: 304,
+    })
+    await fetchWithETag({ cacheKey, fetcher, ttlMs })
+    const afterFirst304 = readCache<{ url: string }>(cacheKey)
+    expect(afterFirst304?.expiresAt).toBe(initialTime + ttlMs)
+    // 旧実装ではここで expiresAt が initialTime + 40min + 50min にリセットされていた
+    expect(afterFirst304?.expiresAt).not.toBe(initialTime + 40 * 60 * 1000 + ttlMs)
+
+    // T=51min: キャッシュが TTL 切れで破棄される
+    vi.setSystemTime(initialTime + 51 * 60 * 1000)
+    expect(readCache<{ url: string }>(cacheKey)).toBeNull()
+
+    vi.useRealTimers()
+  })
+
+  it('304 応答時は writeCache を呼ばない (fetchedAt も維持される)', async () => {
+    const cacheKey = 'cache:v1:test:no-write-on-304'
+    const ttlMs = 50 * 60 * 1000
+    const initialTime = 1_700_000_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(initialTime)
+
+    // 初回 200
+    await fetchWithETag({
+      cacheKey,
+      fetcher: vi.fn().mockResolvedValue({
+        data: { v: 1 },
+        etag: 'W/"x"',
+        status: 200,
+      }),
+      ttlMs,
+    })
+    const initial = readCache<{ v: number }>(cacheKey)
+    expect(initial?.fetchedAt).toBe(initialTime)
+
+    // 30分後に 304
+    vi.setSystemTime(initialTime + 30 * 60 * 1000)
+    await fetchWithETag({
+      cacheKey,
+      fetcher: vi.fn().mockResolvedValue({
+        data: null as unknown as { v: number },
+        etag: 'W/"x"',
+        status: 304,
+      }),
+      ttlMs,
+    })
+    const after304 = readCache<{ v: number }>(cacheKey)
+    expect(after304?.fetchedAt).toBe(initialTime)
+    expect(after304?.expiresAt).toBe(initialTime + ttlMs)
+
+    vi.useRealTimers()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // sequences.ts: mutation 後に clearCache が呼ばれることを確認 (P0-2)
 // ---------------------------------------------------------------------------
 // Note: sequences.ts は apiClient に依存するため、spy テストは sequences.ts を直接

--- a/frontend/src/lib/cache/etagCache.ts
+++ b/frontend/src/lib/cache/etagCache.ts
@@ -210,7 +210,7 @@ export interface FetchWithETagOptions<T> {
  * 1. localStorage を読む → あれば onCacheHit(cached.payload) を即座にコール（楽観表示）
  * 2. If-None-Match ヘッダー付きでサーバーにリクエスト
  *    ただし TTL 切れの場合は If-None-Match を送らず非条件 GET でフレッシュなデータを取得
- * 3. 304 → キャッシュの payload を返す（fetchedAt のみ更新）
+ * 3. 304 → キャッシュの payload を返す（expiresAt は維持し、TTL を延長しない）
  * 4. 200 → 新しい etag でキャッシュを更新して payload を返す
  */
 export async function fetchWithETag<T>(opts: FetchWithETagOptions<T>): Promise<T> {
@@ -236,12 +236,11 @@ export async function fetchWithETag<T>(opts: FetchWithETagOptions<T>): Promise<T
   const result = await fetcher(headers)
 
   if (result.status === 304) {
-    // 304: キャッシュが有効 — fetchedAt と expiresAt を更新して payload を返す
-    if (cached) {
-      writeCache<T>(cacheKey, cached.etag, cached.payload, ttlMs)
-    }
-    // cached が null になるケースは通常ない（If-None-Match を送った場合のみ 304 になる）
-    // 万一 cached が null でも fetcher が data を返していればそれを使う
+    // 304: キャッシュが有効 — expiresAt は維持して payload を返す。
+    // writeCache で TTL をリセットしてしまうと、キャッシュ内に保持している
+    // GCS 署名付き URL (storage_url / thumbnail_url) が 60 分で失効する前に
+    // 強制再取得する仕組みが効かなくなり、期限切れ URL が残り続けてしまう。
+    // (#233)
     return cached?.payload ?? result.data
   }
 


### PR DESCRIPTION
## Summary
- `fetchWithETag` の 304 応答処理から `writeCache` 呼び出しを削除し、`expiresAt` を維持する
- これにより最初の `writeCache` から `ttlMs` (Assets は 50分) 経過したらキャッシュが破棄され、GCS 署名付き URL (60分 TTL) が失効する前に新しい URL を再取得できる
- regression test を 2 件追加（旧実装では fail する条件を含む）

## Background
PR #210 で導入された localStorage ETag キャッシュにおいて、304 応答時に `writeCache(cacheKey, cached.etag, cached.payload, ttlMs)` を呼んでいたため `expiresAt` が「現在時刻 + ttlMs」にリセットされていた。結果として Assets パネルの `asset.storage_url` / `asset.thumbnail_url` を直接 `<img src>` に渡す画像・動画サムネイルが、署名付き URL の 60 分 TTL を超えて期限切れのまま表示され続けていた。

音声 (`AudioWaveformThumbnail`) と thumbnail_url 無し動画 (`LazyVideoThumbnail`) は都度 API 経由で署名 URL を再取得していたため影響を受けていなかった。

## Verification
- ✅ `npm run lint`
- ✅ `npx tsc -p tsconfig.json --noEmit`
- ✅ `npx vitest run src/lib/cache/etagCache.test.ts` (25 tests)
- ✅ `npm run build`
- ✅ `npx playwright test e2e/cache-localstorage.spec.ts` (4 tests)

## Test plan
- [x] regression test: 304 を繰り返しても初回 writeCache 時刻から ttlMs 経過後にキャッシュが破棄される
- [x] regression test: 304 応答時に `fetchedAt` と `expiresAt` が変化しない
- [x] 既存 Vitest / Playwright スイート pass
- [ ] 手動確認: Assets パネルで時間経過後もサムネイルが壊れないこと（マージ後 staging で）

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>