### PR TITLE
fix(#250): drop legacy asset.thumbnail_url fallback (stale signed URLs)

### DIFF
--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -113,18 +113,24 @@ def _asset_to_response_with_signed_url(
     storage: StorageService,
 ) -> AssetResponse:
     """Convert asset to response with signed URL instead of direct storage URL."""
-    # Generate thumbnail URL with priority: thumbnail_storage_key > thumbnail_url
+    # Generate thumbnail URL: re-sign on every request from thumbnail_storage_key.
+    # Legacy asset.thumbnail_url fallback was removed in #250 because DB may
+    # contain stale signed URLs from earlier code paths, causing 403 in the
+    # frontend. If signing fails, return None and let the frontend's
+    # LazyVideoThumbnail fetch fresh URL via the on-demand /thumbnail API.
     thumbnail_url = None
     if asset.thumbnail_storage_key:
         try:
             thumbnail_url = storage.generate_download_url(
                 storage_key=asset.thumbnail_storage_key,
-                expires_minutes=5760,  # 4 日 (TTL を伸ばして長期セッションでも有効)
+                expires_minutes=5760,  # 4 日
             )
         except Exception:
-            pass  # Fall back to thumbnail_url on error
-    if thumbnail_url is None and asset.thumbnail_url:
-        thumbnail_url = asset.thumbnail_url  # Backward compatibility
+            logger.exception(
+                "Failed to sign thumbnail URL for asset %s (storage_key=%s)",
+                asset.id,
+                asset.thumbnail_storage_key,
+            )
 
     # Manually construct response to avoid SQLAlchemy metadata attribute conflict
     response = AssetResponse(
@@ -159,7 +165,12 @@ def _asset_to_response_with_signed_url(
                 expires_minutes=5760,  # 4 日 (TTL を伸ばして長期セッションでも有効)
             )
         except Exception:
-            pass  # Keep original URL on error
+            logger.exception(
+                "Failed to sign storage URL for asset %s (storage_key=%s)",
+                asset.id,
+                asset.storage_key,
+            )
+            # Keep original asset.storage_url (likely unsigned public URL; may fail)
     return response
 
 

--- a/backend/tests/test_assets_api.py
+++ b/backend/tests/test_assets_api.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from fastapi import FastAPI
@@ -107,6 +108,57 @@ def test_asset_timing_audit_is_bounded_and_skips_expensive_sources_by_default(mo
     assert data["has_more"] is True
     assert len(data["entries"]) == 1
     assert waveform_calls == []
+
+
+def test_thumbnail_url_legacy_fallback_dropped():
+    """#250: asset.thumbnail_url legacy fallback was removed.
+
+    If thumbnail_storage_key is None, response.thumbnail_url should be None
+    even if the DB has a value in asset.thumbnail_url (which may be a stale
+    signed URL).
+    """
+    from datetime import datetime, timezone
+
+    asset = SimpleNamespace(
+        id=uuid4(),
+        project_id=uuid4(),
+        name="video.mp4",
+        type="video",
+        subtype="background",
+        storage_key="video/video.mp4",
+        storage_url="https://storage.googleapis.com/bucket/video.mp4",
+        thumbnail_storage_key=None,
+        thumbnail_url="https://storage.googleapis.com/bucket/old-stale-signed-url?X-Goog-Date=20240101",
+        duration_ms=5000,
+        width=1920,
+        height=1080,
+        file_size=1024000,
+        mime_type="video/mp4",
+        sample_rate=None,
+        channels=None,
+        has_alpha=False,
+        chroma_key_color=None,
+        hash=None,
+        is_internal=False,
+        folder_id=None,
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        asset_metadata=None,
+    )
+
+    # storage.generate_download_url succeeds for storage_key but should never
+    # be called for thumbnail (no thumbnail_storage_key).
+    mock_storage = MagicMock()
+    mock_storage.generate_download_url.return_value = "https://signed.example.com/video.mp4"
+
+    result = assets_api._asset_to_response_with_signed_url(asset, mock_storage)
+
+    # Legacy fallback must NOT apply: stale signed URL in DB should be ignored.
+    assert result.thumbnail_url is None
+    # generate_download_url called exactly once — only for storage_key, not thumbnail.
+    mock_storage.generate_download_url.assert_called_once_with(
+        storage_key="video/video.mp4",
+        expires_minutes=5760,
+    )
 
 
 def test_asset_timing_audit_requires_asset_id_for_storage_probe(monkeypatch):


### PR DESCRIPTION
## Summary
本番で thumbnail URL が 3 時間以上前の X-Goog-Date で 403 になる事象を確認。原因は \`_asset_to_response_with_signed_url\` が \`generate_download_url\` 失敗時にサイレントに DB の **legacy \`asset.thumbnail_url\` フィールド** にフォールバックしていたこと。このフィールドには過去の古い署名 URL が残っている。

実害ログ (PR #247 の診断ログより):
\`\`\`
[AssetLibrary] thumbnail load failed {
  X_Goog_Date: '20260512T042504Z',  ← 3時間前 (PR #245 デプロイ前)
  url_head: 'https://storage.googleapis.com/douga-assets/thumbn...'
}
\`\`\`

## 修正
- **legacy thumbnail_url fallback を撤去**: \`thumbnail_storage_key=None\` or signing 失敗時は \`response.thumbnail_url=None\` を返す
- **silent pass を廃止**: \`logger.exception\` で記録 (storage_url 側も同様)
- \`thumbnail_url=None\` の場合 frontend は \`LazyVideoThumbnail\` で fresh URL をオンデマンド取得するため UX 影響なし
- regression test 追加

## Verification
- ✅ \`ruff check src/\` / \`ruff format --check src/\` / \`mypy src/\`
- ✅ \`pytest test_etag_cache.py test_assets_api.py test_preview.py\` (25 passed, 9 skipped)

## Test plan
- [x] new test: thumbnail_storage_key=None + legacy thumbnail_url → response.thumbnail_url=None
- [x] 既存テスト全パス
- [ ] デプロイ後: console で \`[AssetLibrary] thumbnail load failed\` が再発しないこと
- [ ] \`Failed to sign thumbnail URL\` ログが Cloud Run に出ないこと (出たら新規調査)

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>