### PR TITLE
fix(#252): add thumbnail failure diagnostics

### DIFF
--- a/backend/src/api/assets.py
+++ b/backend/src/api/assets.py
@@ -4,10 +4,13 @@ import json
 import logging
 import re
 import tempfile
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
 from uuid import UUID
 
+import httpx
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy import or_, select, update
@@ -178,6 +181,182 @@ def _asset_to_response_with_signed_url(
 def _asset_storage_url_for_persistence(storage_key: str) -> str:
     """Persist the logical storage reference, not a signed or public URL."""
     return storage_key
+
+
+def _media_url_storage_key(url: str) -> str | None:
+    """Extract the object storage key from a known media URL shape."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+
+    path = unquote(parsed.path)
+
+    if parsed.netloc == "storage.googleapis.com":
+        parts = path.lstrip("/").split("/", 1)
+        if len(parts) == 2 and parts[1]:
+            return parts[1]
+        return None
+
+    local_marker = "/api/storage/files/"
+    if local_marker in path:
+        storage_key = path.split(local_marker, 1)[1].lstrip("/")
+        return storage_key or None
+
+    return None
+
+
+def _signed_url_details(url: str, now: datetime | None = None) -> dict[str, Any]:
+    """Return signed URL timing details without validating the signature itself."""
+    now = now or datetime.now(UTC)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return {
+            "host": None,
+            "path": None,
+            "storage_key": None,
+            "query_keys": [],
+            "signed_at": None,
+            "expires_in_seconds": None,
+            "expires_at": None,
+            "is_expired": None,
+            "parse_error": "invalid_url",
+        }
+
+    query = parse_qs(parsed.query)
+    signed_at_raw = query.get("X-Goog-Date", [None])[0]
+    expires_raw = query.get("X-Goog-Expires", [None])[0]
+    signed_at: datetime | None = None
+    expires_in_seconds: int | None = None
+    expires_at: datetime | None = None
+    is_expired: bool | None = None
+    parse_error: str | None = None
+
+    if signed_at_raw and expires_raw:
+        try:
+            signed_at = datetime.strptime(signed_at_raw, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+            expires_in_seconds = int(expires_raw)
+            expires_at = signed_at + timedelta(seconds=expires_in_seconds)
+            is_expired = now >= expires_at
+        except (TypeError, ValueError):
+            parse_error = "invalid_signed_url_timestamp"
+
+    return {
+        "host": parsed.netloc or None,
+        "path": parsed.path or None,
+        "storage_key": _media_url_storage_key(url),
+        "query_keys": sorted(query.keys()),
+        "signed_at": signed_at.isoformat() if signed_at else None,
+        "expires_in_seconds": expires_in_seconds,
+        "expires_at": expires_at.isoformat() if expires_at else None,
+        "is_expired": is_expired,
+        "parse_error": parse_error,
+    }
+
+
+def _safe_file_exists(storage: StorageService, storage_key: str | None) -> bool | None:
+    if not storage_key:
+        return None
+    try:
+        return storage.file_exists(storage_key)
+    except Exception:
+        logger.exception("Failed to check storage object existence (storage_key=%s)", storage_key)
+        return None
+
+
+def _diagnose_thumbnail_failure(
+    asset: Asset,
+    storage: StorageService,
+    *,
+    url: str,
+    source: str,
+    url_http_status: int | None,
+    url_http_error: str | None,
+) -> dict[str, Any]:
+    url_details = _signed_url_details(url)
+    url_storage_key = url_details["storage_key"]
+    asset_storage_key_exists = _safe_file_exists(storage, asset.storage_key)
+    thumbnail_storage_key_exists = _safe_file_exists(storage, asset.thumbnail_storage_key)
+
+    matches_asset_storage_key = url_storage_key == asset.storage_key
+    matches_thumbnail_storage_key = (
+        asset.thumbnail_storage_key is not None and url_storage_key == asset.thumbnail_storage_key
+    )
+    if matches_asset_storage_key:
+        url_storage_key_exists = asset_storage_key_exists
+    elif matches_thumbnail_storage_key:
+        url_storage_key_exists = thumbnail_storage_key_exists
+    else:
+        url_storage_key_exists = None
+
+    if url_details["is_expired"] is True:
+        diagnosis = "signed_url_expired"
+    elif source.endswith("thumbnail_url") and not matches_thumbnail_storage_key:
+        diagnosis = "thumbnail_url_points_to_unexpected_object"
+    elif url_http_status == 404 or url_storage_key_exists is False:
+        diagnosis = "url_object_missing"
+    elif asset.thumbnail_storage_key and thumbnail_storage_key_exists is False:
+        diagnosis = "db_thumbnail_storage_key_missing_object"
+    elif url_http_status in {401, 403}:
+        diagnosis = "signed_url_rejected"
+    elif url_http_status is None and url_http_error:
+        diagnosis = "url_probe_failed"
+    elif url_http_status in {200, 206}:
+        diagnosis = "image_decode_or_browser_load_failed"
+    else:
+        diagnosis = "unknown_thumbnail_load_failure"
+
+    return {
+        "diagnosis": diagnosis,
+        "asset_id": str(asset.id),
+        "project_id": str(asset.project_id),
+        "source": source,
+        "asset": {
+            "name": asset.name,
+            "type": asset.type,
+            "mime_type": asset.mime_type,
+            "storage_key": asset.storage_key,
+            "thumbnail_storage_key": asset.thumbnail_storage_key,
+            "has_legacy_thumbnail_url": bool(asset.thumbnail_url),
+        },
+        "url": {
+            **url_details,
+            "url_head": url[:180],
+            "matches_asset_storage_key": matches_asset_storage_key,
+            "matches_thumbnail_storage_key": matches_thumbnail_storage_key,
+        },
+        "storage": {
+            "asset_storage_key_exists": asset_storage_key_exists,
+            "thumbnail_storage_key_exists": thumbnail_storage_key_exists,
+            "url_storage_key_exists": url_storage_key_exists,
+        },
+        "probe": {
+            "http_status": url_http_status,
+            "error": url_http_error,
+        },
+    }
+
+
+async def _probe_media_url_status(url: str) -> tuple[int | None, str | None]:
+    """Probe a browser-failed media URL with the same GET method as the signed URL."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None, "invalid_url"
+
+    hostname = parsed.hostname
+    if parsed.scheme != "https":
+        return None, "unsupported_scheme"
+    if hostname != "storage.googleapis.com":
+        return None, "disallowed_host"
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+            async with client.stream("GET", url, headers={"Range": "bytes=0-0"}) as response:
+                return response.status_code, None
+    except httpx.HTTPError as exc:
+        return None, f"{exc.__class__.__name__}: {exc}"
 
 
 @router.get("/projects/{project_id}/assets", response_model=list[AssetResponse])
@@ -1662,6 +1841,26 @@ class ThumbnailResponse(BaseModel):
     height: int
 
 
+class ThumbnailDiagnosticsRequest(BaseModel):
+    """Request body for diagnosing a browser thumbnail load failure."""
+
+    url: str
+    source: str
+
+
+class ThumbnailDiagnosticsResponse(BaseModel):
+    """Structured diagnosis for a browser thumbnail load failure."""
+
+    diagnosis: str
+    asset_id: str
+    project_id: str
+    source: str
+    asset: dict[str, Any]
+    url: dict[str, Any]
+    storage: dict[str, Any]
+    probe: dict[str, Any]
+
+
 class BatchThumbnailRequest(BaseModel):
     """Request model for batch thumbnail generation."""
 
@@ -1686,6 +1885,36 @@ class GridThumbnailsResponse(BaseModel):
     duration_ms: int
     width: int = 160
     height: int = 90
+
+
+@router.post(
+    "/projects/{project_id}/assets/{asset_id}/thumbnail-diagnostics",
+    response_model=ThumbnailDiagnosticsResponse,
+)
+async def diagnose_thumbnail_failure(
+    project_id: UUID,
+    asset_id: UUID,
+    body: ThumbnailDiagnosticsRequest,
+    current_user: LightweightUser = None,
+) -> ThumbnailDiagnosticsResponse:
+    """Diagnose a browser thumbnail load failure without mutating asset state."""
+    asset = await _get_asset_short_lived(project_id, asset_id, current_user.id)
+    storage = get_storage_service()
+    url_http_status, url_http_error = await _probe_media_url_status(body.url)
+    diagnostics = await asyncio.to_thread(
+        _diagnose_thumbnail_failure,
+        asset,
+        storage,
+        url=body.url,
+        source=body.source,
+        url_http_status=url_http_status,
+        url_http_error=url_http_error,
+    )
+    logger.warning(
+        "Asset thumbnail load failure diagnostics: %s",
+        json.dumps(diagnostics, ensure_ascii=False),
+    )
+    return ThumbnailDiagnosticsResponse(**diagnostics)
 
 
 @router.get(

--- a/backend/tests/test_assets_api.py
+++ b/backend/tests/test_assets_api.py
@@ -170,6 +170,117 @@ def test_thumbnail_url_legacy_fallback_dropped():
     )
 
 
+def test_thumbnail_diagnostics_identifies_missing_url_object():
+    asset = SimpleNamespace(
+        id=uuid4(),
+        project_id=uuid4(),
+        name="video.mp4",
+        type="video",
+        mime_type="video/mp4",
+        storage_key="projects/project-id/assets/video.mp4",
+        thumbnail_storage_key="thumbnails/project-id/asset-id/0_64x36.jpg",
+        thumbnail_url=None,
+    )
+    mock_storage = MagicMock()
+    mock_storage.file_exists.side_effect = (
+        lambda key: key == "projects/project-id/assets/video.mp4"
+    )
+
+    result = assets_api._diagnose_thumbnail_failure(
+        asset,
+        mock_storage,
+        url=(
+            "https://storage.googleapis.com/bucket/"
+            "thumbnails/project-id/asset-id/0_64x36.jpg"
+        ),
+        source="asset-library-thumbnail_url",
+        url_http_status=404,
+        url_http_error=None,
+    )
+
+    assert result["diagnosis"] == "url_object_missing"
+    assert result["url"]["storage_key"] == "thumbnails/project-id/asset-id/0_64x36.jpg"
+    assert result["url"]["matches_thumbnail_storage_key"] is True
+    assert result["storage"] == {
+        "asset_storage_key_exists": True,
+        "thumbnail_storage_key_exists": False,
+        "url_storage_key_exists": False,
+    }
+
+
+def test_thumbnail_diagnostics_identifies_expired_signed_url():
+    asset = SimpleNamespace(
+        id=uuid4(),
+        project_id=uuid4(),
+        name="video.mp4",
+        type="video",
+        mime_type="video/mp4",
+        storage_key="projects/project-id/assets/video.mp4",
+        thumbnail_storage_key="thumbnails/project-id/asset-id/0_64x36.jpg",
+        thumbnail_url=None,
+    )
+    mock_storage = MagicMock()
+    mock_storage.file_exists.return_value = True
+
+    result = assets_api._diagnose_thumbnail_failure(
+        asset,
+        mock_storage,
+        url=(
+            "https://storage.googleapis.com/bucket/"
+            "thumbnails/project-id/asset-id/0_64x36.jpg"
+            "?X-Goog-Date=20240101T000000Z&X-Goog-Expires=60"
+        ),
+        source="asset-library-thumbnail_url",
+        url_http_status=403,
+        url_http_error=None,
+    )
+
+    assert result["diagnosis"] == "signed_url_expired"
+    assert result["url"]["is_expired"] is True
+    assert result["url"]["expires_in_seconds"] == 60
+    assert result["probe"]["http_status"] == 403
+
+
+def test_thumbnail_diagnostics_does_not_probe_unrelated_url_storage_key():
+    asset = SimpleNamespace(
+        id=uuid4(),
+        project_id=uuid4(),
+        name="video.mp4",
+        type="video",
+        mime_type="video/mp4",
+        storage_key="projects/project-id/assets/video.mp4",
+        thumbnail_storage_key="thumbnails/project-id/asset-id/0_64x36.jpg",
+        thumbnail_url=None,
+    )
+    mock_storage = MagicMock()
+    mock_storage.file_exists.return_value = True
+
+    result = assets_api._diagnose_thumbnail_failure(
+        asset,
+        mock_storage,
+        url="https://storage.googleapis.com/bucket/projects/other-project/private.jpg",
+        source="asset-library-thumbnail_url",
+        url_http_status=None,
+        url_http_error="probe_skipped",
+    )
+
+    assert result["diagnosis"] == "thumbnail_url_points_to_unexpected_object"
+    assert result["storage"]["url_storage_key_exists"] is None
+    mock_storage.file_exists.assert_any_call("projects/project-id/assets/video.mp4")
+    mock_storage.file_exists.assert_any_call("thumbnails/project-id/asset-id/0_64x36.jpg")
+    assert mock_storage.file_exists.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_diagnostics_probe_rejects_non_gcs_hosts():
+    status_code, error = await assets_api._probe_media_url_status(
+        "http://127.0.0.1:8000/internal"
+    )
+
+    assert status_code is None
+    assert error == "unsupported_scheme"
+
+
 def test_asset_storage_url_persistence_uses_storage_key() -> None:
     assert (
         assets_api._asset_storage_url_for_persistence("projects/project-id/assets/file.mp4")

--- a/frontend/src/api/assets.clearCache.test.ts
+++ b/frontend/src/api/assets.clearCache.test.ts
@@ -41,6 +41,7 @@ vi.mock('./client', () => ({
 vi.mock('heic2any/dist/heic2any.min.js?url', () => ({ default: '' }))
 
 import { assetsApi, foldersApi, assetsCacheKey } from './assets'
+import apiClient from './client'
 
 const PROJECT_ID = 'proj-abc'
 const FOLDER_ID = 'folder-xyz'
@@ -59,6 +60,23 @@ describe('foldersApi: mutation メソッドは assets キャッシュをクリ�
       cacheKey: assetsCacheKey(PROJECT_ID),
       conditionalRequests: false,
     })
+  })
+
+  it('diagnoseThumbnailFailure: 失敗した URL を診断 endpoint に送る', async () => {
+    await assetsApi.diagnoseThumbnailFailure(
+      PROJECT_ID,
+      'asset-123',
+      'https://storage.googleapis.com/bucket/thumb.jpg?X-Goog-Date=20240101T000000Z',
+      'asset-library-thumbnail_url'
+    )
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      `/projects/${PROJECT_ID}/assets/asset-123/thumbnail-diagnostics`,
+      {
+        url: 'https://storage.googleapis.com/bucket/thumb.jpg?X-Goog-Date=20240101T000000Z',
+        source: 'asset-library-thumbnail_url',
+      }
+    )
   })
 
   it('create: assets キャッシュをクリアする', async () => {

--- a/frontend/src/api/assets.ts
+++ b/frontend/src/api/assets.ts
@@ -80,6 +80,17 @@ export interface ThumbnailResponse {
   height: number
 }
 
+export interface ThumbnailDiagnosticsResponse {
+  diagnosis: string
+  asset_id: string
+  project_id: string
+  source: string
+  asset: Record<string, unknown>
+  url: Record<string, unknown>
+  storage: Record<string, unknown>
+  probe: Record<string, unknown>
+}
+
 export interface BatchThumbnailRequest {
   times_ms: number[]
   width: number
@@ -500,6 +511,19 @@ export const assetsApi = {
     const response = await apiClient.get(
       `/projects/${projectId}/assets/${assetId}/thumbnail`,
       { params: { time_ms: timeMs, width, height } }
+    )
+    return response.data
+  },
+
+  diagnoseThumbnailFailure: async (
+    projectId: string,
+    assetId: string,
+    url: string,
+    source: string
+  ): Promise<ThumbnailDiagnosticsResponse> => {
+    const response = await apiClient.post(
+      `/projects/${projectId}/assets/${assetId}/thumbnail-diagnostics`,
+      { url, source }
     )
     return response.data
   },

--- a/frontend/src/components/assets/AssetLibrary.tsx
+++ b/frontend/src/components/assets/AssetLibrary.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback, useRef, useLayoutEffect, useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { assetsApi, foldersApi, assetsCacheKey, type Asset, type AssetFolder, type SessionData } from '@/api/assets'
-import { clearCache } from '@/lib/cache/etagCache'
+import { assetsApi, foldersApi, type Asset, type AssetFolder, type SessionData } from '@/api/assets'
 import { RequestPriority, withPriority } from '@/utils/requestPriority'
 import AudioWaveformThumbnail from './AudioWaveformThumbnail'
 
@@ -75,6 +74,22 @@ const LazyVideoThumbnail = memo(function LazyVideoThumbnail({
           src={thumbnailUrl}
           alt={assetName}
           className="w-full h-full object-cover"
+          onError={(e) => {
+            const img = e.currentTarget
+            if (img.dataset.diagnosticReported === '1') return
+            img.dataset.diagnosticReported = '1'
+            reportAssetThumbnailLoadFailure(
+              projectId,
+              {
+                id: assetId,
+                name: assetName,
+                type: 'video',
+                thumbnail_url: thumbnailUrl,
+              },
+              img.currentSrc || img.src,
+              'asset-library-lazy-thumbnail'
+            )
+          }}
         />
       ) : isLoading ? (
         <div className="animate-pulse bg-gray-500/30 w-full h-full" />
@@ -112,6 +127,50 @@ type ViewMode = 'list' | 'compact'
 
 // Cache for video thumbnails
 const thumbnailCache = new Map<string, string>()
+
+type AssetThumbnailErrorSource =
+  | 'asset-library-storage_url'
+  | 'asset-library-thumbnail_url'
+  | 'asset-library-lazy-thumbnail'
+
+function reportAssetThumbnailLoadFailure(
+  projectId: string,
+  asset: Pick<Asset, 'id' | 'name' | 'type'> & {
+    storage_key?: string
+    thumbnail_url?: string | null
+  },
+  url: string,
+  source: AssetThumbnailErrorSource
+) {
+  const googDate = url.match(/X-Goog-Date=(\d{8}T\d{6}Z)/)?.[1] ?? null
+  const googExpires = url.match(/X-Goog-Expires=(\d+)/)?.[1] ?? null
+  const context = {
+    projectId,
+    assetId: asset.id,
+    assetName: asset.name,
+    assetType: asset.type,
+    assetStorageKey: asset.storage_key ?? null,
+    hasThumbnailUrl: Boolean(asset.thumbnail_url),
+    source,
+    X_Goog_Date: googDate,
+    X_Goog_Expires: googExpires,
+    url_head: url.substring(0, 200),
+  }
+
+  console.warn('[AssetLibrary] thumbnail load failed', context)
+
+  void assetsApi
+    .diagnoseThumbnailFailure(projectId, asset.id, url, source)
+    .then((diagnostics) => {
+      console.warn('[AssetLibrary] thumbnail diagnostics', diagnostics)
+    })
+    .catch((error) => {
+      console.error('[AssetLibrary] thumbnail diagnostics request failed', {
+        ...context,
+        error,
+      })
+    })
+}
 
 // localStorage key for view preferences
 const ASSET_VIEW_PREFS_KEY = 'douga-asset-view-prefs'
@@ -222,9 +281,6 @@ export default function AssetLibrary({
   const [dropTargetFolderId, setDropTargetFolderId] = useState<string | null | undefined>(undefined)
   const dragCounterRef = useRef(0)
 
-  // single-flight guard: 再 fetch が進行中は追加の clearCache+dispatch を抑止 (#246)
-  const refetchInFlightRef = useRef(false)
-
   // Dropdown refs
   const filterDropdownRef = useRef<HTMLDivElement>(null)
   const sortDropdownRef = useRef<HTMLDivElement>(null)
@@ -272,7 +328,6 @@ export default function AssetLibrary({
       }
     } finally {
       setLoading(false)
-      refetchInFlightRef.current = false  // single-flight フラグをリセット (#246)
     }
   }, [projectId])
 
@@ -365,27 +420,16 @@ export default function AssetLibrary({
     setTooltip((prev) => ({ ...prev, visible: false }))
   }, [])
 
-  // 署名 URL 期限切れによる画像ロード失敗時に cache を破棄して再 fetch する (#242, #246)
-  const handleAssetThumbnailError = useCallback((e: React.SyntheticEvent<HTMLImageElement>, assetId: string) => {
+  const handleAssetThumbnailError = useCallback((
+    e: React.SyntheticEvent<HTMLImageElement>,
+    asset: Asset,
+    source: AssetThumbnailErrorSource
+  ) => {
     const img = e.currentTarget
-    // 1 アセットあたり 1 回までリトライ (無限ループ防止)
-    if (img.dataset.retried === '1') return
-    img.dataset.retried = '1'
+    if (img.dataset.diagnosticReported === '1') return
+    img.dataset.diagnosticReported = '1'
 
-    // single-flight: 既に refetch 中なら何もしない (多重 fetch 防止) #246
-    if (refetchInFlightRef.current) return
-    refetchInFlightRef.current = true
-
-    const url = img.src
-    const goog_date = url.match(/X-Goog-Date=(\d{8}T\d{6}Z)/)?.[1]
-    console.warn('[AssetLibrary] thumbnail load failed, invalidating cache', {
-      assetId,
-      X_Goog_Date: goog_date,
-      url_head: url.substring(0, 200),
-    })
-
-    clearCache(assetsCacheKey(projectId))
-    window.dispatchEvent(new CustomEvent('douga-assets-changed'))
+    reportAssetThumbnailLoadFailure(projectId, asset, img.currentSrc || img.src, source)
   }, [projectId])
 
   // Refresh assets when refreshTrigger changes
@@ -1105,7 +1149,7 @@ export default function AssetLibrary({
               alt={asset.name}
               className="w-full h-full object-cover"
               loading="lazy"
-              onError={(e) => handleAssetThumbnailError(e, asset.id)}
+              onError={(e) => handleAssetThumbnailError(e, asset, 'asset-library-storage_url')}
             />
           ) : asset.type === 'audio' ? (
             <AudioWaveformThumbnail
@@ -1122,7 +1166,7 @@ export default function AssetLibrary({
               src={asset.thumbnail_url}
               alt={asset.name}
               className="w-full h-full object-cover"
-              onError={(e) => handleAssetThumbnailError(e, asset.id)}
+              onError={(e) => handleAssetThumbnailError(e, asset, 'asset-library-thumbnail_url')}
             />
           ) : asset.type === 'video' ? (
             // Video without thumbnail_url (old assets) - lazy load on visibility


### PR DESCRIPTION
## Summary
- Stops AssetLibrary image error handling from clearing cache and dispatching another global refresh on failure.
- Adds a diagnostic-only endpoint for asset thumbnail load failures.
- Logs structured backend diagnostics: diagnosis, source, signed URL timing, URL object key match, current asset storage keys, limited object existence checks, and HTTP probe status for storage.googleapis.com URLs only.
- Sends exactly one diagnostic request per failed img element from AssetLibrary and LazyVideoThumbnail.

## Root cause posture
PR #253 did not change the visible symptom. This PR intentionally does not add another fallback or self-heal path. It makes the next production failure classify itself as signed_url_expired, url_object_missing, db_thumbnail_storage_key_missing_object, thumbnail_url_points_to_unexpected_object, signed_url_rejected, url_probe_failed, or image_decode_or_browser_load_failed.

## Safety
- URL probing is restricted to https://storage.googleapis.com only.
- Arbitrary URL-derived GCS keys are not checked with storage.file_exists unless they match the current asset storage_key or thumbnail_storage_key.
- The endpoint does not mutate asset state.

## Verification
- Self-review completed.
- Backend review agent: no blocking backend findings after two P1 fixes.
- Frontend review agent: no blocking frontend findings.
- git diff --check
- uv run ruff check src tests/test_assets_api.py tests/test_projects_last_edited.py
- uv run pytest tests/test_assets_api.py tests/test_projects_last_edited.py -q
- npm run lint
- npx tsc --noEmit
- npm run build
- npx vitest run
- npm run test

## Manual behavior note
The user-visible broken thumbnails are intentionally not masked in this PR. The expected production check is to reproduce the failure once and inspect browser console plus backend logs for the structured diagnosis.