### PR TITLE
fix(#252): bypass asset list signed-url cache

### DIFF
--- a/frontend/e2e/cache-localstorage.spec.ts
+++ b/frontend/e2e/cache-localstorage.spec.ts
@@ -1,364 +1,174 @@
 /**
- * E2E テスト: localStorage ETag キャッシュ動作の検証
- *
- * 検証内容:
- * 1. 初回ロード → ETag 付きレスポンスで localStorage にキャッシュエントリが作られる
- * 2. signed URL を含む assets list は 2回目も If-None-Match を送らず 200 を取り直す
- * 3. キャッシュがある状態でページリロード → UI が即時表示される
+ * E2E: assets list must not render or persist cached signed-url payloads.
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { bootstrapMockEditorPage } from './helpers/editorMockServer'
 import { openSeededEditor } from './helpers/editorPage'
 import { SCHEMA_VERSION } from '../src/lib/cache/etagCache'
 
 const ASSET_CACHE_KEY_PREFIX = 'cache:v1:assets:'
 
-test.describe('localStorage ETag キャッシュ', () => {
-  // ---------------------------------------------------------------------------
-  // テスト 1: 初回ロードで localStorage にキャッシュエントリが作られる (ETag ありのモック)
-  // ---------------------------------------------------------------------------
-  test('初回ロード後に assets キャッシュエントリが localStorage に存在する', async ({ page }) => {
+function assetCacheKey(projectId: string): string {
+  return `${ASSET_CACHE_KEY_PREFIX}${projectId}`
+}
+
+async function readAssetCache(page: Page, projectId: string): Promise<string | null> {
+  return page.evaluate((key) => localStorage.getItem(key), assetCacheKey(projectId))
+}
+
+function legacyAssetCache(projectId: string, payload: unknown): string {
+  return JSON.stringify({
+    schemaVersion: SCHEMA_VERSION,
+    etag: 'W/"legacy-assets-etag"',
+    payload,
+    fetchedAt: Date.now() - 60_000,
+    expiresAt: Date.now() + 86_400_000,
+  })
+}
+
+test.describe('assets list signed URL cache boundary', () => {
+  test('assets list uses a cache-busted no-store GET and does not write localStorage cache', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
     const projectId = mock.projectId
+    const capturedRequests: Array<{ url: string; headers: Record<string, string> }> = []
 
-    // アセット一覧リクエストをインターセプトして ETag ヘッダーを追加
-    await page.route(`**/api/projects/${projectId}/assets`, async (route) => {
+    await page.route(new RegExp(`/api/projects/${projectId}/assets(?:\\?.*)?$`), async (route) => {
       const req = route.request()
-      const ifNoneMatch = req.headers()['if-none-match']
-
-      if (ifNoneMatch) {
-        // 2回目以降は 304 を返す
-        await route.fulfill({ status: 304, headers: {}, body: '' })
-        return
-      }
+      capturedRequests.push({ url: req.url(), headers: req.headers() })
 
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        headers: { etag: 'W/"initial-etag"' },
+        headers: { etag: 'W/"assets-etag-ignored"' },
         body: JSON.stringify([]),
       })
     })
 
     await openSeededEditor(page, projectId, mock.sequenceId)
 
-    // アセットライブラリが表示されるまで待機
-    await page.waitForTimeout(500)
-
-    // localStorage にキャッシュエントリが存在するか確認
-    const cacheEntry = await page.evaluate(
-      ({ key }) => localStorage.getItem(key),
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
-    )
-
-    // エントリが存在すること（旧実装では null になる — regression 防止アサート）
-    expect(cacheEntry).not.toBeNull()
-
-    // パースして schemaVersion と etag を検証
-    const parsed = JSON.parse(cacheEntry!) as {
-      schemaVersion: number
-      etag: unknown
-      payload: unknown
-      fetchedAt: number
-    }
-    expect(parsed.schemaVersion).toBe(SCHEMA_VERSION)
-    expect(parsed.fetchedAt).toBeGreaterThan(0)
-    expect(parsed.etag).toBe('W/"initial-etag"')
+    await expect.poll(() => capturedRequests.length).toBeGreaterThan(0)
+    expect(capturedRequests[0].url).toContain('_signed_url_refresh=')
+    expect(capturedRequests[0].headers['cache-control']).toBe('no-store')
+    expect(capturedRequests[0].headers['pragma']).toBe('no-cache')
+    expect(capturedRequests[0].headers['if-none-match']).toBeUndefined()
+    await expect.poll(() => readAssetCache(page, projectId)).toBeNull()
   })
 
-  // ---------------------------------------------------------------------------
-  // テスト 2: signed URL を含む assets list は ETag を保存しても If-None-Match を送らない
-  // ---------------------------------------------------------------------------
-  test('ETag ヘッダーが返るとき: キャッシュに etag が保存され、2回目も非条件 GET になる', async ({ page }) => {
+  test('asset refreshes never send If-None-Match even when the API returns ETag', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
     const projectId = mock.projectId
+    const capturedHeaders: Array<Record<string, string>> = []
+    const capturedUrls: string[] = []
 
-    // アセット一覧リクエストをインターセプトして ETag ヘッダーを追加
-    const capturedIfNoneMatchHeaders: Array<string | undefined> = []
-    await page.route(`**/api/projects/${projectId}/assets`, async (route) => {
+    await page.route(new RegExp(`/api/projects/${projectId}/assets(?:\\?.*)?$`), async (route) => {
       const req = route.request()
-      const ifNoneMatch = req.headers()['if-none-match']
-      capturedIfNoneMatchHeaders.push(ifNoneMatch)
+      capturedHeaders.push(req.headers())
+      capturedUrls.push(req.url())
 
-      // この endpoint では送られないはずだが、送られた場合は旧仕様どおり 304 を返す。
-      if (ifNoneMatch === 'W/"mock-etag-v1"') {
-        await route.fulfill({
-          status: 304,
-          headers: {},
-          body: '',
-        })
-        return
-      }
-
-      // 通常レスポンスに ETag を付与
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        headers: {
-          etag: 'W/"mock-etag-v1"',
-        },
+        headers: { etag: 'W/"assets-etag-ignored"' },
         body: JSON.stringify([]),
       })
     })
 
-    // 1回目のロード
     await openSeededEditor(page, projectId, mock.sequenceId)
-    await page.waitForTimeout(800)
+    await expect.poll(() => capturedHeaders.length).toBeGreaterThan(0)
 
-    // localStorage にキャッシュエントリが作られている
-    const entryAfterFirstLoad = await page.evaluate(
-      ({ key }) => localStorage.getItem(key),
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
-    )
-
-    expect(entryAfterFirstLoad).not.toBeNull()
-    const parsed = JSON.parse(entryAfterFirstLoad!) as { etag: string; schemaVersion: number }
-    expect(parsed.etag).toBe('W/"mock-etag-v1"')
-    expect(parsed.schemaVersion).toBe(SCHEMA_VERSION)
-
-    // 2回目のロード（同ページ内でアセット再フェッチをトリガー）
     await page.evaluate(() => {
       window.dispatchEvent(new Event('douga-assets-changed'))
     })
-    await page.waitForTimeout(500)
 
-    // 2回目以降も If-None-Match を送らず、signed URL を含む payload は 200 で取り直す。
-    expect(capturedIfNoneMatchHeaders.length).toBeGreaterThanOrEqual(2)
-    expect(capturedIfNoneMatchHeaders).not.toContain('W/"mock-etag-v1"')
+    await expect.poll(() => capturedHeaders.length).toBeGreaterThanOrEqual(2)
+    expect(capturedHeaders.every((headers) => headers['if-none-match'] === undefined)).toBe(true)
+    expect(capturedUrls.every((url) => url.includes('_signed_url_refresh='))).toBe(true)
+    await expect.poll(() => readAssetCache(page, projectId)).toBeNull()
   })
 
-  // ---------------------------------------------------------------------------
-  // テスト 3: キャッシュがある状態でページ再訪問すると DOM が即時に表示される
-  // ---------------------------------------------------------------------------
-  test('キャッシュがある状態でページ再訪問すると DOM が即時に表示される', async ({ page }) => {
+  test('legacy assets localStorage entry is cleared instead of rendered', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
     const projectId = mock.projectId
+    const staleAssetName = 'expired-signed-url-video.mp4'
 
-    const mockAssets = [
+    await page.addInitScript(
+      ({ key, value }) => localStorage.setItem(key, value),
       {
-        id: 'asset-cached-1',
-        project_id: projectId,
-        name: 'cached-test-video.mp4',
-        type: 'video' as const,
-        storage_key: 'key/cached.mp4',
-        storage_url: 'https://example.com/cached.mp4',
-        thumbnail_url: null,
-        duration_ms: 5000,
-        width: 1280,
-        height: 720,
-        file_size: 1000000,
-        mime_type: 'video/mp4',
-        folder_id: null,
-        created_at: '2026-01-01T00:00:00Z',
-      },
-    ]
-
-    await page.route(`**/api/projects/${projectId}/assets`, async (route) => {
-      const req = route.request()
-      const ifNoneMatch = req.headers()['if-none-match']
-
-      if (ifNoneMatch === 'W/"etag-with-assets"') {
-        await route.fulfill({
-          status: 304,
-          headers: {},
-          body: '',
-        })
-        return
+        key: assetCacheKey(projectId),
+        value: legacyAssetCache(projectId, [
+          {
+            id: 'asset-stale-1',
+            project_id: projectId,
+            name: staleAssetName,
+            type: 'video',
+            storage_key: 'key/stale.mp4',
+            storage_url: 'https://storage.googleapis.com/mock/stale.mp4?X-Goog-Date=20240101T000000Z&X-Goog-Expires=3600',
+            thumbnail_url: null,
+            duration_ms: 3000,
+            width: 1280,
+            height: 720,
+            file_size: 500000,
+            mime_type: 'video/mp4',
+            folder_id: null,
+            created_at: '2026-01-01T00:00:00Z',
+          },
+        ]),
       }
-
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        headers: {
-          etag: 'W/"etag-with-assets"',
-        },
-        body: JSON.stringify(mockAssets),
-      })
-    })
-
-    // 1回目のロード — キャッシュを作る
-    await openSeededEditor(page, projectId, mock.sequenceId)
-    await page.waitForTimeout(800)
-
-    // キャッシュが作られていることを確認
-    const entryRaw = await page.evaluate(
-      ({ key }) => localStorage.getItem(key),
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
     )
-    expect(entryRaw).not.toBeNull()
 
-    // 2回目: ページリロード（同じ localStorage を保持）
-    await page.reload()
-    await page.waitForLoadState('domcontentloaded')
-
-    // リロード後 200ms 以内にアプリが起動していること
-    await expect(page.locator('body')).toBeVisible()
-
-    // ページが完全に表示されること（楽観表示のため通常より速い）
-    await page.waitForTimeout(200)
-    await expect(page.locator('body')).toBeVisible()
-  })
-
-  // ---------------------------------------------------------------------------
-  // テスト 4: TTL 期限切れ後にページリロードすると非条件 GET が走る (#235)
-  // ---------------------------------------------------------------------------
-  test('TTL 期限切れ後のリロードで If-None-Match を含まない非条件 GET が走る', async ({ page }) => {
-    const mock = await bootstrapMockEditorPage(page)
-    const projectId = mock.projectId
-
-    const capturedRequestHeaders: Array<Record<string, string>> = []
-
-    await page.route(`**/api/projects/${projectId}/assets`, async (route) => {
-      const req = route.request()
-      capturedRequestHeaders.push({ ...req.headers() })
-
+    await page.route(new RegExp(`/api/projects/${projectId}/assets(?:\\?.*)?$`), async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        headers: { etag: 'W/"ttl-expiry-etag"' },
         body: JSON.stringify([]),
       })
     })
 
-    // 1回目のロード — キャッシュを作る
     await openSeededEditor(page, projectId, mock.sequenceId)
-    await page.waitForTimeout(800)
 
-    // localStorage にキャッシュが存在することを確認
-    const entryRaw = await page.evaluate(
-      ({ key }) => localStorage.getItem(key),
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
-    )
-    expect(entryRaw).not.toBeNull()
-
-    // expiresAt を過去時刻に書き換えてキャッシュを期限切れにする
-    // 十分に遠い過去 (1 時間前) にすることで時計のずれを排除する
-    await page.evaluate(
-      ({ key }) => {
-        const raw = localStorage.getItem(key)
-        if (!raw) return
-        const entry = JSON.parse(raw) as Record<string, unknown>
-        entry['expiresAt'] = Date.now() - 60 * 60 * 1000 // 1 時間前に切れた
-        localStorage.setItem(key, JSON.stringify(entry))
-      },
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
-    )
-
-    // 期限切れになっていることを確認
-    const expiredEntry = await page.evaluate(
-      ({ key }) => {
-        const raw = localStorage.getItem(key)
-        if (!raw) return null
-        return JSON.parse(raw) as Record<string, unknown>
-      },
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
-    )
-    expect(expiredEntry?.['expiresAt']).toBeLessThan(Date.now())
-
-    // リクエストヘッダー記録をリセット
-    capturedRequestHeaders.length = 0
-
-    // ページリロード
-    await page.reload()
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForTimeout(800)
-
-    // デバッグ: リロード後の localStorage の状態を確認
-    const afterReloadEntry = await page.evaluate(
-      ({ key }) => localStorage.getItem(key),
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
-    )
-    // リロード後 readCache が期限切れを検出して削除するため null になるはず
-    // (新しい 200 応答でキャッシュが再作成される前の一瞬は null)
-    // ただし再作成後は非 null になる — ここでは最終状態を確認
-    // 重要: リロード後最初のリクエストに If-None-Match がないことを確認
-    const allCaptured = capturedRequestHeaders.length
-    expect(allCaptured).toBeGreaterThan(0) // リロード後にリクエストが発生していること
-    // 最初のリクエスト（インデックス 0）に If-None-Match が含まれていないこと
-    expect(capturedRequestHeaders[0]?.['if-none-match']).toBeUndefined()
-    // 後続リクエストも assets list では非条件 GET になるが、ここでは最初の回復リクエストだけを検証する
-    // afterReloadEntry はデバッグ情報として記録（アサートしない）
-    void afterReloadEntry
+    await expect.poll(() => readAssetCache(page, projectId)).toBeNull()
+    await expect(page.getByText(staleAssetName)).toHaveCount(0)
   })
 
-  // ---------------------------------------------------------------------------
-  // テスト 5: fetch 失敗時に stale バナーが表示され、再試行で消える (C-1)
-  // ---------------------------------------------------------------------------
-  test('fetch 失敗時に stale バナーが表示され、再試行で消える', async ({ page }) => {
+  test('asset fetch failure does not fall back to stale assets cache', async ({ page }) => {
     const mock = await bootstrapMockEditorPage(page)
     const projectId = mock.projectId
+    const staleAssetName = 'stale-cache-should-not-render.mp4'
 
-    const mockAssets = [
+    await page.addInitScript(
+      ({ key, value }) => localStorage.setItem(key, value),
       {
-        id: 'asset-stale-1',
-        project_id: projectId,
-        name: 'stale-test-video.mp4',
-        type: 'video' as const,
-        storage_key: 'key/stale.mp4',
-        storage_url: 'https://example.com/stale.mp4',
-        thumbnail_url: null,
-        duration_ms: 3000,
-        width: 1280,
-        height: 720,
-        file_size: 500000,
-        mime_type: 'video/mp4',
-        folder_id: null,
-        created_at: '2026-01-01T00:00:00Z',
-      },
-    ]
-
-    // step1: 通常フローでキャッシュを作る（200 + ETag）
-    let blockRequests = false
-
-    await page.route(`**/api/projects/${projectId}/assets`, async (route) => {
-      if (blockRequests) {
-        // step2: ネットワークブロック → 500 エラー
-        await route.fulfill({ status: 500, body: 'Internal Server Error' })
-        return
+        key: assetCacheKey(projectId),
+        value: legacyAssetCache(projectId, [
+          {
+            id: 'asset-stale-2',
+            project_id: projectId,
+            name: staleAssetName,
+            type: 'video',
+            storage_key: 'key/stale-2.mp4',
+            storage_url: 'https://storage.googleapis.com/mock/stale-2.mp4?X-Goog-Date=20240101T000000Z&X-Goog-Expires=3600',
+            thumbnail_url: null,
+            duration_ms: 3000,
+            width: 1280,
+            height: 720,
+            file_size: 500000,
+            mime_type: 'video/mp4',
+            folder_id: null,
+            created_at: '2026-01-01T00:00:00Z',
+          },
+        ]),
       }
-      // 通常レスポンス（ETag あり）
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        headers: { etag: 'W/"stale-etag-v1"' },
-        body: JSON.stringify(mockAssets),
-      })
-    })
-
-    // step1: 通常ロードでキャッシュを作る
-    await openSeededEditor(page, projectId, mock.sequenceId)
-    await page.waitForTimeout(800)
-
-    // キャッシュが作られていることを確認
-    const entryRaw = await page.evaluate(
-      ({ key }) => localStorage.getItem(key),
-      { key: `${ASSET_CACHE_KEY_PREFIX}${projectId}` }
     )
-    expect(entryRaw).not.toBeNull()
 
-    // step2: ネットワークブロックを有効化
-    blockRequests = true
-
-    // step3: ページリロード（キャッシュはそのまま）
-    await page.reload()
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForTimeout(1200)
-
-    // step4: キャッシュからデータが表示され、stale バナーが表示される
-    await expect(page.locator('[data-testid="stale-data-banner"]').first()).toBeVisible({
-      timeout: 5000,
+    await page.route(new RegExp(`/api/projects/${projectId}/assets(?:\\?.*)?$`), async (route) => {
+      await route.fulfill({ status: 500, body: 'Internal Server Error' })
     })
 
-    // step5: ネットワークブロック解除 → 再試行でバナーが消える
-    blockRequests = false
+    await openSeededEditor(page, projectId, mock.sequenceId)
 
-    // 再試行ボタンをクリック（アセットライブラリまたはシーケンスパネルいずれか）
-    const retryButton = page.locator('[data-testid="stale-data-retry"]').first()
-    await retryButton.click()
-    await page.waitForTimeout(1000)
-
-    // バナーが消えていること
+    await expect.poll(() => readAssetCache(page, projectId)).toBeNull()
+    await expect(page.getByText(staleAssetName)).toHaveCount(0)
     await expect(page.locator('[data-testid="stale-data-banner"]')).toHaveCount(0)
   })
 })

--- a/frontend/src/api/assets.clearCache.test.ts
+++ b/frontend/src/api/assets.clearCache.test.ts
@@ -1,7 +1,7 @@
 /**
  * assets.ts / foldersApi の mutation メソッドが clearCache を呼ぶことを確認するテスト (P0-3)
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // ---------------------------------------------------------------------------
 // etagCache モック
@@ -48,18 +48,50 @@ const FOLDER_ID = 'folder-xyz'
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('foldersApi: mutation メソッドは assets キャッシュをクリアする (P0-3)', () => {
-  it('assetsApi.list: signed URL を含むため If-None-Match を使わない', async () => {
-    await assetsApi.list(PROJECT_ID)
+  it('assetsApi.list: signed URL を含むため localStorage/ETag キャッシュを使わない', async () => {
+    const onCacheHit = vi.fn()
 
-    expect(fetchWithETagMock).toHaveBeenCalledOnce()
-    const calls = fetchWithETagMock.mock.calls as unknown as Array<[Record<string, unknown>]>
-    expect(calls[0][0]).toMatchObject({
-      cacheKey: assetsCacheKey(PROJECT_ID),
-      conditionalRequests: false,
-    })
+    await assetsApi.list(PROJECT_ID, false, onCacheHit)
+
+    expect(fetchWithETagMock).not.toHaveBeenCalled()
+    expect(onCacheHit).not.toHaveBeenCalled()
+    expect(clearCacheMock).toHaveBeenCalledWith(assetsCacheKey(PROJECT_ID))
+    expect(apiClient.get).toHaveBeenCalledWith(
+      `/projects/${PROJECT_ID}/assets`,
+      {
+        params: { _signed_url_refresh: '1700000000000' },
+        headers: {
+          'Cache-Control': 'no-store',
+          Pragma: 'no-cache',
+        },
+      }
+    )
+  })
+
+  it('assetsApi.list: includeInternal=true を API params として渡す', async () => {
+    await assetsApi.list(PROJECT_ID, true)
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      `/projects/${PROJECT_ID}/assets`,
+      {
+        params: {
+          _signed_url_refresh: '1700000000000',
+          include_internal: true,
+        },
+        headers: {
+          'Cache-Control': 'no-store',
+          Pragma: 'no-cache',
+        },
+      }
+    )
   })
 
   it('diagnoseThumbnailFailure: 失敗した URL を診断 endpoint に送る', async () => {

--- a/frontend/src/api/assets.ts
+++ b/frontend/src/api/assets.ts
@@ -1,7 +1,6 @@
 import apiClient from './client'
 import heic2anyScriptUrl from 'heic2any/dist/heic2any.min.js?url'
-import { fetchWithETag, clearCache, ASSETS_CACHE_TTL_MS } from '@/lib/cache/etagCache'
-import { areSignedUrlsValid } from '@/lib/cache/signedUrl'
+import { clearCache } from '@/lib/cache/etagCache'
 
 /** アセット一覧キャッシュキー */
 export function assetsCacheKey(projectId: string): string {
@@ -338,34 +337,24 @@ export const assetsApi = {
   list: async (
     projectId: string,
     includeInternal: boolean = false,
-    onCacheHit?: (cached: Asset[]) => void
+    _onCacheHit?: (cached: Asset[]) => void
   ): Promise<Asset[]> => {
     const cacheKey = assetsCacheKey(projectId)
-    return fetchWithETag<Asset[]>({
-      cacheKey,
-      fetcher: async (headers) => {
-        const response = await apiClient.get(`/projects/${projectId}/assets`, {
-          params: includeInternal ? { include_internal: true } : undefined,
-          headers,
-          validateStatus: (s) => s === 304 || (s >= 200 && s < 300),
-        })
-        return {
-          data: response.data as Asset[],
-          etag: (response.headers['etag'] as string | undefined) ?? null,
-          status: response.status,
-        }
-      },
-      onCacheHit,
-      conditionalRequests: false,
-      // GCS 署名付き URL の TTL は 4 日。キャッシュは 3 日で失効させ
-      // 期限切れ URL がフロントに残らないようにする。
-      ttlMs: ASSETS_CACHE_TTL_MS,
-      // 防御: 期限切れ署名 URL が cached payload に含まれていれば破棄して再 fetch (#242)
-      validatePayload: (cached) => {
-        const now = Date.now()
-        return cached.every((a) => areSignedUrlsValid([a.storage_url, a.thumbnail_url], now))
+    clearCache(cacheKey)
+    const params: Record<string, boolean | string> = {
+      _signed_url_refresh: String(Date.now()),
+    }
+    if (includeInternal) {
+      params.include_internal = true
+    }
+    const response = await apiClient.get(`/projects/${projectId}/assets`, {
+      params,
+      headers: {
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
       },
     })
+    return response.data as Asset[]
   },
 
   getUploadUrl: async (


### PR DESCRIPTION
## Summary

This PR removes the localStorage/ETag optimistic cache path from `assetsApi.list`.

## Root Cause

The new diagnostics confirmed that AssetLibrary is rendering expired GCS signed URLs (`diagnosis: signed_url_expired`). The assets endpoint payload includes signed URLs, so serving a cached payload can display stale URLs before the fresh API response arrives. That keeps the issue noisy and makes the real source harder to isolate.

## Change

- `assetsApi.list` now clears the legacy assets cache and fetches `/projects/{projectId}/assets` directly.
- The existing `onCacheHit` argument is kept for call-site compatibility, but no cached assets payload is rendered.
- Tests now assert that `assetsApi.list` does not use `fetchWithETag`, does not call `onCacheHit`, clears the legacy cache key, and still passes `include_internal` to the API.

## Verification

- `npm run test:unit -- assets.clearCache.test.ts`
- `npm run lint`
- `npm run build`
- `npm run test:unit`

## Deploy Note

Frontend-only change. After review and green checks, deploy production from merged `main` to Firebase hosting project `douga-2f6f8`.