### PR TITLE
feat(#244): extend assets cache TTL 50min→3d, signed URL TTL 60min→4d

### DIFF
--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -202,7 +202,7 @@ async def list_assets(
         lambda: [_asset_to_response_with_signed_url(a, storage) for a in assets]
     )
     # Exclude volatile GCS signed URL fields from the ETag hash.
-    # storage_url and thumbnail_url are re-signed on every request (60 min TTL)
+    # storage_url and thumbnail_url are re-signed on every request (4 日 TTL, #244)
     # and therefore change on each call even when the underlying data is unchanged.
     # Hashing them would prevent 304 responses and could serve stale signed URLs.
     return etag_response(request, responses, exclude_keys=["storage_url", "thumbnail_url"])

--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -119,7 +119,7 @@ def _asset_to_response_with_signed_url(
         try:
             thumbnail_url = storage.generate_download_url(
                 storage_key=asset.thumbnail_storage_key,
-                expires_minutes=60,
+                expires_minutes=5760,  # 4 日 (TTL を伸ばして長期セッションでも有効)
             )
         except Exception:
             pass  # Fall back to thumbnail_url on error
@@ -151,12 +151,12 @@ def _asset_to_response_with_signed_url(
         created_at=asset.created_at,
         metadata=asset.asset_metadata,  # Map asset_metadata -> metadata
     )
-    # Replace storage_url with signed URL (60 min expiration)
+    # Replace storage_url with signed URL (4 日 = 5760 分 expiration)
     if asset.storage_key:
         try:
             response.storage_url = storage.generate_download_url(
                 storage_key=asset.storage_key,
-                expires_minutes=60,
+                expires_minutes=5760,  # 4 日 (TTL を伸ばして長期セッションでも有効)
             )
         except Exception:
             pass  # Keep original URL on error

--- a/frontend/src/api/assets.ts
+++ b/frontend/src/api/assets.ts
@@ -345,15 +345,16 @@ export const assetsApi = {
         }
       },
       onCacheHit,
-      // GCS 署名付き URL の TTL は 60 分。キャッシュは 50 分で失効させ
+      // GCS 署名付き URL の TTL は 4 日。キャッシュは 3 日で失効させ
       // 期限切れ URL がフロントに残らないようにする。
       ttlMs: ASSETS_CACHE_TTL_MS,
       // 防御: 期限切れ署名 URL が cached payload に含まれていれば破棄して再 fetch (#242)
       validatePayload: (cached) => {
         const now = Date.now()
+        const marginMs = 60 * 60 * 1000  // 1 hour: clock skew + 安全マージン
         return cached.every((a) => {
-          if (a.storage_url && !isSignedUrlValid(a.storage_url, now)) return false
-          if (a.thumbnail_url && !isSignedUrlValid(a.thumbnail_url, now)) return false
+          if (a.storage_url && !isSignedUrlValid(a.storage_url, now, marginMs)) return false
+          if (a.thumbnail_url && !isSignedUrlValid(a.thumbnail_url, now, marginMs)) return false
           return true
         })
       },

--- a/frontend/src/lib/cache/etagCache.test.ts
+++ b/frontend/src/lib/cache/etagCache.test.ts
@@ -283,8 +283,8 @@ describe('TTL: writeCache / readCache with ttlMs', () => {
     expect(store['cache:v1:ttl-expired']).toBeUndefined()
   })
 
-  it('ASSETS_CACHE_TTL_MS は 50 分 (3000000 ms) である', () => {
-    expect(ASSETS_CACHE_TTL_MS).toBe(50 * 60 * 1000)
+  it('ASSETS_CACHE_TTL_MS は 3 日 (259200000 ms) である', () => {
+    expect(ASSETS_CACHE_TTL_MS).toBe(3 * 24 * 60 * 60 * 1000)
   })
 })
 

--- a/frontend/src/lib/cache/etagCache.ts
+++ b/frontend/src/lib/cache/etagCache.ts
@@ -183,11 +183,14 @@ export function clearAllUserData(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * GCS 署名付き URL の有効期間 (60 分) より十分短い TTL (50 分)。
- * assets キャッシュに使用する。これにより、キャッシュから復元した storage_url が
- * 有効期限切れになる前に再フェッチが強制される。
+ * Assets cache TTL.
+ *
+ * Backend signs GCS download URLs with `expires_minutes=5760` (4 日)。
+ * cache TTL は 3 日に設定し、署名 URL TTL に対して 1 日のマージンを確保する。
+ * 万一 cache 内に期限近い URL が残った場合は、`validatePayload` (isSignedUrlValid)
+ * と `<img onError>` の二段で自己回復する (#242, #244)。
  */
-export const ASSETS_CACHE_TTL_MS = 50 * 60 * 1000 // 50 minutes
+export const ASSETS_CACHE_TTL_MS = 3 * 24 * 60 * 60 * 1000 // 3 days
 
 /**
  * sequences / sequence detail キャッシュの TTL。
@@ -236,7 +239,7 @@ export interface FetchWithETagOptions<T> {
  * ## TTL non-sliding design (#233, #235)
  *
  * 304 応答時に expiresAt を延長しない (TTL 非スライド) のは、assets キャッシュが
- * GCS 署名付き URL (60 分 TTL) を含むため。URL が失効しても 304 が返り続けると、
+ * GCS 署名付き URL (4 日 TTL) を含むため。URL が失効しても 304 が返り続けると、
  * キャッシュ内の URL がいつまでも更新されない問題を防ぐ。
  *
  * sequences キャッシュ (24h TTL, 署名付き URL なし) は本来 TTL スライド可能だが、
@@ -279,7 +282,7 @@ export async function fetchWithETag<T>(opts: FetchWithETagOptions<T>): Promise<T
   if (result.status === 304) {
     // 304: キャッシュが有効 — expiresAt は維持して payload を返す。
     // writeCache で TTL をリセットしてしまうと、キャッシュ内に保持している
-    // GCS 署名付き URL (storage_url / thumbnail_url) が 60 分で失効する前に
+    // GCS 署名付き URL (storage_url / thumbnail_url) が 4 日で失効する前に
     // 強制再取得する仕組みが効かなくなり、期限切れ URL が残り続けてしまう。
     // (#233)
     //


### PR DESCRIPTION
## Summary
- 長期作業セッション中の cache hit 率を上げるため TTL を大幅延長
- GCS signed URL TTL: 60 分 → **4 日** (`expires_minutes=5760`)
- localStorage cache TTL: 50 分 → **3 日** (`3*24*60*60*1000`)
- validatePayload margin: 60 秒 → **1 時間** (clock skew 安全マージン)

## Design
| 層 | TTL | 制約 |
|----|-----|-----|
| GCS signed URL | 4 日 | cache + margin より長い |
| localStorage cache | 3 日 | signed URL TTL より 1 日短い |
| validatePayload margin | 1 時間 | clock skew + 早期再 fetch |

PR #243 で導入した `validatePayload` + `<img onError>` の自己回復機構により、万一 cache 内に期限近い URL が残った場合でも安全に refresh される。

## Trade-off
- 署名 URL が漏洩した場合の有効期間が 60 分 → 4 日に延長
- 社内 Udemy 制作ツールでログイン必須のため受容範囲

## Verification
- ✅ Backend: `ruff check`, `ruff format --check`, `mypy`, `pytest test_etag_cache + test_assets_api + test_preview` (24 passed)
- ✅ Frontend: `lint`, `tsc --noEmit`, `vitest run` (70 tests), `npm run build`, `playwright cache-localstorage` (5 passed)

## Test plan
- [x] backend `_asset_to_response_with_signed_url` 関連テスト pass
- [x] frontend `ASSETS_CACHE_TTL_MS` 直接参照テスト の値更新確認
- [x] e2e (cache-localstorage) pass
- [ ] デプロイ後: 既存ユーザーの localStorage は v2 schema 維持 → 新 TTL 反映には次回 cache write を待つ

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>