### PR TITLE
refactor(#235): cache layer follow-up — defensive 304 throw, type docs, design comments, TTL expiry E2E

### DIFF
--- a/frontend/e2e/cache-localstorage.spec.ts
+++ b/frontend/e2e/cache-localstorage.spec.ts
@@ -202,7 +202,89 @@ test.describe('localStorage ETag キャッシュ', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // テスト 4: fetch 失敗時に stale バナーが表示され、再試行で消える (C-1)
+  // テスト 4: TTL 期限切れ後にページリロードすると非条件 GET が走る (#235)
+  // ---------------------------------------------------------------------------
+  test('TTL 期限切れ後のリロードで If-None-Match を含まない非条件 GET が走る', async ({ page }) => {
+    const mock = await bootstrapMockEditorPage(page)
+    const projectId = mock.projectId
+
+    const capturedRequestHeaders: Array<Record<string, string>> = []
+
+    await page.route(`**/api/projects/${projectId}/assets`, async (route) => {
+      const req = route.request()
+      capturedRequestHeaders.push({ ...req.headers() })
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { etag: 'W/"ttl-expiry-etag"' },
+        body: JSON.stringify([]),
+      })
+    })
+
+    // 1回目のロード — キャッシュを作る
+    await openSeededEditor(page, projectId, mock.sequenceId)
+    await page.waitForTimeout(800)
+
+    // localStorage にキャッシュが存在することを確認
+    const entryRaw = await page.evaluate(
+      ({ key }) => localStorage.getItem(key),
+      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
+    )
+    expect(entryRaw).not.toBeNull()
+
+    // expiresAt を過去時刻に書き換えてキャッシュを期限切れにする
+    // 十分に遠い過去 (1 時間前) にすることで時計のずれを排除する
+    await page.evaluate(
+      ({ key }) => {
+        const raw = localStorage.getItem(key)
+        if (!raw) return
+        const entry = JSON.parse(raw) as Record<string, unknown>
+        entry['expiresAt'] = Date.now() - 60 * 60 * 1000 // 1 時間前に切れた
+        localStorage.setItem(key, JSON.stringify(entry))
+      },
+      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
+    )
+
+    // 期限切れになっていることを確認
+    const expiredEntry = await page.evaluate(
+      ({ key }) => {
+        const raw = localStorage.getItem(key)
+        if (!raw) return null
+        return JSON.parse(raw) as Record<string, unknown>
+      },
+      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
+    )
+    expect(expiredEntry?.['expiresAt']).toBeLessThan(Date.now())
+
+    // リクエストヘッダー記録をリセット
+    capturedRequestHeaders.length = 0
+
+    // ページリロード
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(800)
+
+    // デバッグ: リロード後の localStorage の状態を確認
+    const afterReloadEntry = await page.evaluate(
+      ({ key }) => localStorage.getItem(key),
+      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
+    )
+    // リロード後 readCache が期限切れを検出して削除するため null になるはず
+    // (新しい 200 応答でキャッシュが再作成される前の一瞬は null)
+    // ただし再作成後は非 null になる — ここでは最終状態を確認
+    // 重要: リロード後最初のリクエストに If-None-Match がないことを確認
+    const allCaptured = capturedRequestHeaders.length
+    expect(allCaptured).toBeGreaterThan(0) // リロード後にリクエストが発生していること
+    // 最初のリクエスト（インデックス 0）に If-None-Match が含まれていないこと
+    expect(capturedRequestHeaders[0]?.['if-none-match']).toBeUndefined()
+    // 後続リクエスト（2回目以降）は新しいキャッシュがあれば If-None-Match 付きになる可能性があるため除外
+    // afterReloadEntry はデバッグ情報として記録（アサートしない）
+    void afterReloadEntry
+  })
+
+  // ---------------------------------------------------------------------------
+  // テスト 5: fetch 失敗時に stale バナーが表示され、再試行で消える (C-1)
   // ---------------------------------------------------------------------------
   test('fetch 失敗時に stale バナーが表示され、再試行で消える', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)

