### PR TITLE
fix(#248): unify thumbnail signed URL TTL 60min→4d (PR #245 missed paths)

### DIFF
--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -1818,7 +1818,7 @@ async def get_thumbnail(
 
     # Check if thumbnail already exists in storage
     if storage.file_exists(thumb_key):
-        existing_url = storage.generate_download_url(thumb_key, expires_minutes=60)
+        existing_url = storage.generate_download_url(thumb_key, expires_minutes=5760)  # 4 日 (#248)
         return ThumbnailResponse(
             url=existing_url,
             time_ms=time_ms,
@@ -1847,7 +1847,7 @@ async def get_thumbnail(
 
         await storage.upload_file(str(thumb_path), thumb_key, "image/jpeg")
 
-    thumb_url = storage.generate_download_url(thumb_key, expires_minutes=60)
+    thumb_url = storage.generate_download_url(thumb_key, expires_minutes=5760)  # 4 日 (#248)
 
     return ThumbnailResponse(
         url=thumb_url,
@@ -1937,7 +1937,9 @@ async def get_batch_thumbnails(
     if not uncached_times:
         thumbnails: list[ThumbnailResponse] = []
         for time_ms, thumb_key in cached_results:
-            url = await asyncio.to_thread(storage.generate_download_url, thumb_key, 60)
+            url = await asyncio.to_thread(
+                storage.generate_download_url, thumb_key, 5760
+            )  # 4 日 (#248)
             thumbnails.append(
                 ThumbnailResponse(
                     url=url,
@@ -2006,7 +2008,7 @@ async def get_batch_thumbnails(
     # 5. Generate signed URLs for all thumbnails
     thumbnails: list[ThumbnailResponse] = []
     for time_ms, thumb_key in cached_results:
-        url = await asyncio.to_thread(storage.generate_download_url, thumb_key, 60)
+        url = await asyncio.to_thread(storage.generate_download_url, thumb_key, 5760)  # 4 日 (#248)
         thumbnails.append(
             ThumbnailResponse(
                 url=url,


### PR DESCRIPTION
## Summary
PR #245 で assets 本体の signed URL TTL を延長したが、**on-demand サムネ生成エンドポイント 4 箇所が漏れていた**。本番で video の `thumbnail_url` が 60 分で失効し `<img onError>` が発火する事象を確認 (PR #247 の診断ログで判明)。

```
[AssetLibrary] thumbnail load failed, ... X_Goog_Date: '20260512T042504Z'  ← 3時間前
url_head: '...storage.googleapis.com/douga-assets/thumbn...'
```

修正対象 (`backend/src/api/assets.py`):
- L1821: 既存サムネ取得時の URL
- L1850: 新規サムネ生成後の URL
- L1940: batch (cached path)
- L2009: batch (generated path)

すべて `60` → `5760` (4 日) に統一。

## Why
このサムネ URL は frontend の `Asset.thumbnail_url` に乗って Assets パネルの動画サムネに使われる。60 分で失効すると、利用者が project を開くたびに `<img>` が壊れ、`<img onError>` の自己回復ロジックが発火 (UX 不快 + 余計 API call)。

## Verification
- ✅ `ruff check src/`
- ✅ `ruff format --check src/`
- ✅ `mypy src/`
- ✅ `pytest tests/test_etag_cache.py tests/test_assets_api.py tests/test_preview.py` (24 passed, 9 skipped)

## Test plan
- [x] backend テスト pass
- [ ] デプロイ後: console で `[AssetLibrary] thumbnail load failed` が再発しないこと

Fixes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>