### PR TITLE
fix(#239): bump cache SCHEMA_VERSION to 2 to evict PR #210-era poisoned entries

### DIFF
--- a/frontend/src/lib/cache/etagCache.test.ts
+++ b/frontend/src/lib/cache/etagCache.test.ts
@@ -82,6 +82,27 @@ describe('スキーマバージョン検証', () => {
     expect(readCache('cache:v1:broken')).toBeNull()
   })
 
+  // #239: PR #210 era (v1) で書かれた壊れた expiresAt を持つエントリを
+  // SCHEMA_VERSION バンプで一括破棄できることを確認する。
+  // v1 entry が現在の readCache で評価された時:
+  //  - 旧コードは 304 ループで expiresAt を将来時刻に延長していたので
+  //    そのままだと「TTL 内」と判定されてしまい、期限切れ署名 URL を返し続ける
+  //  - v2 では schemaVersion 不一致で即破棄されるので回復する
+  it('PR #210 era の v1 エントリは expiresAt が将来時刻でも破棄される (#239)', () => {
+    const poisonedV1Entry = {
+      schemaVersion: 1, // 旧バージョン
+      etag: 'W/"old-etag"',
+      payload: ['poisoned'],
+      fetchedAt: Date.now() - 30 * 60 * 1000,
+      // 旧バグで延長されたまま将来時刻に残っている expiresAt
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    }
+    store['cache:v1:assets:proj-x'] = JSON.stringify(poisonedV1Entry)
+
+    expect(readCache('cache:v1:assets:proj-x')).toBeNull()
+    expect(store['cache:v1:assets:proj-x']).toBeUndefined()
+  })
+
   it('不正な JSON は null を返す', () => {
     store['cache:v1:malformed'] = 'NOT_JSON{'
     expect(readCache('cache:v1:malformed')).toBeNull()

--- a/frontend/src/lib/cache/etagCache.ts
+++ b/frontend/src/lib/cache/etagCache.ts
@@ -7,7 +7,17 @@
  *     `cache:v1:sequence:<projectId>:<sequenceId>`
  */
 
-export const SCHEMA_VERSION = 1
+/**
+ * Cache schema version. Bumped to invalidate all existing entries whose semantics
+ * are no longer compatible with the current reader.
+ *
+ * - v1: initial release (PR #210). 304 応答時に expiresAt をスライド延長していたため
+ *   署名付き URL (60min TTL) が失効しても再フェッチされない欠陥があった。
+ * - v2: PR #234/#237 で TTL スライドを廃止したため、v1 entry が残っていると
+ *   (1) 旧 ttl の expiresAt をそのまま使い続け、(2) 旧 signed URL を 304 ループで
+ *   持ち続けてしまう。v2 にバンプして v1 entry を即時破棄する。(#239)
+ */
+export const SCHEMA_VERSION = 2
 
 /** キャッシュキーの接頭辞 (clearAllCache で削除対象を識別するために使用) */
 const CACHE_KEY_PREFIX = 'cache:'


### PR DESCRIPTION
## Summary
PR #234/#237 だけでは既存ユーザーの壊れた localStorage キャッシュは TTL が切れるまで残り続けるため、`SCHEMA_VERSION` を `1 → 2` にバンプして v1 entry を即時破棄する。

## Problem
PR #210 の旧実装は 304 応答時に `expiresAt` を「現在時刻 + 50min」にスライド延長していた。これによりユーザーの localStorage には `expiresAt` が将来時刻に固定された v1 cache entry が残っている。PR #234/#237 で TTL スライドを廃止したが、新コードは既存の v1 entry を読んで「まだ TTL 内」と判定し、`If-None-Match` を送って 304 を受け、期限切れ署名 URL を返し続ける（自然回復まで最悪 50 分）。

実報告: PR #234/#237 デプロイ後も Assets パネルのサムネイル（画像・動画）が壊れたままの利用者あり。調査結果は [issue #239](https://github.com/Naofumi-1000ri/douga/issues/239) を参照。

## Fix
`SCHEMA_VERSION = 2` にバンプ。既存の `readCache` 実装が `schemaVersion !== SCHEMA_VERSION` のエントリを破棄して `localStorage.removeItem` する仕様のため、デプロイ瞬間に v1 entry が一括廃棄され、次の GET で非条件 GET → 新しい署名 URL を取得 → 自動回復する。

## Verification
- ✅ `npm run lint`
- ✅ `npx tsc -p tsconfig.json --noEmit`
- ✅ `npx vitest run src/lib/cache/etagCache.test.ts` (27 tests, 既存 26 + 新規 1)
- ✅ `npm run build`
- ✅ `npx playwright test e2e/cache-localstorage.spec.ts` (5 tests)

## Test plan
- [x] regression test: v1 entry は expiresAt が将来時刻でも readCache で破棄される (#239)
- [x] 既存スイート全 pass
- [ ] デプロイ後に壊れていたアカウントでサムネイル復活を確認

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>