--- a/frontend/src/lib/cache/etagCache.test.ts
+++ b/frontend/src/lib/cache/etagCache.test.ts
@@ -151,6 +151,27 @@ describe('fetchWithETag: 304 Not Modified', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 4-b. fetchWithETag: 304 + cached が null のとき throw する (#235 防御コード)
+// ---------------------------------------------------------------------------
+describe('fetchWithETag: 304 + cached null は throw する', () => {
+  it('キャッシュなしで 304 が返ったとき Error を throw する', async () => {
+    // キャッシュを書かずに 304 が返るシナリオ（サーバープロトコル違反）
+    const fetcher = vi.fn(async () => ({
+      data: [] as unknown[],
+      etag: null,
+      status: 304,
+    }))
+
+    await expect(
+      fetchWithETag({
+        cacheKey: 'cache:v1:test:304-no-cache',
+        fetcher,
+      })
+    ).rejects.toThrow('[fetchWithETag] Received 304 without a cached entry.')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // 5. fetchWithETag: 200 レスポンスでキャッシュが etag 付きで更新される
 // ---------------------------------------------------------------------------
 describe('fetchWithETag: 200 OK', () => {

--- a/frontend/src/lib/cache/etagCache.ts
+++ b/frontend/src/lib/cache/etagCache.ts
@@ -16,6 +16,11 @@ export type CacheEntry<T> = {
   schemaVersion: number
   etag: string
   payload: T
+  /**
+   * キャッシュに **書き込まれた** 時刻 (ms epoch)。
+   * = 最後に 200 を受信した時刻。304 応答時には更新されない (#233/#235)。
+   * したがって「最後にサーバーと通信した時刻」ではない点に注意。
+   */
   fetchedAt: number
   /** エントリの有効期限 (ms epoch)。省略時は無期限。 */
   expiresAt?: number
@@ -212,6 +217,21 @@ export interface FetchWithETagOptions<T> {
  *    ただし TTL 切れの場合は If-None-Match を送らず非条件 GET でフレッシュなデータを取得
  * 3. 304 → キャッシュの payload を返す（expiresAt は維持し、TTL を延長しない）
  * 4. 200 → 新しい etag でキャッシュを更新して payload を返す
+ *
+ * ## TTL non-sliding design (#233, #235)
+ *
+ * 304 応答時に expiresAt を延長しない (TTL 非スライド) のは、assets キャッシュが
+ * GCS 署名付き URL (60 分 TTL) を含むため。URL が失効しても 304 が返り続けると、
+ * キャッシュ内の URL がいつまでも更新されない問題を防ぐ。
+ *
+ * sequences キャッシュ (24h TTL, 署名付き URL なし) は本来 TTL スライド可能だが、
+ * 以下の理由で同じ非スライド設計を共用している:
+ * - 24h を超える連続作業セッションは稀で、24h 経過時に full GET が走る実害は最小
+ * - リソース種別ごとに挙動を分けると `fetchWithETag` の API が複雑化する
+ * - assets / sequences で挙動が揃っているほうがデバッグが容易
+ *
+ * もし将来 sequences の cache hit 率向上が必要になったら、`extendOn304: boolean`
+ * オプションを追加する方針を検討する。
  */
 export async function fetchWithETag<T>(opts: FetchWithETagOptions<T>): Promise<T> {
   const { cacheKey, fetcher, onCacheHit, ttlMs } = opts
@@ -241,7 +261,17 @@ export async function fetchWithETag<T>(opts: FetchWithETagOptions<T>): Promise<T
     // GCS 署名付き URL (storage_url / thumbnail_url) が 60 分で失効する前に
     // 強制再取得する仕組みが効かなくなり、期限切れ URL が残り続けてしまう。
     // (#233)
-    return cached?.payload ?? result.data
+    //
+    // 304 が返るのは If-None-Match を送った場合のみ → cached は必ず非 null。
+    // サーバが仕様外の 304 を返した場合の防御として明示的にエラーにする。(#235)
+    if (!cached) {
+      throw new Error(
+        '[fetchWithETag] Received 304 without a cached entry. ' +
+        'This is a server protocol violation — 304 should only be returned ' +
+        'when If-None-Match was sent.'
+      )
+    }
+    return cached.payload
   }
 
   // 4. 200: キャッシュを更新


### PR DESCRIPTION
## Summary
PR #234 の 2 エージェントレビューで指摘された軽微改善点 4 点に対応。

1. **304 防御コード**: `cached === null` で 304 が返った場合（サーバプロトコル違反）に明示的に `throw` する
2. **`CacheEntry.fetchedAt` の型コメント**: 304 で更新されない意味変化を JSDoc に明記
3. **TTL 非スライド設計の記録 (C案)**: `fetchWithETag` JSDoc に sequences への適用理由・将来の `extendOn304` オプション方針を記載
4. **TTL 期限切れ E2E**: 期限切れ後に非条件 GET (If-None-Match なし) が走ることを Playwright で確認

## Design choice (item 3)

sequences (24h TTL, 署名 URL なし) でも assets と同じ TTL 非スライドを共用。理由は JSDoc に記録:
- 24h 超え連続セッションは稀
- リソース種別ごとに挙動を分けると API 複雑化
- assets/sequences の挙動を揃えるとデバッグ容易

将来 cache hit 率向上が必要になったら `extendOn304: boolean` を検討。

## Verification
- ✅ `npm run lint`
- ✅ `npx tsc -p tsconfig.json --noEmit`
- ✅ `npx vitest run src/lib/cache/etagCache.test.ts` (26 tests, 既存 25 + 新規 1)
- ✅ `npm run build`
- ✅ `npx playwright test e2e/cache-localstorage.spec.ts` (5 tests)

## Test plan
- [x] 防御 throw の vitest 追加
- [x] TTL 期限切れ後 E2E（最初のリクエストに If-None-Match が含まれないことを assert）
- [x] 既存 vitest / Playwright スイート pass

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>