### PR TITLE
fix(#246): single-flight onError refetch + URL diagnostics in AssetLibrary

### DIFF
--- a/frontend/src/components/assets/AssetLibrary.tsx
+++ b/frontend/src/components/assets/AssetLibrary.tsx
@@ -222,6 +222,9 @@ export default function AssetLibrary({
   const [dropTargetFolderId, setDropTargetFolderId] = useState<string | null | undefined>(undefined)
   const dragCounterRef = useRef(0)
 
+  // single-flight guard: 再 fetch が進行中は追加の clearCache+dispatch を抑止 (#246)
+  const refetchInFlightRef = useRef(false)
+
   // Dropdown refs
   const filterDropdownRef = useRef<HTMLDivElement>(null)
   const sortDropdownRef = useRef<HTMLDivElement>(null)
@@ -269,6 +272,7 @@ export default function AssetLibrary({
       }
     } finally {
       setLoading(false)
+      refetchInFlightRef.current = false  // single-flight フラグをリセット (#246)
     }
   }, [projectId])
 
@@ -361,13 +365,25 @@ export default function AssetLibrary({
     setTooltip((prev) => ({ ...prev, visible: false }))
   }, [])
 
-  // 署名 URL 期限切れによる画像ロード失敗時に cache を破棄して再 fetch する (#242)
+  // 署名 URL 期限切れによる画像ロード失敗時に cache を破棄して再 fetch する (#242, #246)
   const handleAssetThumbnailError = useCallback((e: React.SyntheticEvent<HTMLImageElement>, assetId: string) => {
     const img = e.currentTarget
     // 1 アセットあたり 1 回までリトライ (無限ループ防止)
     if (img.dataset.retried === '1') return
     img.dataset.retried = '1'
-    console.warn('[AssetLibrary] thumbnail load failed, invalidating cache', { assetId })
+
+    // single-flight: 既に refetch 中なら何もしない (多重 fetch 防止) #246
+    if (refetchInFlightRef.current) return
+    refetchInFlightRef.current = true
+
+    const url = img.src
+    const goog_date = url.match(/X-Goog-Date=(\d{8}T\d{6}Z)/)?.[1]
+    console.warn('[AssetLibrary] thumbnail load failed, invalidating cache', {
+      assetId,
+      X_Goog_Date: goog_date,
+      url_head: url.substring(0, 200),
+    })
+
     clearCache(assetsCacheKey(projectId))
     window.dispatchEvent(new CustomEvent('douga-assets-changed'))
   }, [projectId])


### PR DESCRIPTION
## Summary
- 複数サムネが同時失敗した時に `clearCache + dispatchEvent` が並列多重実行される問題を修正
- `useRef<boolean>` で再 fetch 進行中フラグを保持し、1 回目の onError のみが refetch を起動
- 失敗 URL の `X-Goog-Date` と head 200 文字を console.warn に追加 (なぜ validatePayload を抜けたかの診断)

## Why
PR #243 のレビュー軽微改善 #1 が本番で顕在化:
```
[AssetLibrary] thumbnail load failed, invalidating cache  ← 9 回連続
```
9 個のサムネが同時失敗 → 9 回 clearCache + dispatch → 9 並列 fetchAssets。

## Verification
- ✅ `npm run lint`
- ✅ `npx tsc -p tsconfig.json --noEmit`
- ✅ `npx vitest run` (70 tests, 9 files)
- ✅ `npm run build`
- ✅ `npx playwright test e2e/cache-localstorage.spec.ts` (5 tests)

## Test plan
- [x] vitest / e2e pass
- [ ] デプロイ後: console で `[AssetLibrary] thumbnail load failed` が 1 回しか出ないこと
- [ ] `X-Goog-Date` ログから stale URL の原因を特定

Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>