### PR TITLE
feat(#242): self-heal stale signed URLs via validatePayload + img onError

### DIFF
--- a/frontend/src/api/assets.ts
+++ b/frontend/src/api/assets.ts
@@ -1,6 +1,7 @@
 import apiClient from './client'
 import heic2anyScriptUrl from 'heic2any/dist/heic2any.min.js?url'
 import { fetchWithETag, clearCache, ASSETS_CACHE_TTL_MS } from '@/lib/cache/etagCache'
+import { isSignedUrlValid } from '@/lib/cache/signedUrl'
 
 /** アセット一覧キャッシュキー */
 export function assetsCacheKey(projectId: string): string {
@@ -347,6 +348,15 @@ export const assetsApi = {
       // GCS 署名付き URL の TTL は 60 分。キャッシュは 50 分で失効させ
       // 期限切れ URL がフロントに残らないようにする。
       ttlMs: ASSETS_CACHE_TTL_MS,
+      // 防御: 期限切れ署名 URL が cached payload に含まれていれば破棄して再 fetch (#242)
+      validatePayload: (cached) => {
+        const now = Date.now()
+        return cached.every((a) => {
+          if (a.storage_url && !isSignedUrlValid(a.storage_url, now)) return false
+          if (a.thumbnail_url && !isSignedUrlValid(a.thumbnail_url, now)) return false
+          return true
+        })
+      },
     })
   },
 

--- a/frontend/src/components/assets/AssetLibrary.tsx
+++ b/frontend/src/components/assets/AssetLibrary.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef, useLayoutEffect, useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { assetsApi, foldersApi, type Asset, type AssetFolder, type SessionData } from '@/api/assets'
+import { assetsApi, foldersApi, assetsCacheKey, type Asset, type AssetFolder, type SessionData } from '@/api/assets'
+import { clearCache } from '@/lib/cache/etagCache'
 import { RequestPriority, withPriority } from '@/utils/requestPriority'
 import AudioWaveformThumbnail from './AudioWaveformThumbnail'
 
@@ -359,6 +360,17 @@ export default function AssetLibrary({
     setTooltipAnchor(null)
     setTooltip((prev) => ({ ...prev, visible: false }))
   }, [])
+
+  // 署名 URL 期限切れによる画像ロード失敗時に cache を破棄して再 fetch する (#242)
+  const handleAssetThumbnailError = useCallback((e: React.SyntheticEvent<HTMLImageElement>, assetId: string) => {
+    const img = e.currentTarget
+    // 1 アセットあたり 1 回までリトライ (無限ループ防止)
+    if (img.dataset.retried === '1') return
+    img.dataset.retried = '1'
+    console.warn('[AssetLibrary] thumbnail load failed, invalidating cache', { assetId })
+    clearCache(assetsCacheKey(projectId))
+    window.dispatchEvent(new CustomEvent('douga-assets-changed'))
+  }, [projectId])
 
   // Refresh assets when refreshTrigger changes
   useEffect(() => {
@@ -1077,6 +1089,7 @@ export default function AssetLibrary({
               alt={asset.name}
               className="w-full h-full object-cover"
               loading="lazy"
+              onError={(e) => handleAssetThumbnailError(e, asset.id)}
             />
           ) : asset.type === 'audio' ? (
             <AudioWaveformThumbnail
@@ -1093,6 +1106,7 @@ export default function AssetLibrary({
               src={asset.thumbnail_url}
               alt={asset.name}
               className="w-full h-full object-cover"
+              onError={(e) => handleAssetThumbnailError(e, asset.id)}
             />
           ) : asset.type === 'video' ? (
             // Video without thumbnail_url (old assets) - lazy load on visibility

--- a/frontend/src/lib/cache/etagCache.test.ts
+++ b/frontend/src/lib/cache/etagCache.test.ts
@@ -510,6 +510,79 @@ describe('fetchWithETag - 304 TTL non-extension (regression #233)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// validatePayload: cache 検証オプション (#242)
+// ---------------------------------------------------------------------------
+describe('fetchWithETag: validatePayload オプション', () => {
+  it('validatePayload が false を返すと cache が破棄され MISS 扱いになる', async () => {
+    const stalePayload = [{ id: 'stale' }]
+    const freshPayload = [{ id: 'fresh' }]
+    writeCache('cache:v1:test:validate-miss', 'W/"stale-etag"', stalePayload)
+
+    const fetcher = vi.fn(async (headers: Record<string, string>) => {
+      // cache が破棄されているため If-None-Match は送られない
+      expect(headers['If-None-Match']).toBeUndefined()
+      return { data: freshPayload, etag: 'W/"fresh-etag"', status: 200 }
+    })
+
+    const result = await fetchWithETag({
+      cacheKey: 'cache:v1:test:validate-miss',
+      fetcher,
+      validatePayload: () => false,
+    })
+
+    expect(result).toEqual(freshPayload)
+    expect(fetcher).toHaveBeenCalledOnce()
+    // 新しいデータで cache が更新されている
+    expect(readCache('cache:v1:test:validate-miss')?.etag).toBe('W/"fresh-etag"')
+  })
+
+  it('validatePayload が true を返すと cache が通常通り使われる', async () => {
+    const cachedPayload = [{ id: 'valid' }]
+    writeCache('cache:v1:test:validate-hit', 'W/"valid-etag"', cachedPayload)
+
+    const onCacheHit = vi.fn()
+    const fetcher = vi.fn(async (headers: Record<string, string>) => {
+      // cache が有効なので If-None-Match が送られる
+      expect(headers['If-None-Match']).toBe('W/"valid-etag"')
+      return { data: cachedPayload, etag: 'W/"valid-etag"', status: 304 }
+    })
+
+    const result = await fetchWithETag({
+      cacheKey: 'cache:v1:test:validate-hit',
+      fetcher,
+      onCacheHit,
+      validatePayload: () => true,
+    })
+
+    expect(result).toEqual(cachedPayload)
+    expect(onCacheHit).toHaveBeenCalledWith(cachedPayload)
+    expect(fetcher).toHaveBeenCalledOnce()
+  })
+
+  it('validatePayload 未指定なら従来挙動 (cache が有効なら onCacheHit が呼ばれる)', async () => {
+    const cachedPayload = [{ id: 'legacy' }]
+    writeCache('cache:v1:test:validate-unset', 'W/"legacy-etag"', cachedPayload)
+
+    const onCacheHit = vi.fn()
+    const fetcher = vi.fn(async () => ({
+      data: cachedPayload,
+      etag: 'W/"legacy-etag"',
+      status: 304,
+    }))
+
+    await fetchWithETag({
+      cacheKey: 'cache:v1:test:validate-unset',
+      fetcher,
+      onCacheHit,
+      // validatePayload 未指定
+    })
+
+    expect(onCacheHit).toHaveBeenCalledWith(cachedPayload)
+    expect(fetcher).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // sequences.ts: mutation 後に clearCache が呼ばれることを確認 (P0-2)
 // ---------------------------------------------------------------------------
 // Note: sequences.ts は apiClient に依存するため、spy テストは sequences.ts を直接

--- a/frontend/src/lib/cache/etagCache.ts
+++ b/frontend/src/lib/cache/etagCache.ts
@@ -217,6 +217,11 @@ export interface FetchWithETagOptions<T> {
    * GCS 署名付き URL を含むレスポンスには ASSETS_CACHE_TTL_MS を設定すること。
    */
   ttlMs?: number
+  /**
+   * cache から読み込んだ payload を検証する。false を返すと cache を破棄して MISS 扱いになる。
+   * 期限切れ署名 URL を含む cache を破棄するために使う。
+   */
+  validatePayload?: (cachedPayload: T) => boolean
 }
 
 /**
@@ -247,7 +252,13 @@ export async function fetchWithETag<T>(opts: FetchWithETagOptions<T>): Promise<T
   const { cacheKey, fetcher, onCacheHit, ttlMs } = opts
 
   // 1. キャッシュを読む (TTL 切れは readCache 内で null になる)
-  const cached = readCache<T>(cacheKey)
+  let cached = readCache<T>(cacheKey)
+
+  // validatePayload で invalid と判定された場合は cache を破棄して MISS 扱いにする
+  if (cached && opts.validatePayload && !opts.validatePayload(cached.payload)) {
+    clearCache(cacheKey)
+    cached = null
+  }
 
   // 楽観表示: キャッシュがあれば即座にコールバック
   if (cached && onCacheHit) {

--- a/frontend/src/lib/cache/signedUrl.test.ts
+++ b/frontend/src/lib/cache/signedUrl.test.ts
@@ -1,0 +1,76 @@
+/**
+ * isSignedUrlValid ユニットテスト (Vitest)
+ */
+import { describe, it, expect } from 'vitest'
+import { isSignedUrlValid } from './signedUrl'
+
+// テスト用ヘルパー: GCS v4 署名 URL を組み立てる
+function makeUrl(date: string, expires: number): string {
+  return `https://storage.googleapis.com/bucket/file.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Date=${date}&X-Goog-Expires=${expires}&X-Goog-Credential=sa%40proj.iam.gserviceaccount.com&X-Goog-Signature=abc`
+}
+
+// 2026-05-12T02:37:10Z = 1747016230000 ms epoch
+const SIGNED_AT_MS = Date.UTC(2026, 4, 12, 2, 37, 10) // month is 0-indexed
+const DATE_STRING = '20260512T023710Z'
+
+describe('isSignedUrlValid', () => {
+  it('有効な署名 URL で期限内なら true を返す', () => {
+    // expires = 3600s, signedAt + 3600s = 1747019830000
+    // now = signedAt + 1800s (30分後), margin = 60s → now + margin < expiresAt → true
+    const url = makeUrl(DATE_STRING, 3600)
+    const now = SIGNED_AT_MS + 1800 * 1000 // 30分後
+    expect(isSignedUrlValid(url, now)).toBe(true)
+  })
+
+  it('期限切れの署名 URL なら false を返す', () => {
+    // expires = 3600s, now = signedAt + 3601s (期限後)
+    const url = makeUrl(DATE_STRING, 3600)
+    const now = SIGNED_AT_MS + 3601 * 1000
+    expect(isSignedUrlValid(url, now)).toBe(false)
+  })
+
+  it('X-Goog-Date/Expires がない URL (非署名 URL) は true を返す', () => {
+    const url = 'https://storage.googleapis.com/bucket/file.png'
+    expect(isSignedUrlValid(url, Date.now())).toBe(true)
+  })
+
+  it('空文字列は true を返す', () => {
+    expect(isSignedUrlValid('', Date.now())).toBe(true)
+  })
+
+  it('malformed な X-Goog-Date (パースエラー) は true を返す (誤検知防止)', () => {
+    const url = 'https://storage.googleapis.com/bucket/file.png?X-Goog-Date=INVALID&X-Goog-Expires=3600'
+    // parseInt("INV") は NaN なので true になる
+    expect(isSignedUrlValid(url, Date.now())).toBe(true)
+  })
+
+  it('margin 境界: now + margin === expiresAt → false (期限切れ扱い)', () => {
+    // expires = 3600s, expiresAt = signedAt + 3600000ms
+    const url = makeUrl(DATE_STRING, 3600)
+    const expiresAt = SIGNED_AT_MS + 3600 * 1000
+    const margin = 60_000
+    // now + margin === expiresAt → now = expiresAt - margin
+    const now = expiresAt - margin
+    // now + margin < expiresAt → false (now + margin === expiresAt は false ではない)
+    expect(isSignedUrlValid(url, now, margin)).toBe(false)
+  })
+
+  it('margin 境界: now + margin === expiresAt - 1 → true (ギリギリ有効)', () => {
+    const url = makeUrl(DATE_STRING, 3600)
+    const expiresAt = SIGNED_AT_MS + 3600 * 1000
+    const margin = 60_000
+    // now + margin = expiresAt - 1 → now = expiresAt - margin - 1
+    const now = expiresAt - margin - 1
+    expect(isSignedUrlValid(url, now, margin)).toBe(true)
+  })
+
+  it('X-Goog-Date はあるが X-Goog-Expires がない URL は true を返す', () => {
+    const url = `https://storage.googleapis.com/bucket/file.png?X-Goog-Date=${DATE_STRING}`
+    expect(isSignedUrlValid(url, Date.now())).toBe(true)
+  })
+
+  it('X-Goog-Expires はあるが X-Goog-Date がない URL は true を返す', () => {
+    const url = 'https://storage.googleapis.com/bucket/file.png?X-Goog-Expires=3600'
+    expect(isSignedUrlValid(url, Date.now())).toBe(true)
+  })
+})

--- a/frontend/src/lib/cache/signedUrl.ts
+++ b/frontend/src/lib/cache/signedUrl.ts
@@ -1,0 +1,37 @@
+/**
+ * GCS v4 署名 URL の有効性を判定するユーティリティ。
+ *
+ * URL 例: https://storage.googleapis.com/.../foo.png?X-Goog-Date=20260512T023710Z&X-Goog-Expires=3600&...
+ *
+ * - 署名 URL でなければ (date/expires が無ければ) true を返す (検査対象外)
+ * - 期限切れに近い (now + marginMs >= signedAt + expiresSec*1000) なら false
+ * - パースエラー時は true を返す (検査対象外、誤検知防止)
+ *
+ * @param url 検査対象 URL
+ * @param nowMs 現在時刻 (ms epoch)
+ * @param marginMs 期限切れ判定の安全マージン (default 60_000 = 60秒)
+ */
+export function isSignedUrlValid(url: string, nowMs: number, marginMs: number = 60_000): boolean {
+  if (!url) return true
+  const dateMatch = url.match(/X-Goog-Date=(\d{8}T\d{6}Z)/)
+  const expiresMatch = url.match(/X-Goog-Expires=(\d+)/)
+  if (!dateMatch || !expiresMatch) return true
+  // 20260512T023710Z → 2026, 05, 12, 02, 37, 10
+  const s = dateMatch[1]
+  try {
+    const Y = parseInt(s.slice(0, 4), 10)
+    const M = parseInt(s.slice(4, 6), 10) - 1
+    const D = parseInt(s.slice(6, 8), 10)
+    const h = parseInt(s.slice(9, 11), 10)
+    const m = parseInt(s.slice(11, 13), 10)
+    const sec = parseInt(s.slice(13, 15), 10)
+    const signedAtMs = Date.UTC(Y, M, D, h, m, sec)
+    if (Number.isNaN(signedAtMs)) return true
+    const expiresSec = parseInt(expiresMatch[1], 10)
+    if (Number.isNaN(expiresSec)) return true
+    const expiresAtMs = signedAtMs + expiresSec * 1000
+    return nowMs + marginMs < expiresAtMs
+  } catch {
+    return true
+  }
+}


### PR DESCRIPTION
## Summary
- 期限切れ GCS 署名 URL がフロントに残った場合の **自動回復** を 2 層で実装
- A. `fetchWithETag.validatePayload`: readCache の payload を呼出側で検証、false なら cache 破棄→再 fetch
- B. AssetLibrary `<img onError>`: 画像ロード失敗時に cache クリア+再フェッチ (1 回限りリトライ)
- 本 PR デプロイで debug deploy(`debug/cache-logs`)もロールバックされる

## Why
PR #233/#235/#239 で localStorage cache の TTL を修正したが、稀に 4 日前の署名 URL が cache 内に残り 403 ExpiredToken でサムネが壊れる事象を実環境で確認 (詳細 #242 / 関連 #239 トリアージ)。ルートコーズは不明 (HTTP disk cache または Google Frontend の一時的な配信異常が有力) で再現性なし。

ルートコーズ究明は別タスクで継続するが、**ユーザー体験を守るため症状ベースの防御層を先に入れる**。

## Verification
- ✅ `npm run lint`
- ✅ `npx tsc -p tsconfig.json --noEmit`
- ✅ `npx vitest run signedUrl.test.ts etagCache.test.ts` (39 tests)
- ✅ `npm run build`
- ✅ `npx playwright test e2e/cache-localstorage.spec.ts` (5 tests)

## Test plan
- [x] `isSignedUrlValid` の全分岐 (valid/expired/non-signed/malformed/margin 境界) vitest
- [x] `validatePayload` の 3 シナリオ (false→MISS, true→HIT, 未指定→従来挙動) vitest
- [x] 既存 vitest / Playwright スイート全 pass
- [ ] デプロイ後、本番で `[img onError]` が発生しないこと、TTL 内でも期限切れ URL があれば再 fetch されることを確認

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>